### PR TITLE
Add icon support for extensions

### DIFF
--- a/app/api/events/extensions.ts
+++ b/app/api/events/extensions.ts
@@ -30,6 +30,7 @@ eventManager.add(
         server: result.server,
         client: result.client,
         ui: result.index,
+        icon: result.icon,
       },
       { upsert: true },
     );
@@ -40,6 +41,7 @@ eventManager.add(
       server: result.server,
       client: result.client,
       ui: result.index,
+      icon: result.icon,
     } as any);
 
     return { success: true };
@@ -61,5 +63,19 @@ eventManager.add(
     }
     const result = await runtime.callServer(id, fn, args);
     return { result };
+  },
+);
+
+eventManager.add(
+  "takos",
+  "extensions:list",
+  z.null().optional(),
+  async () => {
+    const docs = await Extension.find();
+    return docs.map((d) => ({
+      identifier: d.identifier,
+      name: d.manifest.name,
+      icon: d.icon,
+    }));
   },
 );

--- a/app/api/models/extension.ts
+++ b/app/api/models/extension.ts
@@ -6,6 +6,7 @@ const extensionSchema = new mongoose.Schema({
   server: { type: String },
   client: { type: String },
   ui: { type: String },
+  icon: { type: String },
   createdAt: { type: Date, default: Date.now },
 });
 

--- a/app/api/utils/extensionsRuntime.ts
+++ b/app/api/utils/extensionsRuntime.ts
@@ -14,10 +14,24 @@ export async function initExtensions() {
   }
 }
 
-export async function loadExtension(doc: typeof Extension.prototype & { identifier: string; manifest: any; server?: string; client?: string; ui?: string; }) {
+export async function loadExtension(
+  doc: typeof Extension.prototype & {
+    identifier: string;
+    manifest: any;
+    server?: string;
+    client?: string;
+    ui?: string;
+    icon?: string;
+  },
+) {
   try {
     const pack = new TakoPack([
-      { manifest: doc.manifest, server: doc.server, client: doc.client, ui: doc.ui },
+      {
+        manifest: doc.manifest,
+        server: doc.server,
+        client: doc.client,
+        ui: doc.ui,
+      },
     ]);
     await pack.init();
     runtimes.set(doc.identifier, pack);

--- a/app/client/src/components/ExtensionUpload.tsx
+++ b/app/client/src/components/ExtensionUpload.tsx
@@ -1,7 +1,29 @@
-import { createSignal } from "solid-js";
+import { createSignal, For, onMount } from "solid-js";
 
 export default function ExtensionUpload() {
   const [message, setMessage] = createSignal("");
+  const [extensions, setExtensions] = createSignal<
+    { identifier: string; name: string; icon?: string }[]
+  >([]);
+
+  const fetchExtensions = async () => {
+    const body = {
+      events: [
+        { identifier: "takos", eventId: "extensions:list", payload: null },
+      ],
+    };
+    const res = await fetch("/api/event", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    if (res.ok) {
+      const data = await res.json();
+      setExtensions(data[0]?.result ?? []);
+    }
+  };
+
+  onMount(fetchExtensions);
 
   const handleChange = async (e: Event) => {
     const files = (e.target as HTMLInputElement).files;
@@ -27,8 +49,10 @@ export default function ExtensionUpload() {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(body),
     });
-    if (res.ok) setMessage("Uploaded");
-    else setMessage("Failed");
+    if (res.ok) {
+      setMessage("Uploaded");
+      fetchExtensions();
+    } else setMessage("Failed");
   };
 
   return (
@@ -36,6 +60,20 @@ export default function ExtensionUpload() {
       <h3 class="text-lg mb-2">Upload Extension</h3>
       <input type="file" onChange={handleChange} />
       <p>{message()}</p>
+      <ul class="mt-3 space-y-2">
+        <For each={extensions()}>
+          {(ext) => (
+            <li class="flex items-center space-x-2">
+              <span>
+                {ext.icon
+                  ? <img src={ext.icon} class="w-6 h-6" alt={ext.name} />
+                  : <span class="w-6 h-6 bg-gray-500 inline-block" />}
+              </span>
+              <span>{ext.name}</span>
+            </li>
+          )}
+        </For>
+      </ul>
     </div>
   );
 }

--- a/packages/unpack/mod.test.ts
+++ b/packages/unpack/mod.test.ts
@@ -7,11 +7,14 @@ Deno.test("unpack takopack archive", async () => {
   const zip = new ZipWriter(writer);
   await zip.add(
     "takos/manifest.json",
-    new TextReader('{"name":"test","identifier":"id","version":"0.1.0","icon":"./icon.png"}'),
+    new TextReader(
+      '{"name":"test","identifier":"id","version":"0.1.0","icon":"./icon.png"}',
+    ),
   );
   await zip.add("takos/server.js", new TextReader("console.log('server');"));
   await zip.add("takos/client.js", new TextReader("console.log('client');"));
   await zip.add("takos/index.html", new TextReader("<html></html>"));
+  await zip.add("takos/icon.png", new TextReader("icon"));
   await zip.close();
   const blob = await writer.getData();
   const buffer = new Uint8Array(await blob.arrayBuffer());
@@ -22,4 +25,5 @@ Deno.test("unpack takopack archive", async () => {
   assertEquals(result.server, "console.log('server');");
   assertEquals(result.client, "console.log('client');");
   assertEquals(result.index, "<html></html>");
+  assertEquals(result.icon, "icon");
 });

--- a/packages/unpack/mod.ts
+++ b/packages/unpack/mod.ts
@@ -1,8 +1,8 @@
 import {
+  configure,
   TextWriter,
   Uint8ArrayReader,
   ZipReader,
-  configure,
 } from "jsr:@zip-js/zip-js@^2.7.62";
 
 // Configure to disable workers to prevent timer leaks in tests
@@ -15,6 +15,8 @@ export interface TakoUnpackResult {
   server?: string;
   client?: string;
   index?: string;
+  /** Icon file content if present */
+  icon?: string;
 }
 
 /**
@@ -53,15 +55,20 @@ export async function unpackTakoPack(
     throw new Error("manifest.json not found in package");
   }
   try {
-    JSON.parse(manifest);
+    const manifestObj = JSON.parse(manifest);
+    const iconPath = manifestObj.icon
+      ? `takos/${manifestObj.icon.replace(/^\.\/?/, "")}`
+      : undefined;
+    const icon = iconPath ? files[iconPath] : undefined;
+
+    return {
+      manifest,
+      server: files["takos/server.js"],
+      client: files["takos/client.js"],
+      index: files["takos/index.html"],
+      icon,
+    };
   } catch {
     throw new Error("manifest.json is not valid JSON");
   }
-
-  return {
-    manifest,
-    server: files["takos/server.js"],
-    client: files["takos/client.js"],
-    index: files["takos/index.html"],
-  };
 }


### PR DESCRIPTION
## Summary
- support `icon` in takopack unpacker
- store extension icon in the API
- expose extension list via `extensions:list` event
- include icon property when loading extensions
- show installed extensions with icons in dashboard

## Testing
- `deno test -A packages/unpack` *(fails: JSR package manifest for '@std/assert' failed to load)*
- `deno test -A packages/runtime` *(fails: JSR package manifest for '@std/assert' failed to load)*

------
https://chatgpt.com/codex/tasks/task_e_6846ffb17d348328840b403c647891f9