### PR TITLE
Improve API specification

### DIFF
--- a/app/api/utils/extensionsRuntime.ts
+++ b/app/api/utils/extensionsRuntime.ts
@@ -37,9 +37,9 @@ export async function loadExtension(
       },
     ], {
       events: {
-        publishToClient: (name: string, payload: unknown) => {
+        publish: (name: string, payload: unknown) => {
           wss?.distributeEvent(name, payload);
-          return Promise.resolve();
+          return Promise.resolve(undefined);
         },
       },
       kv: {

--- a/app/client/builder/types/takos-api.ts
+++ b/app/client/builder/types/takos-api.ts
@@ -52,19 +52,7 @@ export interface CdnManager {
 }
 
 export interface EventManager {
-  // Server-side (server.js)
-  publish(eventName: string, payload: unknown): Promise<[number, unknown]>;
-  publishToClient(eventName: string, payload: unknown): Promise<void>;
-  publishToClientPushNotification(
-    eventName: string,
-    payload: unknown,
-  ): Promise<void>;
-
-  // Client-side (client.js)
-  publishToUI(eventName: string, payload: unknown): Promise<void>;
-  publishToBackground(eventName: string, payload: unknown): Promise<void>;
-
-  // Common API
+  publish(eventName: string, payload: unknown): Promise<[number, unknown] | void>;
   subscribe(eventName: string, handler: (payload: unknown) => void): () => void;
 }
 

--- a/app/client/src/takos.ts
+++ b/app/client/src/takos.ts
@@ -60,11 +60,6 @@ export function createTakos(identifier: string) {
   const events = {
     publish: (name: string, payload: unknown) =>
       call("extensions:invoke", { id: identifier, fn: name, args: [payload] }),
-    publishToBackground: (_n: string, _p: unknown) => Promise.resolve(),
-    publishToUI: (_n: string, _p: unknown) => Promise.resolve(),
-    publishToClient: (_n: string, _p: unknown) => Promise.resolve(),
-    publishToClientPushNotification: (_n: string, _p: unknown) =>
-      Promise.resolve(),
     subscribe: (name: string, handler: (payload: unknown) => void) => {
       if (!listeners.has(name)) listeners.set(name, new Set());
       listeners.get(name)!.add(handler);

--- a/docs/builder/README.md
+++ b/docs/builder/README.md
@@ -214,7 +214,6 @@ UI HTMLコンテンツを設定します。
 ```typescript
 .addEvent("customEvent", {
   source: "client",
-  target: "server",
   handler: "handleCustomEvent"
 }, async (payload: any) => {
   return [200, { processed: true }];
@@ -365,7 +364,7 @@ type Permission =
 
 // UI更新処理
 .clientFunction("updateUI", async (data: any) => {
-  await globalThis.takos.events.publishToUI("dataUpdate", data);
+  await globalThis.takos.events.publish("dataUpdate", data);
 })
 ```
 
@@ -387,7 +386,7 @@ type Permission =
 .addServerToClientEvent("dataChanged", async (newData: any) => {
   console.log("Data updated:", newData);
   // UIに通知
-  await globalThis.takos.events.publishToUI("refresh", newData);
+  await globalThis.takos.events.publish("refresh", newData);
 })
 ```
 
@@ -402,7 +401,7 @@ import { ServerExtension } from "@takopack/builder";
 
 export const MyServer = new ServerExtension();
 
-/** @event("userLogin", { source: "client", target: "server" }) */
+/** @event("userLogin", { source: "client" }) */
 MyServer.onUserLogin = (data: { username: string }) => {
   console.log("login", data);
   return [200, { ok: true }];
@@ -566,7 +565,7 @@ const memoExtension = new FunctionBasedTakopack()
         <script>
           async function saveMemo() {
             const memo = document.getElementById('memo').value;
-            await takos.events.publishToBackground('saveMemo', memo);
+            await takos.events.publish('saveMemo', memo);
           }
         </script>
       </body>

--- a/docs/takopack/v3.md
+++ b/docs/takopack/v3.md
@@ -1,5 +1,336 @@
-# 🐙 Takos 拡張機能仕様書 v3 (ドラフト)
+# 🐙 Takos 拡張機能仕様書 v3
 
-この文書は将来の v3 仕様についてまとめるためのドラフトです。現行の `manifest.json` 構造は [manifest.schema.json](./manifest.schema.json) で定義されており、開発時にはスキーマに従って検証してください。
+> **仕様バージョン**: v3.0 (ドラフト) **最終更新**: 2025-06-11
 
-v3 の詳細な変更点は今後追加されます。
+## 🎯 目次
+1. [目的](#目的)
+2. [用語](#用語)
+3. [パッケージ構造](#パッケージ構造)
+4. [manifest.json 詳細仕様](#manifestjson-詳細仕様)
+5. [名前空間と衝突回避](#名前空間と衝突回避)
+6. [APIと権限](#apiと権限)
+7. [globalThis.takos API](#globalthistakos-api)
+8. [ActivityPub フック](#activitypub-フック)
+9. [イベント定義](#イベント定義)
+10. [v2.1からの移行ガイド](#v21からの移行ガイド)
+11. [Sandbox 実行環境](#sandbox-実行環境)
+12. [拡張機能間API連携](#拡張機能間api連携)
+
+---
+
+## 目的
+
+Takos を VSCode ライクに安全かつ柔軟に拡張するための共通仕様を定義します。拡張は **server.js**、**client.js**、**index.html** の 3 ファイルで完結し、Deno 互換環境上で実行されます。
+
+---
+
+## 用語
+
+| 用語 | 説明 |
+| ---- | ---- |
+| Pack (.takopack) | zip 形式の拡張パッケージ。トップに `takos/` フォルダを持つ |
+| Identifier | `com.example.foo` のような逆 FQDN。`takos` は予約済み |
+| Permission | `resource:action(:scope)` 形式の権限文字列 |
+| ExtensionDependencies | 他拡張への依存定義 |
+| Exports | 外部公開 API の一覧 |
+
+---
+
+## パッケージ構造
+
+```
+awesome-pack.takopack
+└─ takos/
+   ├─ manifest.json  # 必須
+   ├─ server.js      # サーバー
+   ├─ client.js      # バックグラウンド
+   └─ index.html     # UI
+```
+
+`server.js` と `client.js` は依存のない単一ファイルです。`index.html` は UI を提供します。
+
+---
+
+## manifest.json 詳細仕様
+
+`manifest.json` は [manifest.schema.json](./manifest.schema.json) で検証できます。主なフィールドは次のとおりです。
+
+```jsonc
+{
+  "name": "awesome-pack",
+  "description": "拡張機能の説明",
+  "version": "1.2.0",
+  "identifier": "com.example.awesome",
+  "icon": "./icon.png",
+  "apiVersion": "3.0",
+
+  "extensionDependencies": [
+    { "identifier": "com.example.lib", "version": "^1.0.0" }
+  ],
+
+  "exports": {
+    "server": ["calculateHash", "sign"],
+    "background": [],
+    "ui": []
+  },
+
+  "permissions": [
+    "fetch:net",
+    "activitypub:send",
+    "activitypub:read",
+    "activitypub:receive:hook",
+    "activitypub:actor:read",
+    "activitypub:actor:write",
+    "plugin-actor:create",
+    "plugin-actor:read",
+    "plugin-actor:write",
+    "plugin-actor:delete",
+    "kv:read",
+    "kv:write",
+    "cdn:read",
+    "cdn:write",
+    "events:publish",
+    "events:subscribe",
+    "extensions:invoke",
+    "extensions:export",
+    "deno:read",
+    "deno:write",
+    "deno:net",
+    "deno:env",
+    "deno:run",
+    "deno:sys",
+    "deno:ffi"
+  ],
+
+  "server": { "entry": "./server.js" },
+  "client": {
+    "entryUI": "./index.html",
+    "entryBackground": "./client.js"
+  },
+
+  "activityPub": {
+    "objects": [{
+      "accepts": ["Note", "Create", "Like"],
+      "context": "https://www.w3.org/ns/activitystreams",
+      "hooks": {
+        "canAccept": "canAccept",
+        "onReceive": "onReceive",
+        "priority": 1,
+        "serial": false
+      }
+    }]
+  },
+
+  "eventDefinitions": {
+    "postMessage": {
+      "source": "client",
+      "handler": "onPostMessage"
+    },
+    "notifyClient": {
+      "source": "server",
+      "handler": "onNotifyClient"
+    }
+  }
+}
+```
+
+---
+
+## 名前空間と衝突回避
+
+- Identifier は逆 FQDN 形式を採用し衝突を避けます。
+- KV とアセットは `identifier` 毎に名前空間分離されます。
+  - KV: `${identifier}:${key}`
+  - CDN: `${identifier}/${path}`
+- 同名関数を export しても識別子ごとに独立するため衝突しません。
+- 依存解決は npm-semver 準拠で最新版優先、警告あり。
+
+---
+
+## APIと権限
+
+主要 API のメソッドシグネチャと必要権限は以下の通りです。
+
+### ActivityPub
+
+#### オブジェクト操作
+- **send**: `takos.activitypub.send(userId: string, activity: object): Promise<void>`
+  - **必要権限**: `activitypub:send`
+- **read**: `takos.activitypub.read(id: string): Promise<object>`
+  - **必要権限**: `activitypub:read`
+- **delete**: `takos.activitypub.delete(id: string): Promise<void>`
+  - **必要権限**: `activitypub:send`
+- **list**: `takos.activitypub.list(userId?: string): Promise<string[]>`
+  - **必要権限**: `activitypub:read`
+
+#### フック処理
+- ActivityPub オブジェクト受信時のフック (`canAccept`, `onReceive`)
+  - **必要権限**: `activitypub:receive:hook`
+
+#### アクター操作
+- **read**: `takos.activitypub.actor.read(userId: string): Promise<object>`
+- **update**: `takos.activitypub.actor.update(userId: string, key: string, value: string): Promise<void>`
+- **delete**: `takos.activitypub.actor.delete(userId: string, key: string): Promise<void>`
+- **follow**: `takos.activitypub.follow(followerId: string, followeeId: string): Promise<void>`
+- **unfollow**: `takos.activitypub.unfollow(followerId: string, followeeId: string): Promise<void>`
+- **listFollowers**: `takos.activitypub.listFollowers(actorId: string): Promise<string[]>`
+- **listFollowing**: `takos.activitypub.listFollowing(actorId: string): Promise<string[]>`
+  - **必要権限**: `activitypub:actor:read` / `activitypub:actor:write`
+
+### プラグインアクター操作
+- **create**: `takos.activitypub.pluginActor.create(localName: string, profile: object): Promise<string>`
+- **read**: `takos.activitypub.pluginActor.read(iri: string): Promise<object>`
+- **update**: `takos.activitypub.pluginActor.update(iri: string, partial: object): Promise<void>`
+- **delete**: `takos.activitypub.pluginActor.delete(iri: string): Promise<void>`
+- **list**: `takos.activitypub.pluginActor.list(): Promise<string[]>`
+  - **必要権限**: `plugin-actor:create` / `plugin-actor:read` / `plugin-actor:write` / `plugin-actor:delete`
+
+### kv
+- **read**: `takos.kv.read(key: string): Promise<any>`
+- **write**: `takos.kv.write(key: string, value: any): Promise<void>`
+- **delete**: `takos.kv.delete(key: string): Promise<void>`
+- **list**: `takos.kv.list(): Promise<string[]>`
+  - **必要権限**: `kv:read` / `kv:write`
+  - `server.js` と `client.js` / `index.html` のストレージは独立
+
+### fetch
+- **fetch**: `takos.fetch(url: string, options?: object): Promise<Response>`
+  - **必要権限**: `fetch:net`  (クライアントでは `client.allowedConnectSrc` 設定が必要)
+
+### cdn
+- **read**: `takos.cdn.read(path: string): Promise<string>`
+- **write**: `takos.cdn.write(path: string, data: string | Uint8Array, options?: { cacheTTL?: number }): Promise<string>`
+- **delete**: `takos.cdn.delete(path: string): Promise<void>`
+- **list**: `takos.cdn.list(prefix?: string): Promise<string[]>`
+  - **必要権限**: `cdn:read` / `cdn:write`
+  - **制限**: 合計 20MB まで。エンドポイント `/cdn/<identifier>/<path>`
+
+### events
+イベントは manifest.json の `eventDefinitions` で宣言します。各レイヤー (server, client, background, ui) からは同じ API で実行できます。
+
+- `takos.events.publish(eventName: string, payload: any): Promise<[number, object]> | Promise<void>`
+  - 送信先が `server` の場合、ハンドラーが返す `[status, body]` を取得します。その他のレイヤー向けは `void` を返します。
+- `takos.events.subscribe(eventName: string, handler: (payload: any) => void): () => void`
+  - **必要権限**: `events:publish` / `events:subscribe`
+  - **レート制限**: 10 件/秒
+
+### 拡張間 API
+- `takos.extensions.get(identifier: string): Extension | undefined`
+- `Extension.activate(): Promise<any>`
+  - **必要権限**: `extensions:invoke` / `extensions:export`
+
+権限はすべて `manifest.permissions` に列挙し、必要最低限を宣言してください。
+
+---
+
+## globalThis.takos API
+
+Takos の各 API は `globalThis` 上の `takos` オブジェクトとして公開されます。
+そのため、各スクリプトの冒頭で次のように取得して利用します。
+
+```javascript
+const { takos } = globalThis;
+```
+
+```typescript
+namespace takos.extensions {
+  function get(identifier: string): Extension | undefined;
+  const all: Extension[];
+}
+interface Extension {
+  identifier: string;
+  version: string;
+  isActive: boolean;
+  activate(): Promise<any>;
+}
+```
+
+利用例:
+
+```javascript
+const ext = takos.extensions.get("com.example.lib");
+if (ext) {
+  const api = await ext.activate();
+  const hash = await api.calculateHash("hello");
+}
+```
+
+その他の API も `takos.*` 名前空間に集約されています。
+
+---
+
+## ActivityPub フック
+
+`activityPub.objects.accepts` に指定したオブジェクトを受信すると、各 Pack の `canAccept` → `onReceive` が順に呼ばれます。`serial: true` を指定すると優先度順に逐次実行されます。
+
+```javascript
+const afterA = await PackA.onReceive(obj);
+const afterB = await PackB.onReceive(afterA);
+```
+
+---
+
+## イベント定義
+
+`eventDefinitions` にイベントを宣言し、`server.js` 等でハンドラーを実装します。
+
+```jsonc
+{
+  "eventDefinitions": {
+    "myEvent": {
+      "source": "client",
+      "handler": "onMyEvent"
+    }
+  }
+}
+```
+
+- 送信元は `client`、`server`、`background`、`ui` のいずれか
+- 対象レイヤーはハンドラーを実装したファイルで決まります
+
+サーバー側ハンドラーは `[200|400|500, body]` を返します。
+
+定義したイベントは、どのレイヤーからも共通の `takos.events.publish(eventName, payload)` で発行できます。
+
+---
+
+## v2.1からの移行ガイド
+
+1. 権限宣言を `manifest.permissions` に集約。
+2. イベント定義は `source` のみを指定し、ハンドラー実装側が受信先となります。
+3. ActivityPub API は `activityPub()` に統合。
+4. `extensionDependencies` と `exports` を利用し、`takos.extensions` API で他拡張と連携。
+
+---
+
+## Sandbox 実行環境
+
+- すべてのレイヤーはサンドボックスで分離されます。
+- `activate()` の戻り値は structuredClone 準拠でシリアライズ。
+- 呼び出し権限は export 元の範囲に限定され、依存循環はエラーとなります。
+
+---
+
+## 拡張機能間API連携
+
+### 記述方法
+- `extensionDependencies` で依存 Pack を宣言し、未インストール時は UI で通知。
+- `exports` で公開関数をレイヤーごとに列挙します。
+
+### 権限制御
+- `extensions:export` 他拡張へ API を公開する権限。
+- `extensions:invoke` 他拡張の API を取得する権限。
+
+### 利用方法
+
+```javascript
+const ext = takos.extensions.get("com.example.lib");
+if (ext) {
+  const api = await ext.activate();
+  await api.doSomething();
+}
+```
+
+TypeScript で型安全に連携でき、npm-semver 準拠で依存解決されます。
+
+---

--- a/examples/simple-extension/src/client/greet.ts
+++ b/examples/simple-extension/src/client/greet.ts
@@ -7,7 +7,7 @@ GreetClient.greet = (): void => {
   console.log("Hello from client background!");
 };
 
-/** @event("userClick", { source: "ui", target: "background" }) */
+/** @event("userClick", { source: "ui" }) */
 GreetClient.onUserClick = (
   data: { x: number; y: number; timestamp: number },
 ): void => {
@@ -22,7 +22,7 @@ GreetClient.onUserClick = (
   }
 };
 
-/** @event("backgroundTask", { source: "server", target: "client" }) */
+/** @event("backgroundTask", { source: "server" }) */
 GreetClient.onBackgroundTask = (task: { id: string; action: string }): void => {
   console.log("Received background task:", task);
   const takosAPI = getTakosClientAPI();

--- a/examples/simple-extension/src/server/hello.ts
+++ b/examples/simple-extension/src/server/hello.ts
@@ -17,7 +17,7 @@ HelloServer.calculateSum = (a: number, b: number): number => {
   return a + b;
 };
 
-/** @event("userLogin", { source: "client", target: "server" }) */
+/** @event("userLogin", { source: "client" }) */
 HelloServer.onUserLogin = async (
   userData: { username: string; timestamp: number },
 ): Promise<[number, SerializableObject]> => {

--- a/examples/simple-extension/src/ui/index.html
+++ b/examples/simple-extension/src/ui/index.html
@@ -159,7 +159,7 @@
         };
 
         if (typeof takos !== "undefined" && takos.events) {
-          takos.events.publishToBackground("userClick", clickData)
+          takos.events.publish("userClick", clickData)
             .then(() => {
               log(`Event published: userClick`);
               showStatus("Event published successfully!", "success");

--- a/packages/builder/src/builder.ts
+++ b/packages/builder/src/builder.ts
@@ -381,10 +381,10 @@ export class TakopackBuilder {
           const eventName = typeof decorator.args[0] === "string" ? decorator.args[0] : "";
           const options = (typeof decorator.args[1] === "object" &&
               decorator.args[1] !== null)
-            ? decorator.args[1] as Record<string, unknown>
-            : {};          eventDefinitions[eventName] = {
+            ? (decorator.args[1] as Record<string, unknown>)
+            : {};
+          eventDefinitions[eventName] = {
             source: (options.source as "client" | "server" | "background" | "ui") || "client",
-            target: (options.target as "server" | "client" | "client:*" | "ui" | "background") || "server",
             handler: handlerName,
           };
         } else if (decorator.name === "activity" && decorator.args.length > 0) {
@@ -620,7 +620,6 @@ export class TakopackBuilder {
 
       return {
         source: options.source || "client",
-        target: options.target || "server",
         handler: targetFunction,
       };
     } catch {

--- a/packages/builder/src/commands.ts
+++ b/packages/builder/src/commands.ts
@@ -161,7 +161,7 @@ export function greet(): void {
   console.log("Hello from client background!");
 }
 
-/** @event("userClick", { source: "ui", target: "background" }) */
+/** @event("userClick", { source: "ui" }) */
 export function onUserClick(data: any): void {
   console.log("User clicked:", data);
 }`;
@@ -189,7 +189,7 @@ export function onUserClick(data: any): void {
     <script>
         function handleClick() {
             if (typeof takos !== 'undefined') {
-                takos.events.publishToBackground('userClick', { timestamp: Date.now() });
+                takos.events.publish('userClick', { timestamp: Date.now() });
             } else {
                 console.log('Takos API not available');
             }

--- a/packages/builder/src/generator.ts
+++ b/packages/builder/src/generator.ts
@@ -238,7 +238,7 @@ export class VirtualEntryGenerator {
           activityPubConfigs.push(activityConfig);
         }
       } else if (tag.tag === "event") {
-        // @event("myEvent", { source: "client", target: "server" })
+        // @event("myEvent", { source: "client" })
         const handlerName = tag.targetClass
           ? `${tag.targetClass}_${tag.targetFunction}`
           : tag.targetFunction;
@@ -280,7 +280,7 @@ export class VirtualEntryGenerator {
           activityPubConfigs.push(activityConfig);
         }
       } else if (decorator.name === "event") {
-        // @event("myEvent", { source: "client", target: "server" })
+        // @event("myEvent", { source: "client" })
         const handlerName = decorator.targetClass
           ? `${decorator.targetClass}_${decorator.targetFunction}`
           : decorator.targetFunction;
@@ -364,7 +364,7 @@ export class VirtualEntryGenerator {
     targetFunction: string,
   ): EventDefinition | null {
     try {
-      // @event("myEvent", { source: "client", target: "server" }) 形式をパース
+      // @event("myEvent", { source: "client" }) 形式をパース
       const match = value.match(/^["']([^"']+)["'](?:,\s*({.+}))?/);
       if (!match) return null;
 
@@ -372,7 +372,6 @@ export class VirtualEntryGenerator {
 
       return {
         source: options.source || "client",
-        target: options.target || "server",
         handler: targetFunction,
       };
     } catch {
@@ -396,12 +395,6 @@ export class VirtualEntryGenerator {
         | "server"
         | "background"
         | "ui",
-      target: (typeof options.target === "string" ? options.target : "server") as
-        | "server"
-        | "client"
-        | "client:*"
-        | "ui"
-        | "background",
       handler: targetFunction,
     };
   }

--- a/packages/builder/src/types.ts
+++ b/packages/builder/src/types.ts
@@ -148,7 +148,6 @@ export interface ExtensionManifest {
 
 export interface EventDefinition {
   source: "client" | "server" | "background" | "ui";
-  target: "server" | "client" | "client:*" | "ui" | "background";
   handler: string;
 }
 
@@ -362,39 +361,11 @@ export interface TakosCdnAPI {
 }
 
 // Context-aware Events API
-export interface TakosServerEventsAPI {
+export interface TakosEventsAPI {
   publish(
     eventName: string,
     payload: SerializableValue,
-  ): Promise<[200 | 400 | 500, SerializableObject]>;
-  publishToClient(eventName: string, payload: SerializableValue): Promise<void>;
-  publishToClientPushNotification(
-    eventName: string,
-    payload: SerializableValue,
-  ): Promise<void>;
-  subscribe<T = SerializableValue>(
-    eventName: string,
-    handler: EventHandler<T>,
-  ): EventUnsubscribe;
-}
-
-export interface TakosClientEventsAPI {
-  publishToUI(eventName: string, payload: SerializableValue): Promise<void>;
-  publishToBackground(
-    eventName: string,
-    payload: SerializableValue,
-  ): Promise<void>;
-  subscribe<T = SerializableValue>(
-    eventName: string,
-    handler: EventHandler<T>,
-  ): EventUnsubscribe;
-}
-
-export interface TakosUIEventsAPI {
-  publishToBackground(
-    eventName: string,
-    payload: SerializableValue,
-  ): Promise<void>;
+  ): Promise<[200 | 400 | 500, SerializableObject] | void>;
   subscribe<T = SerializableValue>(
     eventName: string,
     handler: EventHandler<T>,
@@ -410,15 +381,15 @@ export interface TakosAPI {
 }
 
 export interface TakosServerAPI extends TakosAPI {
-  events: TakosServerEventsAPI;
+  events: TakosEventsAPI;
 }
 
 export interface TakosClientAPI extends TakosAPI {
-  events: TakosClientEventsAPI;
+  events: TakosEventsAPI;
 }
 
 export interface TakosUIAPI {
-  events: TakosUIEventsAPI;
+  events: TakosEventsAPI;
   // UI環境では一部のAPIは制限される
 }
 

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -15,7 +15,6 @@ const runtime = new TakoPack([
   kv: { read: myRead },
   events: {
     publish: myPublish,
-    publishToClient: myPublishClient,
   },
 });
 await runtime.init();

--- a/packages/runtime/mod.test.ts
+++ b/packages/runtime/mod.test.ts
@@ -59,14 +59,15 @@ Deno.test("override new event APIs", async () => {
       icon: "./icon.png",
     }),
     server:
-      `export async function send(){ await globalThis.takos.events.publishToClient('ev', {}); return 1; }`,
+      `export async function send(){ await globalThis.takos.events.publish('ev', {}); return 1; }`,
   };
 
   let called = false;
   const takopack = new TakoPack([pack], {
     events: {
-      publishToClient: async () => {
+      publish: async () => {
         called = true;
+        return undefined;
       },
     },
   });

--- a/packages/runtime/mod.ts
+++ b/packages/runtime/mod.ts
@@ -14,14 +14,6 @@ export interface TakosKV {
 
 export interface TakosEvents {
   publish(name: string, payload: unknown): Promise<unknown>;
-  publishToClient(name: string, payload: unknown): Promise<unknown>;
-
-  publishToClientPushNotification(
-    name: string,
-    payload: unknown,
-  ): Promise<unknown>;
-  publishToBackground(name: string, payload: unknown): Promise<unknown>;
-  publishToUI(name: string, payload: unknown): Promise<unknown>;
   subscribe(name: string, handler: (payload: unknown) => void): () => void;
 }
 
@@ -167,13 +159,6 @@ export class Takos {
   };
   events = {
     publish: async (_name: string, _payload: unknown) => {},
-    publishToClient: async (_name: string, _payload: unknown) => {},
-    publishToClientPushNotification: async (
-      _name: string,
-      _payload: unknown,
-    ) => {},
-    publishToBackground: async (_name: string, _payload: unknown) => {},
-    publishToUI: async (_name: string, _payload: unknown) => {},
     subscribe: (
       _name: string,
       _handler: (payload: unknown) => void,
@@ -223,10 +208,6 @@ const TAKOS_PATHS: string[][] = [
   ["kv", "delete"],
   ["kv", "list"],
   ["events", "publish"],
-  ["events", "publishToClient"],
-  ["events", "publishToClientPushNotification"],
-  ["events", "publishToBackground"],
-  ["events", "publishToUI"],
   ["events", "subscribe"],
   ["cdn", "read"],
   ["cdn", "write"],


### PR DESCRIPTION
## Summary
- clean up event definitions in examples and builder code
- document unified event API in main spec
- drop `target` field from manifest examples

## Testing
- `npm test` *(fails: package.json missing)*
- `deno test packages/runtime/mod.test.ts` *(fails to fetch @std/assert)*

------
https://chatgpt.com/codex/tasks/task_e_6849b128da748328a780cc16fe342ebb