### PR TITLE
Update unpack for Takopack v3

### DIFF
--- a/packages/unpack/README.md
+++ b/packages/unpack/README.md
@@ -7,5 +7,6 @@ import { unpackTakoPack } from "@takopack/unpack";
 const result = await unpackTakoPack("my-extension.takopack");
 ```
 
-`result` contains the `manifest.json`, `server.js`, `client.js` and `index.html`
-as strings. The manifest is validated to be a valid JSON file.
+`result` contains the parsed `manifest.json` object as well as the contents of
+the server script, background script and UI HTML if they exist.
+The manifest is validated to be valid JSON.

--- a/packages/unpack/mod.test.ts
+++ b/packages/unpack/mod.test.ts
@@ -13,7 +13,7 @@ Deno.test("unpack takopack archive", async () => {
   await zip.add(
     "takos/manifest.json",
     new TextReader(
-      '{"name":"test","identifier":"id","version":"0.1.0","icon":"./icon.png"}',
+      '{"name":"test","identifier":"id","version":"0.1.0","icon":"./icon.png","server":{"entry":"./server.js"},"client":{"entryBackground":"./client.js","entryUI":"./index.html"}}',
     ),
   );
   await zip.add("takos/server.js", new TextReader("console.log('server');"));
@@ -26,9 +26,9 @@ Deno.test("unpack takopack archive", async () => {
 
   const result = await unpackTakoPack(buffer);
 
-  assertEquals(typeof result.manifest, "string");
+  assertEquals(result.manifest.name, "test");
   assertEquals(result.server, "console.log('server');");
   assertEquals(result.client, "console.log('client');");
-  assertEquals(result.index, "<html></html>");
+  assertEquals(result.ui, "<html></html>");
   assertEquals(result.icon, "data:image/png;base64,aWNvbg==");
 });


### PR DESCRIPTION
## Summary
- adjust unpack API for Takopack v3 spec
- update readme and tests accordingly

## Testing
- `deno task test` *(fails: invalid peer certificate)*

------
https://chatgpt.com/codex/tasks/task_e_6849decb8a48832890aafeb07274f7e6