### PR TITLE
Fix bundler externals

### DIFF
--- a/packages/builder/src/builder.ts
+++ b/packages/builder/src/builder.ts
@@ -279,7 +279,6 @@ export class TakopackBuilder {
           // Large packages that should remain external for server
           "esbuild",
           "typescript",
-          "@typescript-eslint/*",
           "debug",
           "fast-glob",
         ] : [
@@ -287,8 +286,7 @@ export class TakopackBuilder {
           "node:*",
           "inspector",
           "esbuild",
-          "typescript", 
-          "@typescript-eslint/*",
+          "typescript",
           "debug",
           "fast-glob",
         ],


### PR DESCRIPTION
## Summary
- prevent takopack builder from leaving `@typescript-eslint` imports in bundle by bundling all dependencies

## Testing
- `deno test -A` *(fails: JSR package manifest failed to load)*

------
https://chatgpt.com/codex/tasks/task_e_68455b828e7483289cc2cde2db0e56e8