### PR TITLE
Fix example extension typing

### DIFF
--- a/examples/simple-extension/deno.json
+++ b/examples/simple-extension/deno.json
@@ -4,7 +4,7 @@
     "build": "deno run -A -r jsr:@takopack/builder build"
   },
   "nodeModulesDir": "auto",
-  "imports ": {
+  "imports": {
     "@takopack/builder": "jsr:@takopack/builder@^4.0.0"
   }
 }

--- a/examples/simple-extension/src/server/activity/note.ts
+++ b/examples/simple-extension/src/server/activity/note.ts
@@ -1,7 +1,7 @@
 import type { Note } from "../../types.ts";
 import { SerializableObject, ServerExtension } from "@takopack/builder";
 
-export const NoteActivity = new ServerExtension();
+const NoteActivity = new ServerExtension();
 
 NoteActivity.canAcceptNote = (_ctx: string, obj: unknown): boolean => {
   // Simple validation: check if it's a Note object
@@ -22,7 +22,8 @@ NoteActivity.onReceiveNote = (
 
   // Store the note in KV
   if (note.id) {
-    globalThis.takos?.kv.write(
+    // deno-lint-ignore no-explicit-any
+    (globalThis as any).takos?.kv.write(
       `note:${note.id}`,
       note as SerializableObject,
     );

--- a/examples/simple-extension/src/server/hello.ts
+++ b/examples/simple-extension/src/server/hello.ts
@@ -3,7 +3,7 @@
 import { z } from "npm:zod";
 import { SerializableObject, ServerExtension } from "@takopack/builder";
 
-export const HelloServer = new ServerExtension();
+const HelloServer = new ServerExtension();
 
 HelloServer.hello = (name: string): string => {
   return `Hello, ${name} from server!`;
@@ -27,7 +27,8 @@ HelloServer.onUserLogin = (
   }).parse(userData);
 
   // Save to KV store
-  globalThis.takos?.kv.write(
+  // deno-lint-ignore no-explicit-any
+  (globalThis as any).takos?.kv.write(
     `last_login:${userData.username}`,
     userData.timestamp,
   );

--- a/packages/builder/src/classes.ts
+++ b/packages/builder/src/classes.ts
@@ -1,3 +1,11 @@
-export class ServerExtension {}
-export class ClientExtension {}
-export class UIExtension {}
+export class ServerExtension {
+  [key: string]: unknown;
+}
+
+export class ClientExtension {
+  [key: string]: unknown;
+}
+
+export class UIExtension {
+  [key: string]: unknown;
+}


### PR DESCRIPTION
## Summary
- fix `imports` key in example config
- allow dynamic members on extension classes
- update example server files

## Testing
- `deno lint packages/builder/src/classes.ts examples/simple-extension/src/server/hello.ts examples/simple-extension/src/server/activity/note.ts`
- `deno fmt examples/simple-extension/src/server/activity/note.ts examples/simple-extension/src/server/hello.ts packages/builder/src/classes.ts examples/simple-extension/deno.json`
- `deno task test` *(fails: invalid peer certificate)*

------
https://chatgpt.com/codex/tasks/task_e_6840519d126c8328bf1c2c963e70b54a