### PR TITLE
Support instance-based extension API

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -1,8 +1,10 @@
 {
   "version": "5",
   "specifiers": {
+    "jsr:@std/assert@*": "1.0.13",
     "jsr:@std/dotenv@*": "0.225.4",
     "jsr:@std/dotenv@~0.225.4": "0.225.4",
+    "jsr:@std/internal@^1.0.6": "1.0.6",
     "jsr:@zip-js/zip-js@*": "2.7.62",
     "jsr:@zip-js/zip-js@^2.7.62": "2.7.62",
     "npm:@hono/vite-dev-server@0.19": "0.19.1_hono@4.7.10",
@@ -34,8 +36,17 @@
     "npm:zod@^3.24.4": "3.25.30"
   },
   "jsr": {
+    "@std/assert@1.0.13": {
+      "integrity": "ae0d31e41919b12c656c742b22522c32fb26ed0cba32975cb0de2a273cb68b29",
+      "dependencies": [
+        "jsr:@std/internal"
+      ]
+    },
     "@std/dotenv@0.225.4": {
       "integrity": "2a672c2b192abe535dcfea1ae89f219ee3979af6aad7d185cb19206ee9bc5caf"
+    },
+    "@std/internal@1.0.6": {
+      "integrity": "9533b128f230f73bd209408bb07a4b12f8d4255ab2a4d22a1fd6d87304aca9a4"
     },
     "@zip-js/zip-js@2.7.62": {
       "integrity": "11cbe0746fa1e52e6e0a601c89ba97365f16e38a07f139b9d9914f988aec9081"

--- a/docs/builder/README.md
+++ b/docs/builder/README.md
@@ -390,6 +390,54 @@ type Permission =
 })
 ```
 
+### インスタンスベース開発
+
+Takopack Builder 3.0 では、`ServerExtension` や `ClientExtension` を
+インスタンス化してメソッドを追加するスタイルを推奨しています。 JSDoc
+タグを付与することでイベントや ActivityPub フックを定義できます。
+
+```typescript
+import { ServerExtension } from "@takopack/builder";
+
+export const MyServer = new ServerExtension();
+
+/** @event("userLogin", { source: "client", target: "server" }) */
+MyServer.onUserLogin = (data: { username: string }) => {
+  console.log("login", data);
+  return [200, { ok: true }];
+};
+
+export { MyServer };
+```
+
+インスタンス名とメソッド名の組み合わせから `MyServer_onUserLogin`
+のようなラッパー関数が自動生成され、manifest の `handler` として利用されます。
+
+### アプリコンテナ API
+
+複数の拡張機能インスタンスをまとめて登録したい場合は `TakoPack`
+クラスを利用できます。
+
+```typescript
+import { ClientExtension, ServerExtension, TakoPack } from "@takopack/builder";
+
+export const MyServer = new ServerExtension();
+MyServer.onHello = (name: string) => {
+  return [200, { greeting: name }];
+};
+
+export const MyClient = new ClientExtension();
+MyClient.greet = () => {
+  console.log("Hello from client");
+};
+
+const app = new TakoPack()
+  .useServer(MyServer)
+  .useClient(MyClient);
+
+export const functions = app.functions;
+```
+
 ---
 
 ## 7. esbuildバンドル機能

--- a/docs/builder/README.md
+++ b/docs/builder/README.md
@@ -253,22 +253,23 @@ ActivityPubフック処理を設定します。
 
 ```typescript
 .activityPub(
-  // 設定
-  { 
+  {
+    accepts: ["Note"],
     context: "https://www.w3.org/ns/activitystreams",
-    object: "Note",
-    priority: 1,
-    serial: false
+    hooks: {
+      priority: 1,
+      serial: false,
+    },
   },
   // canAccept関数（オプション）
   (context: string, object: any) => {
     return object.type === "Create" && object.object?.type === "Note";
   },
-  // hook関数（オプション）
+  // onReceiveフック（オプション）
   async (context: string, object: any) => {
     console.log("Note received:", object);
     return { processed: true };
-  }
+  },
 )
 ```
 
@@ -591,9 +592,11 @@ const activityPubExtension = new FunctionBasedTakopack()
   // ActivityPub Note処理
   .activityPub(
     {
+      accepts: ["Note"],
       context: "https://www.w3.org/ns/activitystreams",
-      object: "Note",
-      priority: 1,
+      hooks: {
+        priority: 1,
+      },
     },
     // canAccept: Noteの受信可否判定
     (context: string, object: any) => {
@@ -601,7 +604,7 @@ const activityPubExtension = new FunctionBasedTakopack()
         object.object?.type === "Note" &&
         object.object?.content;
     },
-    // hook: Note処理
+    // onReceive: Note処理
     async (context: string, object: any) => {
       const note = object.object;
 

--- a/examples/simple-extension/deno.json
+++ b/examples/simple-extension/deno.json
@@ -5,6 +5,6 @@
   },
   "nodeModulesDir": "auto",
   "imports": {
-    "@takopack/builder": "jsr:@takopack/builder@^4.0.0"
+    "@takopack/builder": "jsr:@takopack/builder@^4.0.1"
   }
 }

--- a/examples/simple-extension/deno.json
+++ b/examples/simple-extension/deno.json
@@ -4,7 +4,7 @@
     "build": "deno run -A -r jsr:@takopack/builder build"
   },
   "nodeModulesDir": "auto",
-  "imports ": {
+  "imports": {
     "@takopack/builder": "jsr:@takopack/builder@^4.0.0"
   }
 }

--- a/examples/simple-extension/deno.json
+++ b/examples/simple-extension/deno.json
@@ -1,10 +1,21 @@
 {
   "tasks": {
     "dev": "deno run --watch main.ts",
-    "build": "deno run -A -r jsr:@takopack/builder build"
+    "build": "deno run -A -r ../../packages/cli/cli.ts build"
   },
   "nodeModulesDir": "auto",
   "imports": {
-    "@takopack/builder": "jsr:@takopack/builder@^4.0.1"
+    "@takopack/builder": "../../packages/builder/mod.ts",
+    "@typescript-eslint/typescript-estree": "npm:@typescript-eslint/typescript-estree@8.18.0",
+    "@zip-js/zip-js": "jsr:@zip-js/zip-js@^2.7.62",
+    "@luca/esbuild-deno-loader": "jsr:@luca/esbuild-deno-loader@^0.11.1",
+    "esbuild": "npm:esbuild@0.20.2",
+    "@std/path": "jsr:@std/path@1",
+    "@std/fs": "jsr:@std/fs@1",
+    "@std/cli": "jsr:@std/cli@1"
+  },
+  "compilerOptions": {
+    "lib": ["deno.ns", "dom", "es2022"],
+    "strict": true
   }
 }

--- a/examples/simple-extension/deno.json
+++ b/examples/simple-extension/deno.json
@@ -5,6 +5,6 @@
   },
   "nodeModulesDir": "auto",
   "imports ": {
-    "@takopack/builder": "jsr:@takopack/builder@^3.0.0"
+    "@takopack/builder": "jsr:@takopack/builder@^4.0.0"
   }
 }

--- a/examples/simple-extension/deno.lock
+++ b/examples/simple-extension/deno.lock
@@ -1,11 +1,375 @@
 {
   "version": "5",
   "specifiers": {
+    "jsr:@luca/esbuild-deno-loader@~0.11.1": "0.11.1",
+    "jsr:@std/bytes@^1.0.2": "1.0.6",
+    "jsr:@std/cli@1": "1.0.19",
+    "jsr:@std/encoding@^1.0.5": "1.0.10",
+    "jsr:@std/fs@1": "1.0.18",
+    "jsr:@std/path@1": "1.1.0",
+    "jsr:@std/path@^1.0.6": "1.1.0",
+    "jsr:@std/path@^1.1.0": "1.1.0",
+    "jsr:@takopack/builder@^4.0.1": "4.0.1",
+    "jsr:@zip-js/zip-js@^2.7.62": "2.7.62",
+    "npm:@typescript-eslint/typescript-estree@8.18.0": "8.18.0_typescript@5.7.3",
+    "npm:esbuild@0.20.2": "0.20.2",
     "npm:zod@*": "3.25.42"
   },
+  "jsr": {
+    "@luca/esbuild-deno-loader@0.11.1": {
+      "integrity": "dc020d16d75b591f679f6b9288b10f38bdb4f24345edb2f5732affa1d9885267",
+      "dependencies": [
+        "jsr:@std/bytes",
+        "jsr:@std/encoding",
+        "jsr:@std/path@^1.0.6"
+      ]
+    },
+    "@std/bytes@1.0.6": {
+      "integrity": "f6ac6adbd8ccd99314045f5703e23af0a68d7f7e58364b47d2c7f408aeb5820a"
+    },
+    "@std/cli@1.0.19": {
+      "integrity": "b3601a54891f89f3f738023af11960c4e6f7a45dc76cde39a6861124cba79e88"
+    },
+    "@std/encoding@1.0.10": {
+      "integrity": "8783c6384a2d13abd5e9e87a7ae0520a30e9f56aeeaa3bdf910a3eaaf5c811a1"
+    },
+    "@std/fs@1.0.18": {
+      "integrity": "24bcad99eab1af4fde75e05da6e9ed0e0dce5edb71b7e34baacf86ffe3969f3a",
+      "dependencies": [
+        "jsr:@std/path@^1.1.0"
+      ]
+    },
+    "@std/path@1.1.0": {
+      "integrity": "ddc94f8e3c275627281cbc23341df6b8bcc874d70374f75fec2533521e3d6886"
+    },
+    "@takopack/builder@4.0.1": {
+      "integrity": "82e95c3830167220833d8dac32267245b8ce48415854cadc7e5edfc8325ddeb4",
+      "dependencies": [
+        "jsr:@luca/esbuild-deno-loader",
+        "jsr:@std/cli",
+        "jsr:@std/fs",
+        "jsr:@std/path@1",
+        "jsr:@zip-js/zip-js",
+        "npm:@typescript-eslint/typescript-estree",
+        "npm:esbuild"
+      ]
+    },
+    "@zip-js/zip-js@2.7.62": {
+      "integrity": "11cbe0746fa1e52e6e0a601c89ba97365f16e38a07f139b9d9914f988aec9081"
+    }
+  },
   "npm": {
+    "@esbuild/aix-ppc64@0.20.2": {
+      "integrity": "sha512-D+EBOJHXdNZcLJRBkhENNG8Wji2kgc9AZ9KiPr1JuZjsNtyHzrsfLRrY0tk2H2aoFu6RANO1y1iPPUCDYWkb5g==",
+      "os": ["aix"],
+      "cpu": ["ppc64"]
+    },
+    "@esbuild/android-arm64@0.20.2": {
+      "integrity": "sha512-mRzjLacRtl/tWU0SvD8lUEwb61yP9cqQo6noDZP/O8VkwafSYwZ4yWy24kan8jE/IMERpYncRt2dw438LP3Xmg==",
+      "os": ["android"],
+      "cpu": ["arm64"]
+    },
+    "@esbuild/android-arm@0.20.2": {
+      "integrity": "sha512-t98Ra6pw2VaDhqNWO2Oph2LXbz/EJcnLmKLGBJwEwXX/JAN83Fym1rU8l0JUWK6HkIbWONCSSatf4sf2NBRx/w==",
+      "os": ["android"],
+      "cpu": ["arm"]
+    },
+    "@esbuild/android-x64@0.20.2": {
+      "integrity": "sha512-btzExgV+/lMGDDa194CcUQm53ncxzeBrWJcncOBxuC6ndBkKxnHdFJn86mCIgTELsooUmwUm9FkhSp5HYu00Rg==",
+      "os": ["android"],
+      "cpu": ["x64"]
+    },
+    "@esbuild/darwin-arm64@0.20.2": {
+      "integrity": "sha512-4J6IRT+10J3aJH3l1yzEg9y3wkTDgDk7TSDFX+wKFiWjqWp/iCfLIYzGyasx9l0SAFPT1HwSCR+0w/h1ES/MjA==",
+      "os": ["darwin"],
+      "cpu": ["arm64"]
+    },
+    "@esbuild/darwin-x64@0.20.2": {
+      "integrity": "sha512-tBcXp9KNphnNH0dfhv8KYkZhjc+H3XBkF5DKtswJblV7KlT9EI2+jeA8DgBjp908WEuYll6pF+UStUCfEpdysA==",
+      "os": ["darwin"],
+      "cpu": ["x64"]
+    },
+    "@esbuild/freebsd-arm64@0.20.2": {
+      "integrity": "sha512-d3qI41G4SuLiCGCFGUrKsSeTXyWG6yem1KcGZVS+3FYlYhtNoNgYrWcvkOoaqMhwXSMrZRl69ArHsGJ9mYdbbw==",
+      "os": ["freebsd"],
+      "cpu": ["arm64"]
+    },
+    "@esbuild/freebsd-x64@0.20.2": {
+      "integrity": "sha512-d+DipyvHRuqEeM5zDivKV1KuXn9WeRX6vqSqIDgwIfPQtwMP4jaDsQsDncjTDDsExT4lR/91OLjRo8bmC1e+Cw==",
+      "os": ["freebsd"],
+      "cpu": ["x64"]
+    },
+    "@esbuild/linux-arm64@0.20.2": {
+      "integrity": "sha512-9pb6rBjGvTFNira2FLIWqDk/uaf42sSyLE8j1rnUpuzsODBq7FvpwHYZxQ/It/8b+QOS1RYfqgGFNLRI+qlq2A==",
+      "os": ["linux"],
+      "cpu": ["arm64"]
+    },
+    "@esbuild/linux-arm@0.20.2": {
+      "integrity": "sha512-VhLPeR8HTMPccbuWWcEUD1Az68TqaTYyj6nfE4QByZIQEQVWBB8vup8PpR7y1QHL3CpcF6xd5WVBU/+SBEvGTg==",
+      "os": ["linux"],
+      "cpu": ["arm"]
+    },
+    "@esbuild/linux-ia32@0.20.2": {
+      "integrity": "sha512-o10utieEkNPFDZFQm9CoP7Tvb33UutoJqg3qKf1PWVeeJhJw0Q347PxMvBgVVFgouYLGIhFYG0UGdBumROyiig==",
+      "os": ["linux"],
+      "cpu": ["ia32"]
+    },
+    "@esbuild/linux-loong64@0.20.2": {
+      "integrity": "sha512-PR7sp6R/UC4CFVomVINKJ80pMFlfDfMQMYynX7t1tNTeivQ6XdX5r2XovMmha/VjR1YN/HgHWsVcTRIMkymrgQ==",
+      "os": ["linux"],
+      "cpu": ["loong64"]
+    },
+    "@esbuild/linux-mips64el@0.20.2": {
+      "integrity": "sha512-4BlTqeutE/KnOiTG5Y6Sb/Hw6hsBOZapOVF6njAESHInhlQAghVVZL1ZpIctBOoTFbQyGW+LsVYZ8lSSB3wkjA==",
+      "os": ["linux"],
+      "cpu": ["mips64el"]
+    },
+    "@esbuild/linux-ppc64@0.20.2": {
+      "integrity": "sha512-rD3KsaDprDcfajSKdn25ooz5J5/fWBylaaXkuotBDGnMnDP1Uv5DLAN/45qfnf3JDYyJv/ytGHQaziHUdyzaAg==",
+      "os": ["linux"],
+      "cpu": ["ppc64"]
+    },
+    "@esbuild/linux-riscv64@0.20.2": {
+      "integrity": "sha512-snwmBKacKmwTMmhLlz/3aH1Q9T8v45bKYGE3j26TsaOVtjIag4wLfWSiZykXzXuE1kbCE+zJRmwp+ZbIHinnVg==",
+      "os": ["linux"],
+      "cpu": ["riscv64"]
+    },
+    "@esbuild/linux-s390x@0.20.2": {
+      "integrity": "sha512-wcWISOobRWNm3cezm5HOZcYz1sKoHLd8VL1dl309DiixxVFoFe/o8HnwuIwn6sXre88Nwj+VwZUvJf4AFxkyrQ==",
+      "os": ["linux"],
+      "cpu": ["s390x"]
+    },
+    "@esbuild/linux-x64@0.20.2": {
+      "integrity": "sha512-1MdwI6OOTsfQfek8sLwgyjOXAu+wKhLEoaOLTjbijk6E2WONYpH9ZU2mNtR+lZ2B4uwr+usqGuVfFT9tMtGvGw==",
+      "os": ["linux"],
+      "cpu": ["x64"]
+    },
+    "@esbuild/netbsd-x64@0.20.2": {
+      "integrity": "sha512-K8/DhBxcVQkzYc43yJXDSyjlFeHQJBiowJ0uVL6Tor3jGQfSGHNNJcWxNbOI8v5k82prYqzPuwkzHt3J1T1iZQ==",
+      "os": ["netbsd"],
+      "cpu": ["x64"]
+    },
+    "@esbuild/openbsd-x64@0.20.2": {
+      "integrity": "sha512-eMpKlV0SThJmmJgiVyN9jTPJ2VBPquf6Kt/nAoo6DgHAoN57K15ZghiHaMvqjCye/uU4X5u3YSMgVBI1h3vKrQ==",
+      "os": ["openbsd"],
+      "cpu": ["x64"]
+    },
+    "@esbuild/sunos-x64@0.20.2": {
+      "integrity": "sha512-2UyFtRC6cXLyejf/YEld4Hajo7UHILetzE1vsRcGL3earZEW77JxrFjH4Ez2qaTiEfMgAXxfAZCm1fvM/G/o8w==",
+      "os": ["sunos"],
+      "cpu": ["x64"]
+    },
+    "@esbuild/win32-arm64@0.20.2": {
+      "integrity": "sha512-GRibxoawM9ZCnDxnP3usoUDO9vUkpAxIIZ6GQI+IlVmr5kP3zUq+l17xELTHMWTWzjxa2guPNyrpq1GWmPvcGQ==",
+      "os": ["win32"],
+      "cpu": ["arm64"]
+    },
+    "@esbuild/win32-ia32@0.20.2": {
+      "integrity": "sha512-HfLOfn9YWmkSKRQqovpnITazdtquEW8/SoHW7pWpuEeguaZI4QnCRW6b+oZTztdBnZOS2hqJ6im/D5cPzBTTlQ==",
+      "os": ["win32"],
+      "cpu": ["ia32"]
+    },
+    "@esbuild/win32-x64@0.20.2": {
+      "integrity": "sha512-N49X4lJX27+l9jbLKSqZ6bKNjzQvHaT8IIFUy+YIqmXQdjYCToGWwOItDrfby14c78aDd5NHQl29xingXfCdLQ==",
+      "os": ["win32"],
+      "cpu": ["x64"]
+    },
+    "@nodelib/fs.scandir@2.1.5": {
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dependencies": [
+        "@nodelib/fs.stat",
+        "run-parallel"
+      ]
+    },
+    "@nodelib/fs.stat@2.0.5": {
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="
+    },
+    "@nodelib/fs.walk@1.2.8": {
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dependencies": [
+        "@nodelib/fs.scandir",
+        "fastq"
+      ]
+    },
+    "@typescript-eslint/types@8.18.0": {
+      "integrity": "sha512-FNYxgyTCAnFwTrzpBGq+zrnoTO4x0c1CKYY5MuUTzpScqmY5fmsh2o3+57lqdI3NZucBDCzDgdEbIaNfAjAHQA=="
+    },
+    "@typescript-eslint/typescript-estree@8.18.0_typescript@5.7.3": {
+      "integrity": "sha512-rqQgFRu6yPkauz+ms3nQpohwejS8bvgbPyIDq13cgEDbkXt4LH4OkDMT0/fN1RUtzG8e8AKJyDBoocuQh8qNeg==",
+      "dependencies": [
+        "@typescript-eslint/types",
+        "@typescript-eslint/visitor-keys",
+        "debug",
+        "fast-glob",
+        "is-glob",
+        "minimatch",
+        "semver",
+        "ts-api-utils",
+        "typescript"
+      ]
+    },
+    "@typescript-eslint/visitor-keys@8.18.0": {
+      "integrity": "sha512-pCh/qEA8Lb1wVIqNvBke8UaRjJ6wrAWkJO5yyIbs8Yx6TNGYyfNjOo61tLv+WwLvoLPp4BQ8B7AHKijl8NGUfw==",
+      "dependencies": [
+        "@typescript-eslint/types",
+        "eslint-visitor-keys"
+      ]
+    },
+    "balanced-match@1.0.2": {
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+    },
+    "brace-expansion@2.0.1": {
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dependencies": [
+        "balanced-match"
+      ]
+    },
+    "braces@3.0.3": {
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dependencies": [
+        "fill-range"
+      ]
+    },
+    "debug@4.4.1": {
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "dependencies": [
+        "ms"
+      ]
+    },
+    "esbuild@0.20.2": {
+      "integrity": "sha512-WdOOppmUNU+IbZ0PaDiTst80zjnrOkyJNHoKupIcVyU8Lvla3Ugx94VzkQ32Ijqd7UhHJy75gNWDMUekcrSJ6g==",
+      "optionalDependencies": [
+        "@esbuild/aix-ppc64",
+        "@esbuild/android-arm",
+        "@esbuild/android-arm64",
+        "@esbuild/android-x64",
+        "@esbuild/darwin-arm64",
+        "@esbuild/darwin-x64",
+        "@esbuild/freebsd-arm64",
+        "@esbuild/freebsd-x64",
+        "@esbuild/linux-arm",
+        "@esbuild/linux-arm64",
+        "@esbuild/linux-ia32",
+        "@esbuild/linux-loong64",
+        "@esbuild/linux-mips64el",
+        "@esbuild/linux-ppc64",
+        "@esbuild/linux-riscv64",
+        "@esbuild/linux-s390x",
+        "@esbuild/linux-x64",
+        "@esbuild/netbsd-x64",
+        "@esbuild/openbsd-x64",
+        "@esbuild/sunos-x64",
+        "@esbuild/win32-arm64",
+        "@esbuild/win32-ia32",
+        "@esbuild/win32-x64"
+      ],
+      "scripts": true,
+      "bin": true
+    },
+    "eslint-visitor-keys@4.2.0": {
+      "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw=="
+    },
+    "fast-glob@3.3.3": {
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dependencies": [
+        "@nodelib/fs.stat",
+        "@nodelib/fs.walk",
+        "glob-parent",
+        "merge2",
+        "micromatch"
+      ]
+    },
+    "fastq@1.19.1": {
+      "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
+      "dependencies": [
+        "reusify"
+      ]
+    },
+    "fill-range@7.1.1": {
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dependencies": [
+        "to-regex-range"
+      ]
+    },
+    "glob-parent@5.1.2": {
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dependencies": [
+        "is-glob"
+      ]
+    },
+    "is-extglob@2.1.1": {
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="
+    },
+    "is-glob@4.0.3": {
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dependencies": [
+        "is-extglob"
+      ]
+    },
+    "is-number@7.0.0": {
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
+    },
+    "merge2@1.4.1": {
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="
+    },
+    "micromatch@4.0.8": {
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dependencies": [
+        "braces",
+        "picomatch"
+      ]
+    },
+    "minimatch@9.0.5": {
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dependencies": [
+        "brace-expansion"
+      ]
+    },
+    "ms@2.1.3": {
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "picomatch@2.3.1": {
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
+    },
+    "queue-microtask@1.2.3": {
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="
+    },
+    "reusify@1.1.0": {
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="
+    },
+    "run-parallel@1.2.0": {
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dependencies": [
+        "queue-microtask"
+      ]
+    },
+    "semver@7.7.2": {
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "bin": true
+    },
+    "to-regex-range@5.0.1": {
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dependencies": [
+        "is-number"
+      ]
+    },
+    "ts-api-utils@1.4.3_typescript@5.7.3": {
+      "integrity": "sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==",
+      "dependencies": [
+        "typescript"
+      ]
+    },
+    "typescript@5.7.3": {
+      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
+      "bin": true
+    },
     "zod@3.25.42": {
       "integrity": "sha512-PcALTLskaucbeHc41tU/xfjfhcz8z0GdhhDcSgrCTmSazUuqnYqiXO63M0QUBVwpBlsLsNVn5qHSC5Dw3KZvaQ=="
     }
+  },
+  "workspace": {
+    "dependencies": [
+      "jsr:@takopack/builder@^4.0.1"
+    ]
   }
 }

--- a/examples/simple-extension/deno.lock
+++ b/examples/simple-extension/deno.lock
@@ -9,9 +9,9 @@
     "jsr:@std/path@1": "1.1.0",
     "jsr:@std/path@^1.0.6": "1.1.0",
     "jsr:@std/path@^1.1.0": "1.1.0",
-    "jsr:@takopack/builder@^4.0.1": "4.0.1",
     "jsr:@zip-js/zip-js@^2.7.62": "2.7.62",
     "npm:@typescript-eslint/typescript-estree@8.18.0": "8.18.0_typescript@5.7.3",
+    "npm:esbuild@*": "0.20.2",
     "npm:esbuild@0.20.2": "0.20.2",
     "npm:zod@*": "3.25.42"
   },
@@ -41,18 +41,6 @@
     },
     "@std/path@1.1.0": {
       "integrity": "ddc94f8e3c275627281cbc23341df6b8bcc874d70374f75fec2533521e3d6886"
-    },
-    "@takopack/builder@4.0.1": {
-      "integrity": "82e95c3830167220833d8dac32267245b8ce48415854cadc7e5edfc8325ddeb4",
-      "dependencies": [
-        "jsr:@luca/esbuild-deno-loader",
-        "jsr:@std/cli",
-        "jsr:@std/fs",
-        "jsr:@std/path@1",
-        "jsr:@zip-js/zip-js",
-        "npm:@typescript-eslint/typescript-estree",
-        "npm:esbuild"
-      ]
     },
     "@zip-js/zip-js@2.7.62": {
       "integrity": "11cbe0746fa1e52e6e0a601c89ba97365f16e38a07f139b9d9914f988aec9081"
@@ -369,7 +357,13 @@
   },
   "workspace": {
     "dependencies": [
-      "jsr:@takopack/builder@^4.0.1"
+      "jsr:@luca/esbuild-deno-loader@~0.11.1",
+      "jsr:@std/cli@1",
+      "jsr:@std/fs@1",
+      "jsr:@std/path@1",
+      "jsr:@zip-js/zip-js@^2.7.62",
+      "npm:@typescript-eslint/typescript-estree@8.18.0",
+      "npm:esbuild@0.20.2"
     ]
   }
 }

--- a/examples/simple-extension/src/client/greet.ts
+++ b/examples/simple-extension/src/client/greet.ts
@@ -1,6 +1,8 @@
-import { ClientExtension } from "@takopack/builder";
+import { ClientExtension, getTakosClientAPI } from "@takopack/builder";
 
 export const GreetClient = new ClientExtension();
+
+
 
 GreetClient.greet = (): void => {
   console.log("Hello from client background!");
@@ -11,8 +13,9 @@ GreetClient.onUserClick = (
   data: { x: number; y: number; timestamp: number },
 ): void => {
   console.log("User clicked at:", data);
-  if (globalThis.takos?.events) {
-    globalThis.takos.events.publish("userInteraction", {
+  const takosAPI = getTakosClientAPI();
+  if (takosAPI?.events) {
+    takosAPI.events.publish("userInteraction", {
       type: "click",
       position: { x: data.x, y: data.y },
       timestamp: data.timestamp,
@@ -23,13 +26,14 @@ GreetClient.onUserClick = (
 /** @event("backgroundTask", { source: "server", target: "client" }) */
 GreetClient.onBackgroundTask = (task: { id: string; action: string }): void => {
   console.log("Received background task:", task);
+  const takosAPI = getTakosClientAPI();
   switch (task.action) {
     case "refresh":
       console.log("Refreshing client data...");
       break;
     case "notify":
       console.log("Showing notification...");
-      if (globalThis.takos?.events) {
+      if (takosAPI?.events) {
         // Maybe trigger UI notification here
       }
       break;

--- a/examples/simple-extension/src/client/greet.ts
+++ b/examples/simple-extension/src/client/greet.ts
@@ -37,5 +37,3 @@ GreetClient.onBackgroundTask = (task: { id: string; action: string }): void => {
       console.log("Unknown task action:", task.action);
   }
 };
-
-export { GreetClient };

--- a/examples/simple-extension/src/client/greet.ts
+++ b/examples/simple-extension/src/client/greet.ts
@@ -1,15 +1,16 @@
-// Client background functions
-export function greet(): void {
+import { ClientExtension } from "@takopack/builder";
+
+export const GreetClient = new ClientExtension();
+
+GreetClient.greet = (): void => {
   console.log("Hello from client background!");
-}
+};
 
 /** @event("userClick", { source: "ui", target: "background" }) */
-export function onUserClick(
+GreetClient.onUserClick = (
   data: { x: number; y: number; timestamp: number },
-): void {
+): void => {
   console.log("User clicked at:", data);
-
-  // Forward to server if needed
   if (globalThis.takos?.events) {
     globalThis.takos.events.publish("userInteraction", {
       type: "click",
@@ -17,24 +18,24 @@ export function onUserClick(
       timestamp: data.timestamp,
     });
   }
-}
+};
 
 /** @event("backgroundTask", { source: "server", target: "client" }) */
-export function onBackgroundTask(task: { id: string; action: string }): void {
+GreetClient.onBackgroundTask = (task: { id: string; action: string }): void => {
   console.log("Received background task:", task);
-
-  // Process background task
   switch (task.action) {
     case "refresh":
       console.log("Refreshing client data...");
       break;
     case "notify":
       console.log("Showing notification...");
-      // Could trigger UI notification
       if (globalThis.takos?.events) {
+        // Maybe trigger UI notification here
       }
       break;
     default:
       console.log("Unknown task action:", task.action);
   }
-}
+};
+
+export { GreetClient };

--- a/examples/simple-extension/src/server/activity/note.ts
+++ b/examples/simple-extension/src/server/activity/note.ts
@@ -1,7 +1,7 @@
 import type { Note } from "../../types.ts";
 import { SerializableObject, ServerExtension } from "@takopack/builder";
 
-export const NoteActivity = new ServerExtension();
+const NoteActivity = new ServerExtension();
 
 NoteActivity.canAcceptNote = (_ctx: string, obj: unknown): boolean => {
   // Simple validation: check if it's a Note object
@@ -22,7 +22,8 @@ NoteActivity.onReceiveNote = (
 
   // Store the note in KV
   if (note.id) {
-    globalThis.takos?.kv.write(
+    // deno-lint-ignore no-explicit-any
+    (globalThis as any).takos?.kv.write(
       `note:${note.id}`,
       note as SerializableObject,
     );

--- a/examples/simple-extension/src/server/activity/note.ts
+++ b/examples/simple-extension/src/server/activity/note.ts
@@ -25,7 +25,7 @@ NoteActivity.onReceiveNote = (
     // deno-lint-ignore no-explicit-any
     (globalThis as any).takos?.kv.write(
       `note:${note.id}`,
-      note as SerializableObject,
+      note as unknown as SerializableObject,
     );
   }
 

--- a/examples/simple-extension/src/server/hello.ts
+++ b/examples/simple-extension/src/server/hello.ts
@@ -3,7 +3,7 @@
 import { z } from "npm:zod";
 import { SerializableObject, ServerExtension } from "@takopack/builder";
 
-export const HelloServer = new ServerExtension();
+const HelloServer = new ServerExtension();
 
 HelloServer.hello = (name: string): string => {
   return `Hello, ${name} from server!`;
@@ -27,7 +27,8 @@ HelloServer.onUserLogin = (
   }).parse(userData);
 
   // Save to KV store
-  globalThis.takos?.kv.write(
+  // deno-lint-ignore no-explicit-any
+  (globalThis as any).takos?.kv.write(
     `last_login:${userData.username}`,
     userData.timestamp,
   );

--- a/examples/simple-extension/src/server/hello.ts
+++ b/examples/simple-extension/src/server/hello.ts
@@ -1,7 +1,7 @@
 // Server-side functions
 
 import { z } from "npm:zod";
-import { SerializableObject, ServerExtension } from "@takopack/builder";
+import { SerializableObject, ServerExtension, getTakosServerAPI } from "@takopack/builder";
 
 const HelloServer = new ServerExtension();
 
@@ -14,9 +14,9 @@ HelloServer.calculateSum = (a: number, b: number): number => {
 };
 
 /** @event("userLogin", { source: "client", target: "server" }) */
-HelloServer.onUserLogin = (
+HelloServer.onUserLogin = async (
   userData: { username: string; timestamp: number },
-): [number, SerializableObject] => {
+): Promise<[number, SerializableObject]> => {
   console.log("User logged in:", userData);
 
   z.object({
@@ -25,10 +25,9 @@ HelloServer.onUserLogin = (
       "Timestamp must be a positive integer",
     ),
   }).parse(userData);
-
   // Save to KV store
-  // deno-lint-ignore no-explicit-any
-  (globalThis as any).takos?.kv.write(
+  const takosAPI = getTakosServerAPI();
+  await takosAPI?.kv.write(
     `last_login:${userData.username}`,
     userData.timestamp,
   );

--- a/examples/simple-extension/src/server/hello.ts
+++ b/examples/simple-extension/src/server/hello.ts
@@ -1,19 +1,22 @@
 // Server-side functions
 
 import { z } from "npm:zod";
+import { SerializableObject, ServerExtension } from "@takopack/builder";
 
-export function hello(name: string): string {
+export const HelloServer = new ServerExtension();
+
+HelloServer.hello = (name: string): string => {
   return `Hello, ${name} from server!`;
-}
+};
 
-export function calculateSum(a: number, b: number): number {
+HelloServer.calculateSum = (a: number, b: number): number => {
   return a + b;
-}
+};
 
 /** @event("userLogin", { source: "client", target: "server" }) */
-export function onUserLogin(
+HelloServer.onUserLogin = (
   userData: { username: string; timestamp: number },
-): [number, any] {
+): [number, SerializableObject] => {
   console.log("User logged in:", userData);
 
   z.object({
@@ -30,4 +33,6 @@ export function onUserLogin(
   );
 
   return [200, { success: true, message: "Login recorded" }];
-}
+};
+
+export { HelloServer };

--- a/packages/builder/deno.json
+++ b/packages/builder/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@takopack/builder",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "description": "Next generation Takopack extension build tool with static import preservation",
   "license": "MIT",
   "exports": {

--- a/packages/builder/deno.json
+++ b/packages/builder/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@takopack/builder",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Next generation Takopack extension build tool with static import preservation",
   "license": "MIT",
   "exports": {

--- a/packages/builder/deno.lock
+++ b/packages/builder/deno.lock
@@ -11,6 +11,7 @@
     "jsr:@std/path@^1.1.0": "1.1.0",
     "jsr:@zip-js/zip-js@^2.7.62": "2.7.62",
     "npm:@typescript-eslint/typescript-estree@8.18.0": "8.18.0_typescript@5.7.3",
+    "npm:esbuild@*": "0.20.2",
     "npm:esbuild@0.20.2": "0.20.2"
   },
   "jsr": {

--- a/packages/builder/mod.ts
+++ b/packages/builder/mod.ts
@@ -17,3 +17,5 @@ export { build, dev, watch } from "./src/commands.ts";
 
 // TypeScript型エクスポート
 export type * from "./src/types.ts";
+export { ClientExtension, ServerExtension, UIExtension } from "./src/classes.ts";
+export { TakoPack } from "./src/takopack.ts";

--- a/packages/builder/mod.ts
+++ b/packages/builder/mod.ts
@@ -19,3 +19,28 @@ export { build, dev, watch } from "./src/commands.ts";
 export type * from "./src/types.ts";
 export { ClientExtension, ServerExtension, UIExtension } from "./src/classes.ts";
 export { TakoPack } from "./src/takopack.ts";
+
+// Takos API Helpers
+export {
+  getTakosAPI,
+  getTakosServerAPI,
+  getTakosClientAPI,
+  getTakosUIAPI,
+  publishEvent,
+  kvRead,
+  kvWrite,
+  sendActivityPub,
+  isServerContext,
+  isClientContext,
+  isUIContext
+} from "./src/api-helpers.ts";
+export type {
+  TakosEvent,
+  TakosEventsAPI,
+  TakosKVAPI,
+  TakosAssetsAPI,
+  TakosActivityPubAPI,
+  TakosServerAPI,
+  TakosClientAPI,
+  TakosUIAPI
+} from "./src/api-helpers.ts";

--- a/packages/builder/src/api-helpers.ts
+++ b/packages/builder/src/api-helpers.ts
@@ -1,0 +1,205 @@
+/**
+ * Takos API Helpers
+ * 
+ * 型安全なglobalThis.takosアクセスと共通ユーティリティ関数
+ */
+
+// Takos API型定義
+export interface TakosEvent<T = unknown> {
+  name: string;
+  payload: T;
+  timestamp: number;
+  source: "server" | "client" | "ui" | "background";
+}
+
+export interface TakosEventsAPI {
+  publish<T = unknown>(eventName: string, payload: T): Promise<void>;
+  publishToBackground<T = unknown>(eventName: string, payload: T): Promise<void>;
+  publishToUI<T = unknown>(eventName: string, payload: T): Promise<void>;
+  subscribe<T = unknown>(eventName: string, handler: (payload: T) => void): () => void;
+}
+
+export interface TakosKVAPI {
+  read(key: string): Promise<unknown>;
+  write(key: string, value: unknown): Promise<void>;
+  delete(key: string): Promise<void>;
+  list(): Promise<string[]>;
+}
+
+export interface TakosAssetsAPI {
+  read(path: string): Promise<string>;
+  write(path: string, data: string | Uint8Array, options?: { cacheTTL?: number }): Promise<string>;
+  delete(path: string): Promise<void>;
+  list(prefix?: string): Promise<string[]>;
+}
+
+export interface TakosActivityPubAPI {
+  send(userId: string, activity: Record<string, unknown>): Promise<void>;
+  read(id: string): Promise<Record<string, unknown>>;
+  delete(id: string): Promise<void>;
+  list(userId?: string): Promise<string[]>;
+  actor: {
+    read(userId: string): Promise<Record<string, unknown>>;
+    update(userId: string, key: string, value: string): Promise<void>;
+    delete(userId: string, key: string): Promise<void>;
+  };
+  pluginActor: {
+    create(localName: string, profile: Record<string, unknown>): Promise<string>;
+    read(iri: string): Promise<Record<string, unknown>>;
+    update(iri: string, partial: Record<string, unknown>): Promise<void>;
+    delete(iri: string): Promise<void>;
+    list(): Promise<string[]>;
+  };
+}
+
+// コンテキスト別API定義
+export interface TakosServerAPI {
+  kv: TakosKVAPI;
+  activitypub: TakosActivityPubAPI;
+  assets: TakosAssetsAPI;
+  events: TakosEventsAPI;
+  fetch(url: string, options?: RequestInit): Promise<Response>;
+}
+
+export interface TakosClientAPI {
+  kv: TakosKVAPI;
+  assets: TakosAssetsAPI;
+  events: TakosEventsAPI;
+  fetch(url: string, options?: RequestInit): Promise<Response>;
+}
+
+export interface TakosUIAPI {
+  events: Pick<TakosEventsAPI, 'publishToBackground' | 'subscribe'>;
+}
+
+// 型安全なTakos APIアクセス関数群
+/**
+ * サーバーコンテキストでTakos APIにアクセス
+ */
+export function getTakosServerAPI(): TakosServerAPI | undefined {
+  return (globalThis as Record<string, unknown>).takos as TakosServerAPI | undefined;
+}
+
+/**
+ * クライアントコンテキストでTakos APIにアクセス
+ */
+export function getTakosClientAPI(): TakosClientAPI | undefined {
+  return (globalThis as Record<string, unknown>).takos as TakosClientAPI | undefined;
+}
+
+/**
+ * UIコンテキストでTakos APIにアクセス
+ */
+export function getTakosUIAPI(): TakosUIAPI | undefined {
+  return (globalThis as Record<string, unknown>).takos as TakosUIAPI | undefined;
+}
+
+/**
+ * 汎用的なTakos APIアクセス（型推論が制限される）
+ */
+export function getTakosAPI(): TakosServerAPI | TakosClientAPI | TakosUIAPI | undefined {
+  return (globalThis as Record<string, unknown>).takos as TakosServerAPI | TakosClientAPI | TakosUIAPI | undefined;
+}
+
+// 便利なヘルパー関数
+/**
+ * イベントを安全に発行する
+ */
+export async function publishEvent<T = unknown>(
+  eventName: string, 
+  payload: T,
+  context: 'server' | 'client' | 'ui' = 'client'
+): Promise<void> {
+  if (context === 'ui') {
+    const api = getTakosUIAPI();
+    if (!api?.events) {
+      console.warn(`Takos API not available in ${context} context`);
+      return;
+    }
+    await api.events.publishToBackground(eventName, payload);
+  } else {
+    const api = context === 'server' ? getTakosServerAPI() : getTakosClientAPI();
+    if (!api?.events) {
+      console.warn(`Takos API not available in ${context} context`);
+      return;
+    }
+    await api.events.publish(eventName, payload);
+  }
+}
+
+/**
+ * KVストアに安全にアクセスする
+ */
+export async function kvRead(key: string): Promise<unknown> {
+  const serverAPI = getTakosServerAPI();
+  if (serverAPI?.kv) {
+    return await serverAPI.kv.read(key);
+  }
+  
+  const clientAPI = getTakosClientAPI();
+  if (clientAPI?.kv) {
+    return await clientAPI.kv.read(key);
+  }
+  
+  console.warn('KV API not available in this context');
+  return undefined;
+}
+
+export async function kvWrite(key: string, value: unknown): Promise<void> {
+  const serverAPI = getTakosServerAPI();
+  if (serverAPI?.kv) {
+    await serverAPI.kv.write(key, value);
+    return;
+  }
+  
+  const clientAPI = getTakosClientAPI();
+  if (clientAPI?.kv) {
+    await clientAPI.kv.write(key, value);
+    return;
+  }
+  
+  console.warn('KV API not available in this context');
+}
+
+/**
+ * ActivityPubアクションを安全に実行する
+ */
+export async function sendActivityPub(
+  userId: string, 
+  activity: Record<string, unknown>
+): Promise<void> {
+  const api = getTakosServerAPI();
+  if (!api?.activitypub) {
+    console.warn('ActivityPub API not available in this context (server only)');
+    return;
+  }
+  
+  await api.activitypub.send(userId, activity);
+}
+
+// 型ガード関数
+export function isServerContext(api: unknown): api is TakosServerAPI {
+  return api !== null && 
+         typeof api === 'object' && 
+         'kv' in api && 
+         'activitypub' in api && 
+         'assets' in api &&
+         'events' in api &&
+         'fetch' in api;
+}
+
+export function isClientContext(api: unknown): api is TakosClientAPI {
+  return api !== null && 
+         typeof api === 'object' && 
+         'kv' in api && 
+         'assets' in api &&
+         'events' in api &&
+         'fetch' in api;
+}
+
+export function isUIContext(api: unknown): api is TakosUIAPI {
+  return api !== null && 
+         typeof api === 'object' && 
+         'events' in api &&
+         !('kv' in api);
+}

--- a/packages/builder/src/builder.ts
+++ b/packages/builder/src/builder.ts
@@ -414,7 +414,7 @@ export class TakopackBuilder {
       manifest.eventDefinitions = eventDefinitions;
     }
     if (activityPubConfigs.length > 0) {
-      manifest.activityPub = activityPubConfigs;
+      manifest.activityPub = { objects: activityPubConfigs };
     }
 
     return manifest;
@@ -616,12 +616,14 @@ export class TakopackBuilder {
       const options = match[2] ? JSON.parse(match[2]) : {};
 
       return {
+        accepts: [object],
         context: "https://www.w3.org/ns/activitystreams",
-        object,
-        hook: targetFunction,
-        canAccept: targetFunction.startsWith("canAccept") ? targetFunction : undefined,
-        priority: options.priority,
-        serial: options.serial,
+        hooks: {
+          canAccept: targetFunction.startsWith("canAccept") ? targetFunction : undefined,
+          onReceive: targetFunction,
+          priority: options.priority,
+          serial: options.serial,
+        },
       };
     } catch {
       return null;

--- a/packages/builder/src/builder.ts
+++ b/packages/builder/src/builder.ts
@@ -385,10 +385,9 @@ export class TakopackBuilder {
           const options = (typeof decorator.args[1] === "object" &&
               decorator.args[1] !== null)
             ? decorator.args[1] as Record<string, unknown>
-            : {};
-          eventDefinitions[eventName] = {
-            source: (options.source as any) || "client",
-            target: (options.target as any) || "server",
+            : {};          eventDefinitions[eventName] = {
+            source: (options.source as "client" | "server" | "background" | "ui") || "client",
+            target: (options.target as "server" | "client" | "client:*" | "ui" | "background") || "server",
             handler: handlerName,
           };
         } else if (decorator.name === "activity" && decorator.args.length > 0) {
@@ -396,14 +395,15 @@ export class TakopackBuilder {
           const options = (typeof decorator.args[1] === "object" &&
               decorator.args[1] !== null)
             ? decorator.args[1] as Record<string, unknown>
-            : {};
-          activityPubConfigs.push({
+            : {};          activityPubConfigs.push({
             context: "https://www.w3.org/ns/activitystreams",
-            object,
-            hook: handlerName,
-            canAccept: handlerName.startsWith("canAccept") ? handlerName : undefined,
-            priority: options.priority as number,
-            serial: options.serial as boolean,
+            accepts: [object],
+            hooks: {
+              canAccept: handlerName.startsWith("canAccept") ? handlerName : undefined,
+              onReceive: handlerName,
+              priority: options.priority as number,
+              serial: options.serial as boolean,
+            },
           });
         }
       });
@@ -706,10 +706,9 @@ export class TakopackBuilder {
 
   /**
    * 統合型定義ファイルを生成
-   */
-  private async generateUnifiedTypeDefinitions(
+   */  private async generateUnifiedTypeDefinitions(
     outputDir: string,
-    results: TypeGenerationResult[],
+    _results: TypeGenerationResult[],
   ): Promise<void> {
     const lines: string[] = [];
 

--- a/packages/builder/src/classes.ts
+++ b/packages/builder/src/classes.ts
@@ -1,3 +1,11 @@
-export class ServerExtension {}
-export class ClientExtension {}
-export class UIExtension {}
+export class ServerExtension {
+  [key: string]: unknown;
+}
+
+export class ClientExtension {
+  [key: string]: unknown;
+}
+
+export class UIExtension {
+  [key: string]: unknown;
+}

--- a/packages/builder/src/classes.ts
+++ b/packages/builder/src/classes.ts
@@ -1,0 +1,3 @@
+export class ServerExtension {}
+export class ClientExtension {}
+export class UIExtension {}

--- a/packages/builder/src/generator.ts
+++ b/packages/builder/src/generator.ts
@@ -1,6 +1,7 @@
 import type {
   ActivityPubConfig,
   EventDefinition,
+  ExportInfo,
   ModuleAnalysis,
   TypeGenerationOptions,
   TypeGenerationResult,
@@ -23,6 +24,9 @@ export class VirtualEntryGenerator {
   generateServerEntry(analyses: ModuleAnalysis[]): VirtualEntry {
     const exports: string[] = [];
     const imports: string[] = [];
+    const wrappers: string[] = [];
+    const classMap = new Map<string, Set<string>>();
+    const exportInfoMap = new Map<string, ExportInfo>();
     const eventDefinitions: Record<string, EventDefinition> = {};
     const activityPubConfigs: ActivityPubConfig[] = [];
 
@@ -31,33 +35,79 @@ export class VirtualEntryGenerator {
       analysis.imports.forEach((imp) => {
         if (!imp.isTypeOnly) {
           imports.push(
-            `import ${
-              this.formatImportClause(imp.imports)
-            } from "${imp.source}";`,
+            `import ${this.formatImportClause(imp.imports)} from "${imp.source}";`,
           );
         }
       });
 
       // export関数を収集
       analysis.exports.forEach((exp) => {
-        if (exp.type === "function" || exp.type === "const") {
+        exportInfoMap.set(exp.name, exp);
+        if (exp.type === "function") {
           exports.push(exp.name);
           imports.push(
-            `export { ${exp.name} } from "${
-              this.relativePath(analysis.filePath)
-            }";`,
+            `export { ${exp.name} } from "${this.relativePath(analysis.filePath)}";`,
           );
+        } else if (exp.type === "const" && exp.instanceOf) {
+          imports.push(
+            `import { ${exp.name} } from "${this.relativePath(analysis.filePath)}";`,
+          );
+          classMap.set(exp.name, new Set());
+        } else if (exp.type === "const") {
+          exports.push(exp.name);
+          imports.push(
+            `export { ${exp.name} } from "${this.relativePath(analysis.filePath)}";`,
+          );
+        } else if (exp.type === "class") {
+          imports.push(
+            `import { ${exp.name} } from "${this.relativePath(analysis.filePath)}";`,
+          );
+          classMap.set(exp.name, new Set());
         }
       });
 
       // JSDocタグからActivityPubとイベント設定を生成
-      this.processJSDocTags(analysis, eventDefinitions, activityPubConfigs);
+      this.processJSDocTags(
+        analysis,
+        eventDefinitions,
+        activityPubConfigs,
+        classMap,
+      );
 
       // デコレータからActivityPubとイベント設定を生成
-      this.processDecorators(analysis, eventDefinitions, activityPubConfigs);
+      this.processDecorators(
+        analysis,
+        eventDefinitions,
+        activityPubConfigs,
+        classMap,
+      );
     });
 
-    const content = this.buildEntryContent(imports, exports, {
+    // ラッパー関数生成
+    classMap.forEach((methods, className) => {
+      const info = exportInfoMap.get(className);
+      if (info && info.type === "const" && info.instanceOf) {
+        methods.forEach((m) => {
+          const wrapperName = `${className}_${m}`;
+          wrappers.push(
+            `export const ${wrapperName} = (...args: any[]) => ${className}.${m}(...args);`,
+          );
+          exports.push(wrapperName);
+        });
+      } else {
+        const instance = `__${className}`;
+        wrappers.push(`const ${instance} = new ${className}();`);
+        methods.forEach((m) => {
+          const wrapperName = `${className}_${m}`;
+          wrappers.push(
+            `export const ${wrapperName} = (...args: any[]) => ${instance}.${m}(...args);`,
+          );
+          exports.push(wrapperName);
+        });
+      }
+    });
+
+    const content = this.buildEntryContent([...imports, ...wrappers], exports, {
       eventDefinitions,
       activityPubConfigs,
     });
@@ -76,33 +126,86 @@ export class VirtualEntryGenerator {
   generateClientEntry(analyses: ModuleAnalysis[]): VirtualEntry {
     const exports: string[] = [];
     const imports: string[] = [];
+    const wrappers: string[] = [];
+    const classMap = new Map<string, Set<string>>();
+    const exportInfoMap = new Map<string, ExportInfo>();
 
     analyses.forEach((analysis) => {
       // import文を収集
       analysis.imports.forEach((imp) => {
         if (!imp.isTypeOnly) {
           imports.push(
-            `import ${
-              this.formatImportClause(imp.imports)
-            } from "${imp.source}";`,
+            `import ${this.formatImportClause(imp.imports)} from "${imp.source}";`,
           );
         }
       });
 
       // export関数を収集
       analysis.exports.forEach((exp) => {
-        if (exp.type === "function" || exp.type === "const") {
+        exportInfoMap.set(exp.name, exp);
+        if (exp.type === "function") {
           exports.push(exp.name);
           imports.push(
-            `export { ${exp.name} } from "${
-              this.relativePath(analysis.filePath)
-            }";`,
+            `export { ${exp.name} } from "${this.relativePath(analysis.filePath)}";`,
           );
+        } else if (exp.type === "const" && exp.instanceOf) {
+          imports.push(
+            `import { ${exp.name} } from "${this.relativePath(analysis.filePath)}";`,
+          );
+          classMap.set(exp.name, new Set());
+        } else if (exp.type === "const") {
+          exports.push(exp.name);
+          imports.push(
+            `export { ${exp.name} } from "${this.relativePath(analysis.filePath)}";`,
+          );
+        } else if (exp.type === "class") {
+          imports.push(
+            `import { ${exp.name} } from "${this.relativePath(analysis.filePath)}";`,
+          );
+          classMap.set(exp.name, new Set());
         }
       });
+
+      // JSDoc / Decorator 処理してメソッド登録
+      this.processJSDocTags(
+        analysis,
+        {},
+        [],
+        classMap,
+      );
+      this.processDecorators(
+        analysis,
+        {},
+        [],
+        classMap,
+      );
     });
 
-    const content = this.buildEntryContent(imports, exports);
+    // ラッパー生成
+    classMap.forEach((methods, className) => {
+      const info = exportInfoMap.get(className);
+      if (info && info.type === "const" && info.instanceOf) {
+        methods.forEach((m) => {
+          const wrapperName = `${className}_${m}`;
+          wrappers.push(
+            `export const ${wrapperName} = (...args: any[]) => ${className}.${m}(...args);`,
+          );
+          exports.push(wrapperName);
+        });
+      } else {
+        const instance = `__${className}`;
+        wrappers.push(`const ${instance} = new ${className}();`);
+        methods.forEach((m) => {
+          const wrapperName = `${className}_${m}`;
+          wrappers.push(
+            `export const ${wrapperName} = (...args: any[]) => ${instance}.${m}(...args);`,
+          );
+          exports.push(wrapperName);
+        });
+      }
+    });
+
+    const content = this.buildEntryContent([...imports, ...wrappers], exports);
 
     return {
       type: "client",
@@ -119,26 +222,37 @@ export class VirtualEntryGenerator {
     analysis: ModuleAnalysis,
     eventDefinitions: Record<string, EventDefinition>,
     activityPubConfigs: ActivityPubConfig[],
+    classMap: Map<string, Set<string>>,
   ): void {
     analysis.jsDocTags.forEach((tag) => {
       if (tag.tag === "activity") {
         // @activity("Note", { priority: 100, serial: true })
+        const handlerName = tag.targetClass
+          ? `${tag.targetClass}_${tag.targetFunction}`
+          : tag.targetFunction;
         const activityConfig = this.parseActivityTag(
           tag.value,
-          tag.targetFunction,
+          handlerName,
         );
         if (activityConfig) {
           activityPubConfigs.push(activityConfig);
         }
       } else if (tag.tag === "event") {
         // @event("myEvent", { source: "client", target: "server" })
-        const eventConfig = this.parseEventTag(tag.value, tag.targetFunction);
+        const handlerName = tag.targetClass
+          ? `${tag.targetClass}_${tag.targetFunction}`
+          : tag.targetFunction;
+        const eventConfig = this.parseEventTag(tag.value, handlerName);
         if (eventConfig) {
           const eventName = this.extractEventName(tag.value);
           if (eventName) {
             eventDefinitions[eventName] = eventConfig;
           }
         }
+      }
+
+      if (tag.targetClass && classMap.has(tag.targetClass)) {
+        classMap.get(tag.targetClass)!.add(tag.targetFunction);
       }
     });
   }
@@ -150,31 +264,40 @@ export class VirtualEntryGenerator {
     analysis: ModuleAnalysis,
     eventDefinitions: Record<string, EventDefinition>,
     activityPubConfigs: ActivityPubConfig[],
+    classMap: Map<string, Set<string>>,
   ): void {
     analysis.decorators.forEach((decorator) => {
       if (decorator.name === "activity") {
         // @activity("Note", { priority: 100 })
+        const handlerName = decorator.targetClass
+          ? `${decorator.targetClass}_${decorator.targetFunction}`
+          : decorator.targetFunction;
         const activityConfig = this.parseActivityDecorator(
           decorator.args,
-          decorator.targetFunction,
+          handlerName,
         );
         if (activityConfig) {
           activityPubConfigs.push(activityConfig);
         }
       } else if (decorator.name === "event") {
         // @event("myEvent", { source: "client", target: "server" })
+        const handlerName = decorator.targetClass
+          ? `${decorator.targetClass}_${decorator.targetFunction}`
+          : decorator.targetFunction;
         const eventConfig = this.parseEventDecorator(
           decorator.args,
-          decorator.targetFunction,
+          handlerName,
         );
         if (eventConfig) {
-          const eventName = typeof decorator.args[0] === "string"
-            ? decorator.args[0]
-            : "";
+          const eventName = typeof decorator.args[0] === "string" ? decorator.args[0] : "";
           if (eventName) {
             eventDefinitions[eventName] = eventConfig;
           }
         }
+      }
+
+      if (decorator.targetClass && classMap.has(decorator.targetClass)) {
+        classMap.get(decorator.targetClass)!.add(decorator.targetFunction);
       }
     });
   }
@@ -198,9 +321,7 @@ export class VirtualEntryGenerator {
         context: "https://www.w3.org/ns/activitystreams",
         object,
         hook: targetFunction,
-        canAccept: targetFunction.startsWith("canAccept")
-          ? targetFunction
-          : undefined,
+        canAccept: targetFunction.startsWith("canAccept") ? targetFunction : undefined,
         priority: options.priority,
         serial: options.serial,
       };
@@ -225,9 +346,7 @@ export class VirtualEntryGenerator {
       context: "https://www.w3.org/ns/activitystreams",
       object,
       hook: targetFunction,
-      canAccept: targetFunction.startsWith("canAccept")
-        ? targetFunction
-        : undefined,
+      canAccept: targetFunction.startsWith("canAccept") ? targetFunction : undefined,
       priority: options.priority as number,
       serial: options.serial as boolean,
     };
@@ -268,19 +387,17 @@ export class VirtualEntryGenerator {
     const options = (args[1] as Record<string, unknown>) || {};
 
     return {
-      source:
-        (typeof options.source === "string" ? options.source : "client") as
-          | "client"
-          | "server"
-          | "background"
-          | "ui",
-      target:
-        (typeof options.target === "string" ? options.target : "server") as
-          | "server"
-          | "client"
-          | "client:*"
-          | "ui"
-          | "background",
+      source: (typeof options.source === "string" ? options.source : "client") as
+        | "client"
+        | "server"
+        | "background"
+        | "ui",
+      target: (typeof options.target === "string" ? options.target : "server") as
+        | "server"
+        | "client"
+        | "client:*"
+        | "ui"
+        | "background",
       handler: targetFunction,
     };
   }

--- a/packages/builder/src/generator.ts
+++ b/packages/builder/src/generator.ts
@@ -318,12 +318,14 @@ export class VirtualEntryGenerator {
       const options = match[2] ? JSON.parse(match[2]) : {};
 
       return {
+        accepts: [object],
         context: "https://www.w3.org/ns/activitystreams",
-        object,
-        hook: targetFunction,
-        canAccept: targetFunction.startsWith("canAccept") ? targetFunction : undefined,
-        priority: options.priority,
-        serial: options.serial,
+        hooks: {
+          canAccept: targetFunction.startsWith("canAccept") ? targetFunction : undefined,
+          onReceive: targetFunction,
+          priority: options.priority,
+          serial: options.serial,
+        },
       };
     } catch {
       return null;
@@ -343,12 +345,14 @@ export class VirtualEntryGenerator {
     const options = (args[1] as Record<string, unknown>) || {};
 
     return {
+      accepts: [object],
       context: "https://www.w3.org/ns/activitystreams",
-      object,
-      hook: targetFunction,
-      canAccept: targetFunction.startsWith("canAccept") ? targetFunction : undefined,
-      priority: options.priority as number,
-      serial: options.serial as boolean,
+      hooks: {
+        canAccept: targetFunction.startsWith("canAccept") ? targetFunction : undefined,
+        onReceive: targetFunction,
+        priority: options.priority as number,
+        serial: options.serial as boolean,
+      },
     };
   }
 

--- a/packages/builder/src/takopack.ts
+++ b/packages/builder/src/takopack.ts
@@ -1,0 +1,45 @@
+import { ClientExtension, ServerExtension, UIExtension } from "./classes.ts";
+
+/**
+ * Simple container to aggregate extension classes.
+ *
+ * Example usage:
+ * ```ts
+ * const app = new TakoPack();
+ * app.useServer(MyServer);
+ * app.useClient(MyClient);
+ * export const functions = app.functions;
+ * ```
+ */
+export class TakoPack {
+  private serverClasses: Array<typeof ServerExtension> = [];
+  private clientClasses: Array<typeof ClientExtension> = [];
+  private uiClasses: Array<typeof UIExtension> = [];
+
+  useServer(cls: typeof ServerExtension): this {
+    this.serverClasses.push(cls);
+    return this;
+  }
+
+  useClient(cls: typeof ClientExtension): this {
+    this.clientClasses.push(cls);
+    return this;
+  }
+
+  useUI(cls: typeof UIExtension): this {
+    this.uiClasses.push(cls);
+    return this;
+  }
+
+  /**
+   * Exposed for builder to pick up exported classes.
+   * Contains all registered classes grouped by context.
+   */
+  get functions() {
+    return {
+      server: this.serverClasses,
+      client: this.clientClasses,
+      ui: this.uiClasses,
+    };
+  }
+}

--- a/packages/builder/src/takopack.ts
+++ b/packages/builder/src/takopack.ts
@@ -35,7 +35,11 @@ export class TakoPack {
    * Exposed for builder to pick up exported classes.
    * Contains all registered classes grouped by context.
    */
-  get functions() {
+  get functions(): {
+    server: Array<typeof ServerExtension>;
+    client: Array<typeof ClientExtension>;
+    ui: Array<typeof UIExtension>;
+  } {
     return {
       server: this.serverClasses,
       client: this.clientClasses,

--- a/packages/builder/src/types.ts
+++ b/packages/builder/src/types.ts
@@ -41,6 +41,11 @@ export interface ExportInfo {
   isDefault: boolean;
   line: number;
   column: number;
+  /**
+   * If this export is a const initialized with `new SomeClass()`
+   * this holds the class name.
+   */
+  instanceOf?: string;
 }
 
 export interface ImportInfo {
@@ -54,6 +59,8 @@ export interface DecoratorInfo {
   name: string;
   args: unknown[];
   targetFunction: string;
+  /** メソッドが属するクラス名 (あれば) */
+  targetClass?: string;
   line: number;
 }
 
@@ -61,6 +68,8 @@ export interface JSDocTagInfo {
   tag: string;
   value: string;
   targetFunction: string;
+  /** メソッドが属するクラス名 (あれば) */
+  targetClass?: string;
   line: number;
 }
 

--- a/packages/builder/src/types.ts
+++ b/packages/builder/src/types.ts
@@ -139,7 +139,9 @@ export interface ExtensionManifest {
     entryBackground: string;
   };
   eventDefinitions?: Record<string, EventDefinition>;
-  activityPub?: ActivityPubConfig[];
+  activityPub?: {
+    objects: ActivityPubConfig[];
+  };
 }
 
 export interface EventDefinition {
@@ -149,12 +151,14 @@ export interface EventDefinition {
 }
 
 export interface ActivityPubConfig {
+  accepts: string[];
   context: string;
-  object: string;
-  canAccept?: string;
-  hook?: string;
-  priority?: number;
-  serial?: boolean;
+  hooks: {
+    canAccept?: string;
+    onReceive: string;
+    priority?: number;
+    serial?: boolean;
+  };
 }
 
 /**

--- a/packages/cli/deno.lock
+++ b/packages/cli/deno.lock
@@ -3,10 +3,15 @@
   "specifiers": {
     "jsr:@luca/esbuild-deno-loader@~0.11.1": "0.11.1",
     "jsr:@std/bytes@^1.0.2": "1.0.6",
+    "jsr:@std/cli@1": "1.0.19",
     "jsr:@std/encoding@^1.0.5": "1.0.10",
+    "jsr:@std/fs@1": "1.0.18",
+    "jsr:@std/path@1": "1.1.0",
     "jsr:@std/path@^1.0.6": "1.1.0",
+    "jsr:@std/path@^1.1.0": "1.1.0",
     "jsr:@zip-js/zip-js@^2.7.62": "2.7.62",
-    "npm:@typescript-eslint/typescript-estree@8.18.0": "8.18.0_typescript@5.7.3"
+    "npm:@typescript-eslint/typescript-estree@8.18.0": "8.18.0_typescript@5.7.3",
+    "npm:esbuild@*": "0.25.5"
   },
   "jsr": {
     "@luca/esbuild-deno-loader@0.11.1": {
@@ -14,14 +19,23 @@
       "dependencies": [
         "jsr:@std/bytes",
         "jsr:@std/encoding",
-        "jsr:@std/path"
+        "jsr:@std/path@^1.0.6"
       ]
     },
     "@std/bytes@1.0.6": {
       "integrity": "f6ac6adbd8ccd99314045f5703e23af0a68d7f7e58364b47d2c7f408aeb5820a"
     },
+    "@std/cli@1.0.19": {
+      "integrity": "b3601a54891f89f3f738023af11960c4e6f7a45dc76cde39a6861124cba79e88"
+    },
     "@std/encoding@1.0.10": {
       "integrity": "8783c6384a2d13abd5e9e87a7ae0520a30e9f56aeeaa3bdf910a3eaaf5c811a1"
+    },
+    "@std/fs@1.0.18": {
+      "integrity": "24bcad99eab1af4fde75e05da6e9ed0e0dce5edb71b7e34baacf86ffe3969f3a",
+      "dependencies": [
+        "jsr:@std/path@^1.1.0"
+      ]
     },
     "@std/path@1.1.0": {
       "integrity": "ddc94f8e3c275627281cbc23341df6b8bcc874d70374f75fec2533521e3d6886"
@@ -31,6 +45,131 @@
     }
   },
   "npm": {
+    "@esbuild/aix-ppc64@0.25.5": {
+      "integrity": "sha512-9o3TMmpmftaCMepOdA5k/yDw8SfInyzWWTjYTFCX3kPSDJMROQTb8jg+h9Cnwnmm1vOzvxN7gIfB5V2ewpjtGA==",
+      "os": ["aix"],
+      "cpu": ["ppc64"]
+    },
+    "@esbuild/android-arm64@0.25.5": {
+      "integrity": "sha512-VGzGhj4lJO+TVGV1v8ntCZWJktV7SGCs3Pn1GRWI1SBFtRALoomm8k5E9Pmwg3HOAal2VDc2F9+PM/rEY6oIDg==",
+      "os": ["android"],
+      "cpu": ["arm64"]
+    },
+    "@esbuild/android-arm@0.25.5": {
+      "integrity": "sha512-AdJKSPeEHgi7/ZhuIPtcQKr5RQdo6OO2IL87JkianiMYMPbCtot9fxPbrMiBADOWWm3T2si9stAiVsGbTQFkbA==",
+      "os": ["android"],
+      "cpu": ["arm"]
+    },
+    "@esbuild/android-x64@0.25.5": {
+      "integrity": "sha512-D2GyJT1kjvO//drbRT3Hib9XPwQeWd9vZoBJn+bu/lVsOZ13cqNdDeqIF/xQ5/VmWvMduP6AmXvylO/PIc2isw==",
+      "os": ["android"],
+      "cpu": ["x64"]
+    },
+    "@esbuild/darwin-arm64@0.25.5": {
+      "integrity": "sha512-GtaBgammVvdF7aPIgH2jxMDdivezgFu6iKpmT+48+F8Hhg5J/sfnDieg0aeG/jfSvkYQU2/pceFPDKlqZzwnfQ==",
+      "os": ["darwin"],
+      "cpu": ["arm64"]
+    },
+    "@esbuild/darwin-x64@0.25.5": {
+      "integrity": "sha512-1iT4FVL0dJ76/q1wd7XDsXrSW+oLoquptvh4CLR4kITDtqi2e/xwXwdCVH8hVHU43wgJdsq7Gxuzcs6Iq/7bxQ==",
+      "os": ["darwin"],
+      "cpu": ["x64"]
+    },
+    "@esbuild/freebsd-arm64@0.25.5": {
+      "integrity": "sha512-nk4tGP3JThz4La38Uy/gzyXtpkPW8zSAmoUhK9xKKXdBCzKODMc2adkB2+8om9BDYugz+uGV7sLmpTYzvmz6Sw==",
+      "os": ["freebsd"],
+      "cpu": ["arm64"]
+    },
+    "@esbuild/freebsd-x64@0.25.5": {
+      "integrity": "sha512-PrikaNjiXdR2laW6OIjlbeuCPrPaAl0IwPIaRv+SMV8CiM8i2LqVUHFC1+8eORgWyY7yhQY+2U2fA55mBzReaw==",
+      "os": ["freebsd"],
+      "cpu": ["x64"]
+    },
+    "@esbuild/linux-arm64@0.25.5": {
+      "integrity": "sha512-Z9kfb1v6ZlGbWj8EJk9T6czVEjjq2ntSYLY2cw6pAZl4oKtfgQuS4HOq41M/BcoLPzrUbNd+R4BXFyH//nHxVg==",
+      "os": ["linux"],
+      "cpu": ["arm64"]
+    },
+    "@esbuild/linux-arm@0.25.5": {
+      "integrity": "sha512-cPzojwW2okgh7ZlRpcBEtsX7WBuqbLrNXqLU89GxWbNt6uIg78ET82qifUy3W6OVww6ZWobWub5oqZOVtwolfw==",
+      "os": ["linux"],
+      "cpu": ["arm"]
+    },
+    "@esbuild/linux-ia32@0.25.5": {
+      "integrity": "sha512-sQ7l00M8bSv36GLV95BVAdhJ2QsIbCuCjh/uYrWiMQSUuV+LpXwIqhgJDcvMTj+VsQmqAHL2yYaasENvJ7CDKA==",
+      "os": ["linux"],
+      "cpu": ["ia32"]
+    },
+    "@esbuild/linux-loong64@0.25.5": {
+      "integrity": "sha512-0ur7ae16hDUC4OL5iEnDb0tZHDxYmuQyhKhsPBV8f99f6Z9KQM02g33f93rNH5A30agMS46u2HP6qTdEt6Q1kg==",
+      "os": ["linux"],
+      "cpu": ["loong64"]
+    },
+    "@esbuild/linux-mips64el@0.25.5": {
+      "integrity": "sha512-kB/66P1OsHO5zLz0i6X0RxlQ+3cu0mkxS3TKFvkb5lin6uwZ/ttOkP3Z8lfR9mJOBk14ZwZ9182SIIWFGNmqmg==",
+      "os": ["linux"],
+      "cpu": ["mips64el"]
+    },
+    "@esbuild/linux-ppc64@0.25.5": {
+      "integrity": "sha512-UZCmJ7r9X2fe2D6jBmkLBMQetXPXIsZjQJCjgwpVDz+YMcS6oFR27alkgGv3Oqkv07bxdvw7fyB71/olceJhkQ==",
+      "os": ["linux"],
+      "cpu": ["ppc64"]
+    },
+    "@esbuild/linux-riscv64@0.25.5": {
+      "integrity": "sha512-kTxwu4mLyeOlsVIFPfQo+fQJAV9mh24xL+y+Bm6ej067sYANjyEw1dNHmvoqxJUCMnkBdKpvOn0Ahql6+4VyeA==",
+      "os": ["linux"],
+      "cpu": ["riscv64"]
+    },
+    "@esbuild/linux-s390x@0.25.5": {
+      "integrity": "sha512-K2dSKTKfmdh78uJ3NcWFiqyRrimfdinS5ErLSn3vluHNeHVnBAFWC8a4X5N+7FgVE1EjXS1QDZbpqZBjfrqMTQ==",
+      "os": ["linux"],
+      "cpu": ["s390x"]
+    },
+    "@esbuild/linux-x64@0.25.5": {
+      "integrity": "sha512-uhj8N2obKTE6pSZ+aMUbqq+1nXxNjZIIjCjGLfsWvVpy7gKCOL6rsY1MhRh9zLtUtAI7vpgLMK6DxjO8Qm9lJw==",
+      "os": ["linux"],
+      "cpu": ["x64"]
+    },
+    "@esbuild/netbsd-arm64@0.25.5": {
+      "integrity": "sha512-pwHtMP9viAy1oHPvgxtOv+OkduK5ugofNTVDilIzBLpoWAM16r7b/mxBvfpuQDpRQFMfuVr5aLcn4yveGvBZvw==",
+      "os": ["netbsd"],
+      "cpu": ["arm64"]
+    },
+    "@esbuild/netbsd-x64@0.25.5": {
+      "integrity": "sha512-WOb5fKrvVTRMfWFNCroYWWklbnXH0Q5rZppjq0vQIdlsQKuw6mdSihwSo4RV/YdQ5UCKKvBy7/0ZZYLBZKIbwQ==",
+      "os": ["netbsd"],
+      "cpu": ["x64"]
+    },
+    "@esbuild/openbsd-arm64@0.25.5": {
+      "integrity": "sha512-7A208+uQKgTxHd0G0uqZO8UjK2R0DDb4fDmERtARjSHWxqMTye4Erz4zZafx7Di9Cv+lNHYuncAkiGFySoD+Mw==",
+      "os": ["openbsd"],
+      "cpu": ["arm64"]
+    },
+    "@esbuild/openbsd-x64@0.25.5": {
+      "integrity": "sha512-G4hE405ErTWraiZ8UiSoesH8DaCsMm0Cay4fsFWOOUcz8b8rC6uCvnagr+gnioEjWn0wC+o1/TAHt+It+MpIMg==",
+      "os": ["openbsd"],
+      "cpu": ["x64"]
+    },
+    "@esbuild/sunos-x64@0.25.5": {
+      "integrity": "sha512-l+azKShMy7FxzY0Rj4RCt5VD/q8mG/e+mDivgspo+yL8zW7qEwctQ6YqKX34DTEleFAvCIUviCFX1SDZRSyMQA==",
+      "os": ["sunos"],
+      "cpu": ["x64"]
+    },
+    "@esbuild/win32-arm64@0.25.5": {
+      "integrity": "sha512-O2S7SNZzdcFG7eFKgvwUEZ2VG9D/sn/eIiz8XRZ1Q/DO5a3s76Xv0mdBzVM5j5R639lXQmPmSo0iRpHqUUrsxw==",
+      "os": ["win32"],
+      "cpu": ["arm64"]
+    },
+    "@esbuild/win32-ia32@0.25.5": {
+      "integrity": "sha512-onOJ02pqs9h1iMJ1PQphR+VZv8qBMQ77Klcsqv9CNW2w6yLqoURLcgERAIurY6QE63bbLuqgP9ATqajFLK5AMQ==",
+      "os": ["win32"],
+      "cpu": ["ia32"]
+    },
+    "@esbuild/win32-x64@0.25.5": {
+      "integrity": "sha512-TXv6YnJ8ZMVdX+SXWVBo/0p8LTcrUYngpWjvm91TMjjBQii7Oz11Lw5lbDV5Y0TzuhSJHwiH4hEtC1I42mMS0g==",
+      "os": ["win32"],
+      "cpu": ["x64"]
+    },
     "@nodelib/fs.scandir@2.1.5": {
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
       "dependencies": [
@@ -92,6 +231,38 @@
       "dependencies": [
         "ms"
       ]
+    },
+    "esbuild@0.25.5": {
+      "integrity": "sha512-P8OtKZRv/5J5hhz0cUAdu/cLuPIKXpQl1R9pZtvmHWQvrAUVd0UNIPT4IB4W3rNOqVO0rlqHmCIbSwxh/c9yUQ==",
+      "optionalDependencies": [
+        "@esbuild/aix-ppc64",
+        "@esbuild/android-arm",
+        "@esbuild/android-arm64",
+        "@esbuild/android-x64",
+        "@esbuild/darwin-arm64",
+        "@esbuild/darwin-x64",
+        "@esbuild/freebsd-arm64",
+        "@esbuild/freebsd-x64",
+        "@esbuild/linux-arm",
+        "@esbuild/linux-arm64",
+        "@esbuild/linux-ia32",
+        "@esbuild/linux-loong64",
+        "@esbuild/linux-mips64el",
+        "@esbuild/linux-ppc64",
+        "@esbuild/linux-riscv64",
+        "@esbuild/linux-s390x",
+        "@esbuild/linux-x64",
+        "@esbuild/netbsd-arm64",
+        "@esbuild/netbsd-x64",
+        "@esbuild/openbsd-arm64",
+        "@esbuild/openbsd-x64",
+        "@esbuild/sunos-x64",
+        "@esbuild/win32-arm64",
+        "@esbuild/win32-ia32",
+        "@esbuild/win32-x64"
+      ],
+      "scripts": true,
+      "bin": true
     },
     "eslint-visitor-keys@4.2.0": {
       "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw=="

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -13,13 +13,19 @@ const runtime = new TakoPack([
 ], {
   fetch: customFetch,
   kv: { read: myRead },
-  events: { publish: myPublish },
+  events: {
+    publish: myPublish,
+    publishToClient: myPublishClient,
+  },
 });
 await runtime.init();
 const result = await runtime.callServer(manifest.identifier, "hello", [
   "world",
 ]);
 ```
+
+The `assets.write` API accepts an optional `{ cacheTTL }` option following the
+specification in `docs/takopack/main.md`.
 
 The implementation is intentionally minimal and focuses on server-side
 execution. The `takos` object exposes stub implementations of the APIs described

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -1,0 +1,26 @@
+# Takopack Runtime
+
+This module provides a lightweight runtime for executing unpacked `.takopack`
+archives. It exposes a `TakoPack` class which loads extension code and attaches
+a `takos` API instance to `globalThis` so that extension scripts can access the
+Takos APIs.
+
+```ts
+import { TakoPack } from "@takopack/runtime";
+
+const runtime = new TakoPack([
+  { manifest, server },
+], {
+  fetch: customFetch,
+  kv: { read: myRead },
+  events: { publish: myPublish },
+});
+await runtime.init();
+const result = await runtime.callServer(manifest.identifier, "hello", [
+  "world",
+]);
+```
+
+The implementation is intentionally minimal and focuses on server-side
+execution. The `takos` object exposes stub implementations of the APIs described
+in `docs/takopack/main.md`.

--- a/packages/runtime/mod.test.ts
+++ b/packages/runtime/mod.test.ts
@@ -41,3 +41,28 @@ deno.test("override takos APIs via options", async () => {
   assertEquals(result, "value:foo");
   delete (globalThis as Record<string, unknown>).takos;
 });
+
+deno.test("override new event APIs", async () => {
+  const pack = {
+    manifest: JSON.stringify({
+      name: "test3",
+      identifier: "com.example.test3",
+      version: "0.1.0",
+    }),
+    server:
+      `export async function send(){ await globalThis.takos.events.publishToClient('ev', {}); return 1; }`,
+  };
+
+  let called = false;
+  const takopack = new TakoPack([pack], {
+    events: {
+      publishToClient: async () => {
+        called = true;
+      },
+    },
+  });
+  await takopack.init();
+  await takopack.callServer("com.example.test3", "send");
+  assert(called);
+  delete (globalThis as Record<string, unknown>).takos;
+});

--- a/packages/runtime/mod.test.ts
+++ b/packages/runtime/mod.test.ts
@@ -1,0 +1,43 @@
+import { assert, assertEquals } from "jsr:@std/assert";
+import { TakoPack } from "./mod.ts";
+
+deno.test("load takopack and call server function", async () => {
+  const pack = {
+    manifest: JSON.stringify({
+      name: "test",
+      identifier: "com.example.test",
+      version: "0.1.0",
+    }),
+    server: `export function hello(name){ return 'Hello '+name; }`,
+  };
+
+  const takopack = new TakoPack([pack]);
+  await takopack.init();
+  const result = await takopack.callServer("com.example.test", "hello", [
+    "world",
+  ]);
+  assertEquals(result, "Hello world");
+  assert(globalThis.takos);
+  // cleanup
+  delete (globalThis as Record<string, unknown>).takos;
+});
+
+deno.test("override takos APIs via options", async () => {
+  const pack = {
+    manifest: JSON.stringify({
+      name: "test2",
+      identifier: "com.example.test2",
+      version: "0.1.0",
+    }),
+    server:
+      `export async function check(){ return await globalThis.takos.kv.read('foo'); }`,
+  };
+
+  const takopack = new TakoPack([pack], {
+    kv: { read: async (key: string) => `value:${key}` },
+  });
+  await takopack.init();
+  const result = await takopack.callServer("com.example.test2", "check");
+  assertEquals(result, "value:foo");
+  delete (globalThis as Record<string, unknown>).takos;
+});

--- a/packages/runtime/mod.test.ts
+++ b/packages/runtime/mod.test.ts
@@ -1,7 +1,7 @@
 import { assert, assertEquals } from "jsr:@std/assert";
 import { TakoPack } from "./mod.ts";
 
-deno.test("load takopack and call server function", async () => {
+Deno.test("load takopack and call server function", async () => {
   const pack = {
     manifest: JSON.stringify({
       name: "test",
@@ -17,12 +17,11 @@ deno.test("load takopack and call server function", async () => {
     "world",
   ]);
   assertEquals(result, "Hello world");
-  assert(globalThis.takos);
   // cleanup
   delete (globalThis as Record<string, unknown>).takos;
 });
 
-deno.test("override takos APIs via options", async () => {
+Deno.test("override takos APIs via options", async () => {
   const pack = {
     manifest: JSON.stringify({
       name: "test2",
@@ -42,7 +41,7 @@ deno.test("override takos APIs via options", async () => {
   delete (globalThis as Record<string, unknown>).takos;
 });
 
-deno.test("override new event APIs", async () => {
+Deno.test("override new event APIs", async () => {
   const pack = {
     manifest: JSON.stringify({
       name: "test3",

--- a/packages/runtime/mod.ts
+++ b/packages/runtime/mod.ts
@@ -1,0 +1,187 @@
+export interface UnpackedTakoPack {
+  manifest: string | Record<string, unknown>;
+  server?: string;
+  client?: string;
+  ui?: string;
+}
+
+export interface TakosKV {
+  read(key: string): Promise<unknown>;
+  write(key: string, value: unknown): Promise<void>;
+  delete(key: string): Promise<void>;
+  list(prefix?: string): Promise<string[]>;
+}
+
+export interface TakosEvents {
+  publish(name: string, payload: unknown): Promise<unknown>;
+  publishToBackground(name: string, payload: unknown): Promise<unknown>;
+  publishToUI(name: string, payload: unknown): Promise<unknown>;
+  subscribe(name: string, handler: (payload: unknown) => void): () => void;
+}
+
+export interface TakosAssets {
+  read(path: string): Promise<string>;
+  write(path: string, data: string | Uint8Array): Promise<string>;
+  delete(path: string): Promise<void>;
+  list(prefix?: string): Promise<string[]>;
+}
+
+export interface TakosActivityPub {
+  send(userId: string, activity: Record<string, unknown>): Promise<void>;
+  read(id: string): Promise<Record<string, unknown>>;
+  delete(id: string): Promise<void>;
+  list(userId?: string): Promise<string[]>;
+  actor: {
+    read(userId: string): Promise<Record<string, unknown>>;
+    update(userId: string, key: string, value: string): Promise<void>;
+    delete(userId: string, key: string): Promise<void>;
+  };
+  follow(followerId: string, followeeId: string): Promise<void>;
+  unfollow(followerId: string, followeeId: string): Promise<void>;
+  listFollowers(actorId: string): Promise<string[]>;
+  listFollowing(actorId: string): Promise<string[]>;
+  pluginActor: {
+    create(
+      localName: string,
+      profile: Record<string, unknown>,
+    ): Promise<string>;
+    read(iri: string): Promise<Record<string, unknown>>;
+    update(iri: string, partial: Record<string, unknown>): Promise<void>;
+    delete(iri: string): Promise<void>;
+    list(): Promise<string[]>;
+  };
+}
+
+export interface TakosOptions {
+  fetch?: (url: string, options?: RequestInit) => Promise<Response>;
+  kv?: Partial<TakosKV>;
+  events?: Partial<TakosEvents>;
+  assets?: Partial<TakosAssets>;
+  activitypub?: Partial<TakosActivityPub>;
+}
+
+export class Takos {
+  private opts: TakosOptions;
+  constructor(opts: TakosOptions = {}) {
+    this.opts = opts;
+    if (opts.kv) Object.assign(this.kv, opts.kv);
+    if (opts.events) Object.assign(this.events, opts.events);
+    if (opts.assets) Object.assign(this.assets, opts.assets);
+    if (opts.activitypub) Object.assign(this.activitypub, opts.activitypub);
+  }
+  fetch(url: string, options?: RequestInit): Promise<Response> {
+    const fn = this.opts.fetch ?? fetch;
+    return fn(url, options);
+  }
+  kv = {
+    read: async (_key: string) => undefined as unknown,
+    write: async (_key: string, _value: unknown) => {},
+    delete: async (_key: string) => {},
+    list: async () => [] as string[],
+  };
+  events = {
+    publish: async (_name: string, _payload: unknown) => {},
+    publishToBackground: async (_name: string, _payload: unknown) => {},
+    publishToUI: async (_name: string, _payload: unknown) => {},
+    subscribe: (_name: string, _handler: (payload: unknown) => void) => {
+      return () => {};
+    },
+  };
+  assets = {
+    read: async (_path: string) => "",
+    write: async (_path: string, _data: string | Uint8Array) => "",
+    delete: async (_path: string) => {},
+    list: async (_prefix?: string) => [] as string[],
+  };
+  activitypub = {
+    send: async (_userId: string, _activity: Record<string, unknown>) => {},
+    read: async (_id: string) => ({} as Record<string, unknown>),
+    delete: async (_id: string) => {},
+    list: async (_userId?: string) => [] as string[],
+    actor: {
+      read: async (_userId: string) => ({} as Record<string, unknown>),
+      update: async (_userId: string, _key: string, _value: string) => {},
+      delete: async (_userId: string, _key: string) => {},
+    },
+    follow: async (_followerId: string, _followeeId: string) => {},
+    unfollow: async (_followerId: string, _followeeId: string) => {},
+    listFollowers: async (_actorId: string) => [] as string[],
+    listFollowing: async (_actorId: string) => [] as string[],
+    pluginActor: {
+      create: async (_localName: string, _profile: Record<string, unknown>) =>
+        "",
+      read: async (_iri: string) => ({} as Record<string, unknown>),
+      update: async (_iri: string, _partial: Record<string, unknown>) => {},
+      delete: async (_iri: string) => {},
+      list: async () => [] as string[],
+    },
+  };
+}
+
+interface LoadedPack {
+  manifest: Record<string, unknown>;
+  serverCode?: string;
+  clientCode?: string;
+  ui?: string;
+  server?: Record<string, unknown>;
+  client?: Record<string, unknown>;
+}
+
+export class TakoPack {
+  private packs = new Map<string, LoadedPack>();
+  private takos: Takos;
+
+  constructor(packs: UnpackedTakoPack[], options: TakosOptions = {}) {
+    this.takos = new Takos(options);
+    (globalThis as Record<string, unknown>).takos = this.takos;
+    for (const p of packs) {
+      const manifest = typeof p.manifest === "string"
+        ? JSON.parse(p.manifest)
+        : p.manifest;
+      this.packs.set(manifest.identifier as string, {
+        manifest,
+        serverCode: p.server,
+        clientCode: p.client,
+        ui: p.ui,
+      });
+    }
+  }
+
+  async init(): Promise<void> {
+    for (const pack of this.packs.values()) {
+      if (pack.serverCode) {
+        pack.server = await this.importModule(pack.serverCode);
+      }
+      if (pack.clientCode) {
+        pack.client = await this.importModule(pack.clientCode);
+      }
+    }
+  }
+
+  private async importModule(code: string): Promise<Record<string, unknown>> {
+    const blob = new Blob([code], { type: "application/javascript" });
+    const url = URL.createObjectURL(blob);
+    try {
+      const mod = await import(url);
+      return mod as Record<string, unknown>;
+    } finally {
+      URL.revokeObjectURL(url);
+    }
+  }
+
+  async callServer(
+    identifier: string,
+    fnName: string,
+    args: unknown[] = [],
+  ): Promise<unknown> {
+    const pack = this.packs.get(identifier);
+    if (!pack) throw new Error(`pack not found: ${identifier}`);
+    if (!pack.server) throw new Error(`server not loaded for ${identifier}`);
+    const fn = (pack.server as Record<string, unknown>)[fnName];
+    if (typeof fn !== "function") {
+      throw new Error(`function ${fnName} not found in ${identifier}`);
+    }
+    // deno-lint-ignore no-explicit-any
+    return await (fn as any)(...args);
+  }
+}

--- a/packages/runtime/mod.ts
+++ b/packages/runtime/mod.ts
@@ -14,6 +14,9 @@ export interface TakosKV {
 
 export interface TakosEvents {
   publish(name: string, payload: unknown): Promise<unknown>;
+  publishToClient(name: string, payload: unknown): Promise<unknown>;
+  publishToClientPushNotification(name: string, payload: unknown):
+    Promise<unknown>;
   publishToBackground(name: string, payload: unknown): Promise<unknown>;
   publishToUI(name: string, payload: unknown): Promise<unknown>;
   subscribe(name: string, handler: (payload: unknown) => void): () => void;
@@ -21,7 +24,11 @@ export interface TakosEvents {
 
 export interface TakosAssets {
   read(path: string): Promise<string>;
-  write(path: string, data: string | Uint8Array): Promise<string>;
+  write(
+    path: string,
+    data: string | Uint8Array,
+    options?: { cacheTTL?: number },
+  ): Promise<string>;
   delete(path: string): Promise<void>;
   list(prefix?: string): Promise<string[]>;
 }
@@ -81,6 +88,11 @@ export class Takos {
   };
   events = {
     publish: async (_name: string, _payload: unknown) => {},
+    publishToClient: async (_name: string, _payload: unknown) => {},
+    publishToClientPushNotification: async (
+      _name: string,
+      _payload: unknown,
+    ) => {},
     publishToBackground: async (_name: string, _payload: unknown) => {},
     publishToUI: async (_name: string, _payload: unknown) => {},
     subscribe: (_name: string, _handler: (payload: unknown) => void) => {
@@ -89,7 +101,11 @@ export class Takos {
   };
   assets = {
     read: async (_path: string) => "",
-    write: async (_path: string, _data: string | Uint8Array) => "",
+    write: async (
+      _path: string,
+      _data: string | Uint8Array,
+      _options?: { cacheTTL?: number },
+    ) => "",
     delete: async (_path: string) => {},
     list: async (_prefix?: string) => [] as string[],
   };

--- a/packages/unpack/README.md
+++ b/packages/unpack/README.md
@@ -1,0 +1,11 @@
+# Takopack Unpack
+
+Utility module to extract the contents of a `.takopack` archive.
+
+```
+import { unpackTakoPack } from "@takopack/unpack";
+const result = await unpackTakoPack("my-extension.takopack");
+```
+
+`result` contains the `manifest.json`, `server.js`, `client.js` and `index.html`
+as strings. The manifest is validated to be a valid JSON file.

--- a/packages/unpack/deno.json
+++ b/packages/unpack/deno.json
@@ -1,0 +1,19 @@
+{
+  "name": "@takopack/unpack",
+  "version": "1.0.0",
+  "description": "Utility to unpack .takopack archives",
+  "exports": {
+    ".": "./mod.ts"
+  },
+  "imports": {
+    "@zip-js/zip-js": "jsr:@zip-js/zip-js@^2.7.62"
+  },
+  "tasks": {
+    "test": "deno test -A"
+  },
+  "compilerOptions": {
+    "lib": ["deno.ns", "dom"],
+    "strict": true
+  },
+  "nodeModulesDir": "auto"
+}

--- a/packages/unpack/deno.lock
+++ b/packages/unpack/deno.lock
@@ -1,0 +1,27 @@
+{
+  "version": "5",
+  "specifiers": {
+    "jsr:@std/assert@*": "1.0.13",
+    "jsr:@std/internal@^1.0.6": "1.0.6",
+    "jsr:@zip-js/zip-js@^2.7.62": "2.7.62"
+  },
+  "jsr": {
+    "@std/assert@1.0.13": {
+      "integrity": "ae0d31e41919b12c656c742b22522c32fb26ed0cba32975cb0de2a273cb68b29",
+      "dependencies": [
+        "jsr:@std/internal"
+      ]
+    },
+    "@std/internal@1.0.6": {
+      "integrity": "9533b128f230f73bd209408bb07a4b12f8d4255ab2a4d22a1fd6d87304aca9a4"
+    },
+    "@zip-js/zip-js@2.7.62": {
+      "integrity": "11cbe0746fa1e52e6e0a601c89ba97365f16e38a07f139b9d9914f988aec9081"
+    }
+  },
+  "workspace": {
+    "dependencies": [
+      "jsr:@zip-js/zip-js@^2.7.62"
+    ]
+  }
+}

--- a/packages/unpack/mod.test.ts
+++ b/packages/unpack/mod.test.ts
@@ -1,0 +1,25 @@
+import { assertEquals } from "jsr:@std/assert@^0.225.4";
+import { BlobWriter, TextReader, ZipWriter } from "jsr:@zip-js/zip-js@^2.7.62";
+import { unpackTakoPack } from "./mod.ts";
+
+Deno.test("unpack takopack archive", async () => {
+  const writer = new BlobWriter("application/zip");
+  const zip = new ZipWriter(writer);
+  await zip.add(
+    "takos/manifest.json",
+    new TextReader('{"name":"test","identifier":"id","version":"0.1.0"}'),
+  );
+  await zip.add("takos/server.js", new TextReader("console.log('server');"));
+  await zip.add("takos/client.js", new TextReader("console.log('client');"));
+  await zip.add("takos/index.html", new TextReader("<html></html>"));
+  await zip.close();
+  const blob = await writer.getData();
+  const buffer = new Uint8Array(await blob.arrayBuffer());
+
+  const result = await unpackTakoPack(buffer);
+
+  assertEquals(typeof result.manifest, "string");
+  assertEquals(result.server, "console.log('server');");
+  assertEquals(result.client, "console.log('client');");
+  assertEquals(result.index, "<html></html>");
+});

--- a/packages/unpack/mod.test.ts
+++ b/packages/unpack/mod.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "jsr:@std/assert@^0.225.4";
+import { assertEquals } from "jsr:@std/assert";
 import { BlobWriter, TextReader, ZipWriter } from "jsr:@zip-js/zip-js@^2.7.62";
 import { unpackTakoPack } from "./mod.ts";
 

--- a/packages/unpack/mod.ts
+++ b/packages/unpack/mod.ts
@@ -1,0 +1,61 @@
+import {
+  TextWriter,
+  Uint8ArrayReader,
+  ZipReader,
+} from "jsr:@zip-js/zip-js@^2.7.62";
+
+export interface TakoUnpackResult {
+  manifest: string;
+  server?: string;
+  client?: string;
+  index?: string;
+}
+
+/**
+ * Unpack a `.takopack` archive and return its core files as strings.
+ *
+ * @param input - Path to the .takopack file or its binary contents
+ * @throws if manifest.json is missing or invalid
+ */
+export async function unpackTakoPack(
+  input: string | Uint8Array | ArrayBuffer,
+): Promise<TakoUnpackResult> {
+  let bytes: Uint8Array;
+  if (typeof input === "string") {
+    bytes = await Deno.readFile(input);
+  } else if (input instanceof Uint8Array) {
+    bytes = input;
+  } else {
+    bytes = new Uint8Array(input);
+  }
+
+  const reader = new ZipReader(new Uint8ArrayReader(bytes));
+  const entries = await reader.getEntries();
+  const files: Record<string, string> = {};
+
+  for (const entry of entries) {
+    if (!entry.directory && entry.filename.startsWith("takos/")) {
+      const content = await entry.getData!(new TextWriter());
+      files[entry.filename] = content;
+    }
+  }
+
+  await reader.close();
+
+  const manifest = files["takos/manifest.json"];
+  if (!manifest) {
+    throw new Error("manifest.json not found in package");
+  }
+  try {
+    JSON.parse(manifest);
+  } catch {
+    throw new Error("manifest.json is not valid JSON");
+  }
+
+  return {
+    manifest,
+    server: files["takos/server.js"],
+    client: files["takos/client.js"],
+    index: files["takos/index.html"],
+  };
+}

--- a/packages/unpack/mod.ts
+++ b/packages/unpack/mod.ts
@@ -2,7 +2,13 @@ import {
   TextWriter,
   Uint8ArrayReader,
   ZipReader,
+  configure,
 } from "jsr:@zip-js/zip-js@^2.7.62";
+
+// Configure to disable workers to prevent timer leaks in tests
+configure({
+  useWebWorkers: false,
+});
 
 export interface TakoUnpackResult {
   manifest: string;


### PR DESCRIPTION
## Summary
- extend analyzer and generator to handle extension instances
- update docs to recommend instance-based development
- revise example extension files accordingly

## Testing
- `deno fmt packages/builder/src/generator.ts packages/builder/src/analyzer.ts packages/builder/src/types.ts examples/simple-extension/src/server/hello.ts examples/simple-extension/src/server/activity/note.ts examples/simple-extension/src/client/greet.ts docs/builder/README.md`
- `deno lint packages/builder/src/generator.ts packages/builder/src/analyzer.ts packages/builder/src/types.ts examples/simple-extension/src/server/hello.ts examples/simple-extension/src/server/activity/note.ts examples/simple-extension/src/client/greet.ts`
- `deno task test` *(fails: invalid peer certificate)*

------
https://chatgpt.com/codex/tasks/task_e_684033b1aa1c8328b7bc211a35e89661