### PR TITLE
Fix builder ActivityPub manifest format

### DIFF
--- a/docs/builder/README.md
+++ b/docs/builder/README.md
@@ -253,22 +253,23 @@ ActivityPubフック処理を設定します。
 
 ```typescript
 .activityPub(
-  // 設定
-  { 
+  {
+    accepts: ["Note"],
     context: "https://www.w3.org/ns/activitystreams",
-    object: "Note",
-    priority: 1,
-    serial: false
+    hooks: {
+      priority: 1,
+      serial: false,
+    },
   },
   // canAccept関数（オプション）
   (context: string, object: any) => {
     return object.type === "Create" && object.object?.type === "Note";
   },
-  // hook関数（オプション）
+  // onReceiveフック（オプション）
   async (context: string, object: any) => {
     console.log("Note received:", object);
     return { processed: true };
-  }
+  },
 )
 ```
 
@@ -591,9 +592,11 @@ const activityPubExtension = new FunctionBasedTakopack()
   // ActivityPub Note処理
   .activityPub(
     {
+      accepts: ["Note"],
       context: "https://www.w3.org/ns/activitystreams",
-      object: "Note",
-      priority: 1,
+      hooks: {
+        priority: 1,
+      },
     },
     // canAccept: Noteの受信可否判定
     (context: string, object: any) => {
@@ -601,7 +604,7 @@ const activityPubExtension = new FunctionBasedTakopack()
         object.object?.type === "Note" &&
         object.object?.content;
     },
-    // hook: Note処理
+    // onReceive: Note処理
     async (context: string, object: any) => {
       const note = object.object;
 

--- a/packages/builder/src/builder.ts
+++ b/packages/builder/src/builder.ts
@@ -414,7 +414,7 @@ export class TakopackBuilder {
       manifest.eventDefinitions = eventDefinitions;
     }
     if (activityPubConfigs.length > 0) {
-      manifest.activityPub = activityPubConfigs;
+      manifest.activityPub = { objects: activityPubConfigs };
     }
 
     return manifest;
@@ -616,12 +616,14 @@ export class TakopackBuilder {
       const options = match[2] ? JSON.parse(match[2]) : {};
 
       return {
+        accepts: [object],
         context: "https://www.w3.org/ns/activitystreams",
-        object,
-        hook: targetFunction,
-        canAccept: targetFunction.startsWith("canAccept") ? targetFunction : undefined,
-        priority: options.priority,
-        serial: options.serial,
+        hooks: {
+          canAccept: targetFunction.startsWith("canAccept") ? targetFunction : undefined,
+          onReceive: targetFunction,
+          priority: options.priority,
+          serial: options.serial,
+        },
       };
     } catch {
       return null;

--- a/packages/builder/src/generator.ts
+++ b/packages/builder/src/generator.ts
@@ -318,12 +318,14 @@ export class VirtualEntryGenerator {
       const options = match[2] ? JSON.parse(match[2]) : {};
 
       return {
+        accepts: [object],
         context: "https://www.w3.org/ns/activitystreams",
-        object,
-        hook: targetFunction,
-        canAccept: targetFunction.startsWith("canAccept") ? targetFunction : undefined,
-        priority: options.priority,
-        serial: options.serial,
+        hooks: {
+          canAccept: targetFunction.startsWith("canAccept") ? targetFunction : undefined,
+          onReceive: targetFunction,
+          priority: options.priority,
+          serial: options.serial,
+        },
       };
     } catch {
       return null;
@@ -343,12 +345,14 @@ export class VirtualEntryGenerator {
     const options = (args[1] as Record<string, unknown>) || {};
 
     return {
+      accepts: [object],
       context: "https://www.w3.org/ns/activitystreams",
-      object,
-      hook: targetFunction,
-      canAccept: targetFunction.startsWith("canAccept") ? targetFunction : undefined,
-      priority: options.priority as number,
-      serial: options.serial as boolean,
+      hooks: {
+        canAccept: targetFunction.startsWith("canAccept") ? targetFunction : undefined,
+        onReceive: targetFunction,
+        priority: options.priority as number,
+        serial: options.serial as boolean,
+      },
     };
   }
 

--- a/packages/builder/src/types.ts
+++ b/packages/builder/src/types.ts
@@ -139,7 +139,9 @@ export interface ExtensionManifest {
     entryBackground: string;
   };
   eventDefinitions?: Record<string, EventDefinition>;
-  activityPub?: ActivityPubConfig[];
+  activityPub?: {
+    objects: ActivityPubConfig[];
+  };
 }
 
 export interface EventDefinition {
@@ -149,12 +151,14 @@ export interface EventDefinition {
 }
 
 export interface ActivityPubConfig {
+  accepts: string[];
   context: string;
-  object: string;
-  canAccept?: string;
-  hook?: string;
-  priority?: number;
-  serial?: boolean;
+  hooks: {
+    canAccept?: string;
+    onReceive: string;
+    priority?: number;
+    serial?: boolean;
+  };
 }
 
 /**


### PR DESCRIPTION
## Summary
- update builder to use `activityPub.objects` format from spec
- adjust ActivityPub parsing helpers
- document the new API in builder README

## Testing
- `deno task fmt` *(fails: invalid peer certificate)*
- `deno task lint` *(fails: invalid peer certificate)*

------
https://chatgpt.com/codex/tasks/task_e_68406e333184832881bda3d7cc01bc70