### PR TITLE
Fix bundler not externalizing parser

### DIFF
--- a/packages/builder/src/builder.ts
+++ b/packages/builder/src/builder.ts
@@ -272,14 +272,14 @@ export class TakopackBuilder {
         minify: !this.config.build?.dev && (this.config.build?.minify ?? true),
         sourcemap: this.config.build?.dev,
         treeShaking: true,
-        mainFields: ["module", "main"],        external: platform === "node" ? [
+        mainFields: ["module", "main"],
+        external: platform === "node" ? [
           // Node.js built-ins
           "node:*",
           "inspector",
           // Large packages that should remain external for server
           "esbuild",
           "typescript",
-          "@typescript-eslint/*",
           "debug",
           "fast-glob",
         ] : [
@@ -287,8 +287,7 @@ export class TakopackBuilder {
           "node:*",
           "inspector",
           "esbuild",
-          "typescript", 
-          "@typescript-eslint/*",
+          "typescript",
           "debug",
           "fast-glob",
         ],


### PR DESCRIPTION
## Summary
- include `@typescript-eslint/typescript-estree` in bundled output

## Testing
- `deno test -A` *(fails: JSR package manifest for '@std/assert' failed to load)*

------
https://chatgpt.com/codex/tasks/task_e_6844ae3465708328a09c481cff46e89d