### PR TITLE
Implement extension runtime per v3 spec

### DIFF
--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -24,7 +24,7 @@ const result = await runtime.callServer(manifest.identifier, "hello", [
 ```
 
 The `cdn.write` API accepts an optional `{ cacheTTL }` option following the
-specification in `docs/takopack/main.md`.
+specification in `docs/takopack/v3.md`.
 
 
 Server code runs inside a sandboxed Deno `Worker`. The runtime derives
@@ -36,4 +36,6 @@ any Deno namespace, while UI code is intended to be embedded in a sandboxed
 
 The implementation is intentionally minimal and focuses on server-side
 execution. The `takos` object exposes stub implementations of the APIs described
-in `docs/takopack/main.md`.
+in `docs/takopack/v3.md`, including the `extensions` API for cross-pack
+communication. The namespace offers `get()` for fetching a single extension and
+an `all` array listing loaded extensions.

--- a/packages/runtime/mod.test.ts
+++ b/packages/runtime/mod.test.ts
@@ -76,3 +76,27 @@ Deno.test("override new event APIs", async () => {
   assert(called);
   delete (globalThis as Record<string, unknown>).takos;
 });
+
+Deno.test("extensions API activation", async () => {
+  const pack = {
+    manifest: JSON.stringify({
+      name: "lib", 
+      identifier: "com.example.lib",
+      version: "0.1.0",
+      icon: "./icon.png",
+      exports: { server: ["add"] },
+    }),
+    server: `export function add(a,b){return a+b;}`,
+  };
+  const takopack = new TakoPack([pack]);
+  await takopack.init();
+  const ext = (globalThis as any).takos.extensions.get("com.example.lib");
+  assert(ext);
+  const api = await ext.activate();
+  const res = await (api as any).add(1,2);
+  assertEquals(res, 3);
+  const all = (globalThis as any).takos.extensions.all;
+  assert(Array.isArray(all));
+  assertEquals(all.length, 1);
+  delete (globalThis as Record<string, unknown>).takos;
+});


### PR DESCRIPTION
## Summary
- support `takos.extensions` API in runtime
- mention spec v3 in runtime docs
- add test for extensions activation
- change `extensions.all` to property
- implement extensions activation bridge in worker

## Testing
- `deno test -A packages/runtime/mod.test.ts` *(fails: JSR package manifest for '@std/assert' failed to load)*

------
https://chatgpt.com/codex/tasks/task_e_6849dedfe5b0832888bc53bf624ef4ed