### PR TITLE
Fix extension worker dynamic require

### DIFF
--- a/packages/runtime/mod.ts
+++ b/packages/runtime/mod.ts
@@ -63,6 +63,8 @@ export interface TakosActivityPub {
 }
 
 const WORKER_SOURCE = `
+import { createRequire } from "node:module";
+const require = createRequire(import.meta.url);
 let takosCallId = 0;
 const takosCallbacks = new Map();
 function setPath(root, path, fn) {


### PR DESCRIPTION
## Summary
- support Node-style `require` inside extension workers by using `createRequire`

## Testing
- `deno test -A` *(fails: JSR package manifest failed to load)*

------
https://chatgpt.com/codex/tasks/task_e_684562642c1483288e89e387ce8e2a3d