### PR TITLE
Add takopack unpacker module

### DIFF
--- a/packages/unpack/README.md
+++ b/packages/unpack/README.md
@@ -1,0 +1,11 @@
+# Takopack Unpack
+
+Utility module to extract the contents of a `.takopack` archive.
+
+```
+import { unpackTakoPack } from "@takopack/unpack";
+const result = await unpackTakoPack("my-extension.takopack");
+```
+
+`result` contains the `manifest.json`, `server.js`, `client.js` and `index.html`
+as strings. The manifest is validated to be a valid JSON file.

--- a/packages/unpack/deno.json
+++ b/packages/unpack/deno.json
@@ -1,0 +1,19 @@
+{
+  "name": "@takopack/unpack",
+  "version": "1.0.0",
+  "description": "Utility to unpack .takopack archives",
+  "exports": {
+    ".": "./mod.ts"
+  },
+  "imports": {
+    "@zip-js/zip-js": "jsr:@zip-js/zip-js@^2.7.62"
+  },
+  "tasks": {
+    "test": "deno test -A"
+  },
+  "compilerOptions": {
+    "lib": ["deno.ns", "dom"],
+    "strict": true
+  },
+  "nodeModulesDir": "auto"
+}

--- a/packages/unpack/mod.test.ts
+++ b/packages/unpack/mod.test.ts
@@ -1,0 +1,25 @@
+import { assertEquals } from "jsr:@std/assert@^0.225.4";
+import { BlobWriter, TextReader, ZipWriter } from "jsr:@zip-js/zip-js@^2.7.62";
+import { unpackTakoPack } from "./mod.ts";
+
+Deno.test("unpack takopack archive", async () => {
+  const writer = new BlobWriter("application/zip");
+  const zip = new ZipWriter(writer);
+  await zip.add(
+    "takos/manifest.json",
+    new TextReader('{"name":"test","identifier":"id","version":"0.1.0"}'),
+  );
+  await zip.add("takos/server.js", new TextReader("console.log('server');"));
+  await zip.add("takos/client.js", new TextReader("console.log('client');"));
+  await zip.add("takos/index.html", new TextReader("<html></html>"));
+  await zip.close();
+  const blob = await writer.getData();
+  const buffer = new Uint8Array(await blob.arrayBuffer());
+
+  const result = await unpackTakoPack(buffer);
+
+  assertEquals(typeof result.manifest, "string");
+  assertEquals(result.server, "console.log('server');");
+  assertEquals(result.client, "console.log('client');");
+  assertEquals(result.index, "<html></html>");
+});

--- a/packages/unpack/mod.ts
+++ b/packages/unpack/mod.ts
@@ -1,0 +1,61 @@
+import {
+  TextWriter,
+  Uint8ArrayReader,
+  ZipReader,
+} from "jsr:@zip-js/zip-js@^2.7.62";
+
+export interface TakoUnpackResult {
+  manifest: string;
+  server?: string;
+  client?: string;
+  index?: string;
+}
+
+/**
+ * Unpack a `.takopack` archive and return its core files as strings.
+ *
+ * @param input - Path to the .takopack file or its binary contents
+ * @throws if manifest.json is missing or invalid
+ */
+export async function unpackTakoPack(
+  input: string | Uint8Array | ArrayBuffer,
+): Promise<TakoUnpackResult> {
+  let bytes: Uint8Array;
+  if (typeof input === "string") {
+    bytes = await Deno.readFile(input);
+  } else if (input instanceof Uint8Array) {
+    bytes = input;
+  } else {
+    bytes = new Uint8Array(input);
+  }
+
+  const reader = new ZipReader(new Uint8ArrayReader(bytes));
+  const entries = await reader.getEntries();
+  const files: Record<string, string> = {};
+
+  for (const entry of entries) {
+    if (!entry.directory && entry.filename.startsWith("takos/")) {
+      const content = await entry.getData!(new TextWriter());
+      files[entry.filename] = content;
+    }
+  }
+
+  await reader.close();
+
+  const manifest = files["takos/manifest.json"];
+  if (!manifest) {
+    throw new Error("manifest.json not found in package");
+  }
+  try {
+    JSON.parse(manifest);
+  } catch {
+    throw new Error("manifest.json is not valid JSON");
+  }
+
+  return {
+    manifest,
+    server: files["takos/server.js"],
+    client: files["takos/client.js"],
+    index: files["takos/index.html"],
+  };
+}


### PR DESCRIPTION
## Summary
- add `@takopack/unpack` package
- implement `unpackTakoPack` to read `.takopack` archives
- document usage and provide a unit test

## Testing
- `deno lint packages/unpack/mod.ts packages/unpack/mod.test.ts` *(fails: JSR package manifest for '@zip-js/zip-js' failed to load)*
- `deno test packages/unpack/mod.test.ts --allow-all` *(fails: JSR package manifest for '@std/assert' failed to load)*

------
https://chatgpt.com/codex/tasks/task_e_6840764b70d48328b2fc1adb6430df1a