### PR TITLE
Fix event name calls in runtime

### DIFF
--- a/docs/builder/README.md
+++ b/docs/builder/README.md
@@ -410,8 +410,8 @@ MyServer.onUserLogin = (data: { username: string }) => {
 export { MyServer };
 ```
 
-インスタンス名とメソッド名の組み合わせから `MyServer_onUserLogin`
-のようなラッパー関数が自動生成され、manifest の `handler` として利用されます。
+イベント名に対応した `userLogin` のラッパー関数が自動生成され、
+manifest の `handler` として利用されます。
 
 ### アプリコンテナ API
 

--- a/packages/builder/src/generator.test.ts
+++ b/packages/builder/src/generator.test.ts
@@ -29,7 +29,7 @@ Deno.test("export wrappers use method name", () => {
 
   const gen = new VirtualEntryGenerator();
   const entry = gen.generateServerEntry([analysis]);
-  if (!entry.content.includes("export const onRunServerTests")) {
+  if (!entry.content.includes("export const runServerTests")) {
     throw new Error("wrapper name mismatch");
   }
 });

--- a/packages/runtime/mod.ts
+++ b/packages/runtime/mod.ts
@@ -599,7 +599,12 @@ export class TakoPack {
     if (!pack.serverWorker) {
       throw new Error(`server not loaded for ${identifier}`);
     }
-    return await pack.serverWorker.call(fnName, args);
+    let actualName = fnName;
+    const defs = (pack.manifest as any).eventDefinitions;
+    if (defs && defs[fnName] && typeof defs[fnName].handler === "string") {
+      actualName = defs[fnName].handler;
+    }
+    return await pack.serverWorker.call(actualName, args);
   }
 
   #extractPermissions(


### PR DESCRIPTION
## Summary
- map event names to actual handler functions in `TakoPack.callServer`

## Testing
- `deno test packages/builder/src/generator.test.ts`
- `deno test -A packages/runtime/mod.test.ts` *(fails: JSR package manifest for '@std/assert' failed to load)*
- `deno test packages/unpack/mod.test.ts` *(fails: JSR package manifest for '@std/assert' failed to load)*

------
https://chatgpt.com/codex/tasks/task_e_684ae5a9e0888328bea3ae41b271152a