### PR TITLE
Fix extension worker npm support

### DIFF
--- a/packages/runtime/mod.ts
+++ b/packages/runtime/mod.ts
@@ -245,6 +245,7 @@ class PackWorker {
         type: "module",
         deno: {
           namespace: true,
+          npm: true,
           permissions: {
             read: perms.read,
             write: perms.write,


### PR DESCRIPTION
## Summary
- enable NPM modules for extension workers

## Testing
- `deno test -A` *(fails: JSR package manifest for '@std/assert' failed to load)*

------
https://chatgpt.com/codex/tasks/task_e_68455fdb76708328945c9244794a3d8d