### PR TITLE
Fix event handler names in builder

### DIFF
--- a/packages/builder/src/builder.ts
+++ b/packages/builder/src/builder.ts
@@ -344,9 +344,7 @@ export class TakopackBuilder {
     [...analyses.server, ...analyses.client].forEach((analysis) => {
       // JSDocタグから抽出
       analysis.jsDocTags.forEach((tag) => {
-        const handlerName = tag.targetClass && exportedClassSet.has(tag.targetClass)
-          ? `${tag.targetClass}_${tag.targetFunction}`
-          : tag.targetFunction;
+        const handlerName = tag.targetFunction;
         if (tag.tag === "event") {
           const eventName = this.extractEventNameFromTag(tag.value);
           const eventConfig = this.parseEventConfig(
@@ -369,9 +367,7 @@ export class TakopackBuilder {
 
       // デコレータから抽出
       analysis.decorators.forEach((decorator) => {
-        const handlerName = decorator.targetClass && exportedClassSet.has(decorator.targetClass)
-          ? `${decorator.targetClass}_${decorator.targetFunction}`
-          : decorator.targetFunction;
+        const handlerName = decorator.targetFunction;
         if (decorator.name === "event" && decorator.args.length > 0) {
           const eventName = typeof decorator.args[0] === "string" ? decorator.args[0] : "";
           const options = (typeof decorator.args[1] === "object" &&

--- a/packages/builder/src/generator.test.ts
+++ b/packages/builder/src/generator.test.ts
@@ -1,0 +1,35 @@
+import { VirtualEntryGenerator } from "./generator.ts";
+import type { ModuleAnalysis } from "./types.ts";
+
+Deno.test("export wrappers use method name", () => {
+  const analysis: ModuleAnalysis = {
+    filePath: "mod.ts",
+    exports: [
+      {
+        name: "ApiServer",
+        type: "const",
+        isDefault: false,
+        line: 1,
+        column: 0,
+        instanceOf: "ServerExtension",
+      },
+    ],
+    imports: [],
+    decorators: [],
+    jsDocTags: [
+      {
+        tag: "event",
+        value: '"runServerTests", {"source": "ui"}',
+        targetFunction: "onRunServerTests",
+        targetClass: "ApiServer",
+        line: 2,
+      },
+    ],
+  };
+
+  const gen = new VirtualEntryGenerator();
+  const entry = gen.generateServerEntry([analysis]);
+  if (!entry.content.includes("export const onRunServerTests")) {
+    throw new Error("wrapper name mismatch");
+  }
+});

--- a/packages/builder/src/generator.ts
+++ b/packages/builder/src/generator.ts
@@ -88,7 +88,7 @@ export class VirtualEntryGenerator {
       const info = exportInfoMap.get(className);
       if (info && info.type === "const" && info.instanceOf) {
         methods.forEach((m) => {
-          const wrapperName = `${className}_${m}`;
+          const wrapperName = `${m}`;
           wrappers.push(
             `export const ${wrapperName} = (...args: any[]) => ${className}.${m}(...args);`,
           );
@@ -98,7 +98,7 @@ export class VirtualEntryGenerator {
         const instance = `__${className}`;
         wrappers.push(`const ${instance} = new ${className}();`);
         methods.forEach((m) => {
-          const wrapperName = `${className}_${m}`;
+          const wrapperName = `${m}`;
           wrappers.push(
             `export const ${wrapperName} = (...args: any[]) => ${instance}.${m}(...args);`,
           );
@@ -186,7 +186,7 @@ export class VirtualEntryGenerator {
       const info = exportInfoMap.get(className);
       if (info && info.type === "const" && info.instanceOf) {
         methods.forEach((m) => {
-          const wrapperName = `${className}_${m}`;
+          const wrapperName = `${m}`;
           wrappers.push(
             `export const ${wrapperName} = (...args: any[]) => ${className}.${m}(...args);`,
           );
@@ -196,7 +196,7 @@ export class VirtualEntryGenerator {
         const instance = `__${className}`;
         wrappers.push(`const ${instance} = new ${className}();`);
         methods.forEach((m) => {
-          const wrapperName = `${className}_${m}`;
+          const wrapperName = `${m}`;
           wrappers.push(
             `export const ${wrapperName} = (...args: any[]) => ${instance}.${m}(...args);`,
           );
@@ -227,9 +227,7 @@ export class VirtualEntryGenerator {
     analysis.jsDocTags.forEach((tag) => {
       if (tag.tag === "activity") {
         // @activity("Note", { priority: 100, serial: true })
-        const handlerName = tag.targetClass
-          ? `${tag.targetClass}_${tag.targetFunction}`
-          : tag.targetFunction;
+        const handlerName = tag.targetFunction;
         const activityConfig = this.parseActivityTag(
           tag.value,
           handlerName,
@@ -239,9 +237,7 @@ export class VirtualEntryGenerator {
         }
       } else if (tag.tag === "event") {
         // @event("myEvent", { source: "client" })
-        const handlerName = tag.targetClass
-          ? `${tag.targetClass}_${tag.targetFunction}`
-          : tag.targetFunction;
+        const handlerName = tag.targetFunction;
         const eventConfig = this.parseEventTag(tag.value, handlerName);
         if (eventConfig) {
           const eventName = this.extractEventName(tag.value);
@@ -269,9 +265,7 @@ export class VirtualEntryGenerator {
     analysis.decorators.forEach((decorator) => {
       if (decorator.name === "activity") {
         // @activity("Note", { priority: 100 })
-        const handlerName = decorator.targetClass
-          ? `${decorator.targetClass}_${decorator.targetFunction}`
-          : decorator.targetFunction;
+        const handlerName = decorator.targetFunction;
         const activityConfig = this.parseActivityDecorator(
           decorator.args,
           handlerName,
@@ -281,9 +275,7 @@ export class VirtualEntryGenerator {
         }
       } else if (decorator.name === "event") {
         // @event("myEvent", { source: "client" })
-        const handlerName = decorator.targetClass
-          ? `${decorator.targetClass}_${decorator.targetFunction}`
-          : decorator.targetFunction;
+        const handlerName = decorator.targetFunction;
         const eventConfig = this.parseEventDecorator(
           decorator.args,
           handlerName,

--- a/packages/runtime/mod.ts
+++ b/packages/runtime/mod.ts
@@ -86,13 +86,16 @@ globalThis.global = globalThis;
 globalThis.process = process;
 globalThis.Buffer = Buffer;
 globalThis.setImmediate = setImmediate;
+
 let allowedPerms = {};
 const permState = (name) => allowedPerms[name] ? "granted" : "denied";
 Deno.permissions.query = async (desc) => ({ state: permState(desc.name) });
 Deno.permissions.request = async (desc) => ({ state: permState(desc.name) });
 Deno.permissions.revoke = async (desc) => ({ state: permState(desc.name) });
+
 let takosCallId = 0;
 const takosCallbacks = new Map();
+
 function createExtension(desc) {
   return {
     identifier: desc.identifier,
@@ -114,6 +117,7 @@ function createExtension(desc) {
     },
   };
 }
+
 function setPath(root, path, fn, transform) {
   let obj = root;
   for (let i = 0; i < path.length - 1; i++) {
@@ -124,6 +128,7 @@ function setPath(root, path, fn, transform) {
     return fn(transform, args);
   };
 }
+
 function createTakos(paths, exts = []) {
   const t = {};
   for (const p of paths) {
@@ -148,6 +153,7 @@ function createTakos(paths, exts = []) {
   t.extensions.all = exts.map(createExtension);
   return t;
 }
+
 let mod = null;
 self.onmessage = async (e) => {
   const d = e.data;
@@ -162,7 +168,7 @@ self.onmessage = async (e) => {
       const fn = mod[d.fnName];
       if (typeof fn !== 'function') {
         const keys = Object.keys(mod).join(', ');
-        throw new Error(\`function not found: ${d.fnName} (available: ${keys})\`);
+        throw new Error(\`function not found: \${d.fnName} (available: \${keys})\`);
       }
       const result = await fn(...d.args);
       self.postMessage({ type: 'result', id: d.id, result });

--- a/packages/runtime/mod.ts
+++ b/packages/runtime/mod.ts
@@ -160,7 +160,10 @@ self.onmessage = async (e) => {
   } else if (d.type === 'call') {
     try {
       const fn = mod[d.fnName];
-      if (typeof fn !== 'function') throw new Error('function not found');
+      if (typeof fn !== 'function') {
+        const keys = Object.keys(mod).join(', ');
+        throw new Error(\`function not found: ${d.fnName} (available: ${keys})\`);
+      }
       const result = await fn(...d.args);
       self.postMessage({ type: 'result', id: d.id, result });
     } catch (err) {
@@ -478,9 +481,10 @@ class RuntimeExtension implements Extension {
   }
   async activate(): Promise<unknown> {
     if (this.#pack.activated) return this.#pack.activated;
-    const exportsList = Array.isArray((this.#pack.manifest as any)?.exports?.server)
-      ? (this.#pack.manifest as any).exports.server as string[]
-      : [];
+    const exportsList =
+      Array.isArray((this.#pack.manifest as any)?.exports?.server)
+        ? (this.#pack.manifest as any).exports.server as string[]
+        : [];
     if (!this.#pack.serverWorker) {
       this.#pack.activated = {};
       return this.#pack.activated;


### PR DESCRIPTION
## Summary
- correct handler name detection when generating manifests
- export wrapper functions using original method names

## Testing
- `deno fmt packages/builder/src/builder.ts packages/builder/src/generator.ts`
- `deno test -A` *(fails: JSR package manifest for '@std/assert' failed to load)*

------
https://chatgpt.com/codex/tasks/task_e_6849f67a21bc8328bd8e5158767b3251