### PR TITLE
Fix event wrapper name generation

### DIFF
--- a/packages/builder/src/generator.test.ts
+++ b/packages/builder/src/generator.test.ts
@@ -29,7 +29,7 @@ Deno.test("export wrappers use method name", () => {
 
   const gen = new VirtualEntryGenerator();
   const entry = gen.generateServerEntry([analysis]);
-  if (!entry.content.includes("export const onRunServerTests")) {
+  if (!entry.content.includes("export const runServerTests")) {
     throw new Error("wrapper name mismatch");
   }
 });


### PR DESCRIPTION
## Summary
- map event names to handler methods when generating virtual server entries
- export wrapper functions using event names
- update tests for new behavior

## Testing
- `deno test packages/builder/src/generator.test.ts`
- `deno test packages/runtime/mod.test.ts` *(fails: JSR package manifest for '@std/assert' failed to load)*
- `deno test packages/unpack/mod.test.ts` *(fails: JSR package manifest for '@std/assert' failed to load)*

------
https://chatgpt.com/codex/tasks/task_e_684ae5a9e0888328bea3ae41b271152a