### PR TITLE
Fix docs language note

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # takosとは
 
+> **言語について**: README とドキュメントは日本語版のみ提供されています。(English version is not available yet)
+
 takosはActivityPubでweb自主するためのソフトウェアです。
 takosは、ActivityPubに追加で、以下の機能を提供します。
 

--- a/docs/takopack/main.md
+++ b/docs/takopack/main.md
@@ -76,7 +76,7 @@ awesome-pack.takopack (ZIP形式)
 ```jsonc
 {
   "name": "awesome-pack",
-  "description": "A brief description of the extension's functionality.",
+  "description": "拡張機能の簡単な説明です",
   "version": "1.2.0",
   "identifier": "com.example.awesome",
   "icon": "./icon.png",
@@ -373,7 +373,7 @@ async function example() {
   // プラグインアクター作成例
   const actorIri = await takos.activitypub.pluginActor.create("bot1", {
     name: "My Bot",
-    summary: "A helpful bot",
+    summary: "便利なボット",
   });
 }
 ```


### PR DESCRIPTION
## Summary
- clarify docs language status in README
- translate leftover English lines in Takopack docs

## Testing
- `deno task test` in packages/runtime *(fails: JSR package manifest failed to load)*
- `deno task test` in packages/builder *(fails: Failed caching npm package due to invalid peer certificate)*
- `deno task test` in packages/unpack *(fails: Failed caching npm package due to invalid peer certificate)*

------
https://chatgpt.com/codex/tasks/task_e_68499c00f1c8832886e0aa81325e1776