### PR TITLE
Add takos.ap alias

### DIFF
--- a/app/client/builder/types/takos-api.ts
+++ b/app/client/builder/types/takos-api.ts
@@ -90,6 +90,7 @@ export interface ActivityPubManager {
 
 export interface TakosAPI {
   activitypub: ActivityPubManager;
+  ap: ActivityPubManager;
   kv: KVStore;
   cdn: CdnManager;
   events: EventManager;

--- a/docs/takopack/v3.md
+++ b/docs/takopack/v3.md
@@ -154,13 +154,13 @@ awesome-pack.takopack
 ### ActivityPub
 
 #### オブジェクト操作
-- **send**: `takos.activitypub.send(userId: string, activity: object): Promise<void>`
+- **send**: `takos.ap.send(userId: string, activity: object): Promise<void>`
   - **必要権限**: `activitypub:send`
-- **read**: `takos.activitypub.read(id: string): Promise<object>`
+- **read**: `takos.ap.read(id: string): Promise<object>`
   - **必要権限**: `activitypub:read`
-- **delete**: `takos.activitypub.delete(id: string): Promise<void>`
+- **delete**: `takos.ap.delete(id: string): Promise<void>`
   - **必要権限**: `activitypub:send`
-- **list**: `takos.activitypub.list(userId?: string): Promise<string[]>`
+- **list**: `takos.ap.list(userId?: string): Promise<string[]>`
   - **必要権限**: `activitypub:read`
 
 #### フック処理
@@ -168,21 +168,21 @@ awesome-pack.takopack
   - **必要権限**: `activitypub:receive:hook`
 
 #### アクター操作
-- **read**: `takos.activitypub.actor.read(userId: string): Promise<object>`
-- **update**: `takos.activitypub.actor.update(userId: string, key: string, value: string): Promise<void>`
-- **delete**: `takos.activitypub.actor.delete(userId: string, key: string): Promise<void>`
-- **follow**: `takos.activitypub.follow(followerId: string, followeeId: string): Promise<void>`
-- **unfollow**: `takos.activitypub.unfollow(followerId: string, followeeId: string): Promise<void>`
-- **listFollowers**: `takos.activitypub.listFollowers(actorId: string): Promise<string[]>`
-- **listFollowing**: `takos.activitypub.listFollowing(actorId: string): Promise<string[]>`
+- **read**: `takos.ap.actor.read(userId: string): Promise<object>`
+- **update**: `takos.ap.actor.update(userId: string, key: string, value: string): Promise<void>`
+- **delete**: `takos.ap.actor.delete(userId: string, key: string): Promise<void>`
+- **follow**: `takos.ap.follow(followerId: string, followeeId: string): Promise<void>`
+- **unfollow**: `takos.ap.unfollow(followerId: string, followeeId: string): Promise<void>`
+- **listFollowers**: `takos.ap.listFollowers(actorId: string): Promise<string[]>`
+- **listFollowing**: `takos.ap.listFollowing(actorId: string): Promise<string[]>`
   - **必要権限**: `activitypub:actor:read` / `activitypub:actor:write`
 
 ### プラグインアクター操作
-- **create**: `takos.activitypub.pluginActor.create(localName: string, profile: object): Promise<string>`
-- **read**: `takos.activitypub.pluginActor.read(iri: string): Promise<object>`
-- **update**: `takos.activitypub.pluginActor.update(iri: string, partial: object): Promise<void>`
-- **delete**: `takos.activitypub.pluginActor.delete(iri: string): Promise<void>`
-- **list**: `takos.activitypub.pluginActor.list(): Promise<string[]>`
+- **create**: `takos.ap.pluginActor.create(localName: string, profile: object): Promise<string>`
+- **read**: `takos.ap.pluginActor.read(iri: string): Promise<object>`
+- **update**: `takos.ap.pluginActor.update(iri: string, partial: object): Promise<void>`
+- **delete**: `takos.ap.pluginActor.delete(iri: string): Promise<void>`
+- **list**: `takos.ap.pluginActor.list(): Promise<string[]>`
   - **必要権限**: `plugin-actor:create` / `plugin-actor:read` / `plugin-actor:write` / `plugin-actor:delete`
 
 ### kv
@@ -253,6 +253,7 @@ if (ext) {
 ```
 
 その他の API も `takos.*` 名前空間に集約されています。
+ActivityPub API は `takos.activitypub` のほか、短縮形の `takos.ap` からも利用できます。
 
 ---
 

--- a/packages/builder/src/types.ts
+++ b/packages/builder/src/types.ts
@@ -376,6 +376,7 @@ export interface TakosEventsAPI {
 export interface TakosAPI {
   kv: TakosKVAPI;
   activitypub: TakosActivityPubAPI;
+  ap: TakosActivityPubAPI;
   cdn: TakosCdnAPI;
   fetch(url: string, options?: RequestInit): Promise<Response>;
 }

--- a/packages/runtime/mod.ts
+++ b/packages/runtime/mod.ts
@@ -136,6 +136,7 @@ export interface TakosOptions {
   events?: Partial<TakosEvents>;
   cdn?: Partial<TakosCdn>;
   activitypub?: Partial<TakosActivityPub>;
+  ap?: Partial<TakosActivityPub>;
 }
 
 export class Takos {
@@ -146,6 +147,7 @@ export class Takos {
     if (opts.events) Object.assign(this.events, opts.events);
     if (opts.cdn) Object.assign(this.cdn, opts.cdn);
     if (opts.activitypub) Object.assign(this.activitypub, opts.activitypub);
+    if (opts.ap) Object.assign(this.activitypub, opts.ap);
   }
   fetch(url: string, options?: RequestInit): Promise<Response> {
     const fn = this.opts.fetch ?? fetch;
@@ -199,6 +201,9 @@ export class Takos {
       list: async () => [] as string[],
     },
   };
+  get ap() {
+    return this.activitypub;
+  }
 }
 
 const TAKOS_PATHS: string[][] = [
@@ -229,6 +234,22 @@ const TAKOS_PATHS: string[][] = [
   ["activitypub", "pluginActor", "update"],
   ["activitypub", "pluginActor", "delete"],
   ["activitypub", "pluginActor", "list"],
+  ["ap", "send"],
+  ["ap", "read"],
+  ["ap", "delete"],
+  ["ap", "list"],
+  ["ap", "actor", "read"],
+  ["ap", "actor", "update"],
+  ["ap", "actor", "delete"],
+  ["ap", "follow"],
+  ["ap", "unfollow"],
+  ["ap", "listFollowers"],
+  ["ap", "listFollowing"],
+  ["ap", "pluginActor", "create"],
+  ["ap", "pluginActor", "read"],
+  ["ap", "pluginActor", "update"],
+  ["ap", "pluginActor", "delete"],
+  ["ap", "pluginActor", "list"],
 ];
 
 class PackWorker {


### PR DESCRIPTION
## Summary
- document `takos.ap` alias and use it in API examples
- expose `ap` alias for ActivityPub API in runtime
- update Takos API type definitions with `ap`

## Testing
- `deno task test` *(fails: JSR package manifest for '@std/assert' failed to load)*

------
https://chatgpt.com/codex/tasks/task_e_6849cc1a24ec832895a5c52815b23038