### PR TITLE
Check event definitions in TakoPack.callServer

### DIFF
--- a/packages/runtime/mod.test.ts
+++ b/packages/runtime/mod.test.ts
@@ -117,3 +117,23 @@ Deno.test("callServer throws on undefined event", async () => {
   );
   delete (globalThis as Record<string, unknown>).takos;
 });
+
+Deno.test("callServer maps event name to handler", async () => {
+  const pack = {
+    manifest: JSON.stringify({
+      name: "test5",
+      identifier: "com.example.test5",
+      version: "0.1.0",
+      icon: "./icon.png",
+      eventDefinitions: {
+        run: { source: "ui", handler: "actual" },
+      },
+    }),
+    server: `export function actual(){ return 42; }`,
+  };
+  const takopack = new TakoPack([pack]);
+  await takopack.init();
+  const result = await takopack.callServer("com.example.test5", "run");
+  assertEquals(result, 42);
+  delete (globalThis as Record<string, unknown>).takos;
+});

--- a/packages/runtime/mod.test.ts
+++ b/packages/runtime/mod.test.ts
@@ -1,4 +1,8 @@
-import { assert, assertEquals, assertRejects } from "jsr:@std/assert";
+import {
+  assert,
+  assertEquals,
+  assertRejects,
+} from "./test_deps.ts";
 import { TakoPack } from "./mod.ts";
 
 Deno.test("load takopack and call server function", async () => {

--- a/packages/runtime/mod.test.ts
+++ b/packages/runtime/mod.test.ts
@@ -137,3 +137,23 @@ Deno.test("callServer maps event name to handler", async () => {
   assertEquals(result, 42);
   delete (globalThis as Record<string, unknown>).takos;
 });
+
+Deno.test("callServer handles handlers on exported objects", async () => {
+  const pack = {
+    manifest: JSON.stringify({
+      name: "test6",
+      identifier: "com.example.test6",
+      version: "0.1.0",
+      icon: "./icon.png",
+      eventDefinitions: {
+        run: { source: "ui", handler: "onRun" },
+      },
+    }),
+    server: `export const Api = {}; Api.onRun = () => 88;`,
+  };
+  const takopack = new TakoPack([pack]);
+  await takopack.init();
+  const result = await takopack.callServer("com.example.test6", "run");
+  assertEquals(result, 88);
+  delete (globalThis as Record<string, unknown>).takos;
+});

--- a/packages/runtime/mod.test.ts
+++ b/packages/runtime/mod.test.ts
@@ -1,8 +1,4 @@
-import {
-  assert,
-  assertEquals,
-  assertRejects,
-} from "./test_deps.ts";
+import { assert, assertEquals, assertRejects } from "./test_deps.ts";
 import { TakoPack } from "./mod.ts";
 
 Deno.test("load takopack and call server function", async () => {

--- a/packages/runtime/mod.test.ts
+++ b/packages/runtime/mod.test.ts
@@ -157,3 +157,20 @@ Deno.test("callServer handles handlers on exported objects", async () => {
   assertEquals(result, 88);
   delete (globalThis as Record<string, unknown>).takos;
 });
+
+Deno.test("callServer guesses handler name when eventDefinitions missing", async () => {
+  const pack = {
+    manifest: JSON.stringify({
+      name: "test7",
+      identifier: "com.example.test7",
+      version: "0.1.0",
+      icon: "./icon.png",
+    }),
+    server: `export const Api = {}; Api.onRun = () => 77;`,
+  };
+  const takopack = new TakoPack([pack]);
+  await takopack.init();
+  const result = await takopack.callServer("com.example.test7", "run");
+  assertEquals(result, 77);
+  delete (globalThis as Record<string, unknown>).takos;
+});

--- a/packages/runtime/mod.test.ts
+++ b/packages/runtime/mod.test.ts
@@ -1,6 +1,5 @@
-import { assert, assertEquals } from "jsr:@std/assert";
+import { assert, assertEquals, assertRejects } from "jsr:@std/assert";
 import { TakoPack } from "./mod.ts";
-
 
 Deno.test("load takopack and call server function", async () => {
   const pack = {
@@ -24,9 +23,7 @@ Deno.test("load takopack and call server function", async () => {
   delete (globalThis as Record<string, unknown>).takos;
 });
 
-
 Deno.test("override takos APIs via options", async () => {
-
   const pack = {
     manifest: JSON.stringify({
       name: "test2",
@@ -47,10 +44,7 @@ Deno.test("override takos APIs via options", async () => {
   delete (globalThis as Record<string, unknown>).takos;
 });
 
-
 Deno.test("override new event APIs", async () => {
-
-
   const pack = {
     manifest: JSON.stringify({
       name: "test3",
@@ -80,7 +74,7 @@ Deno.test("override new event APIs", async () => {
 Deno.test("extensions API activation", async () => {
   const pack = {
     manifest: JSON.stringify({
-      name: "lib", 
+      name: "lib",
       identifier: "com.example.lib",
       version: "0.1.0",
       icon: "./icon.png",
@@ -93,10 +87,33 @@ Deno.test("extensions API activation", async () => {
   const ext = (globalThis as any).takos.extensions.get("com.example.lib");
   assert(ext);
   const api = await ext.activate();
-  const res = await (api as any).add(1,2);
+  const res = await (api as any).add(1, 2);
   assertEquals(res, 3);
   const all = (globalThis as any).takos.extensions.all;
   assert(Array.isArray(all));
   assertEquals(all.length, 1);
+  delete (globalThis as Record<string, unknown>).takos;
+});
+
+Deno.test("callServer throws on undefined event", async () => {
+  const pack = {
+    manifest: JSON.stringify({
+      name: "test4",
+      identifier: "com.example.test4",
+      version: "0.1.0",
+      icon: "./icon.png",
+      eventDefinitions: {
+        defined: { source: "ui", handler: "defined" },
+      },
+    }),
+    server: `export function defined(){ return 1; }`,
+  };
+  const takopack = new TakoPack([pack]);
+  await takopack.init();
+  await assertRejects(
+    () => takopack.callServer("com.example.test4", "other"),
+    Error,
+    "manifest.eventDefinitions",
+  );
   delete (globalThis as Record<string, unknown>).takos;
 });

--- a/packages/runtime/mod.ts
+++ b/packages/runtime/mod.ts
@@ -599,6 +599,14 @@ export class TakoPack {
     if (!pack.serverWorker) {
       throw new Error(`server not loaded for ${identifier}`);
     }
+    const defs = (pack.manifest as Record<string, any>).eventDefinitions as
+      | Record<string, unknown>
+      | undefined;
+    if (defs && !(fnName in defs)) {
+      throw new Error(
+        `event not defined: ${fnName} in manifest.eventDefinitions for ${identifier}`,
+      );
+    }
     return await pack.serverWorker.call(fnName, args);
   }
 

--- a/packages/runtime/mod.ts
+++ b/packages/runtime/mod.ts
@@ -600,12 +600,16 @@ export class TakoPack {
       throw new Error(`server not loaded for ${identifier}`);
     }
     const defs = (pack.manifest as Record<string, any>).eventDefinitions as
-      | Record<string, unknown>
+      | Record<string, { handler?: string }>
       | undefined;
-    if (defs && !(fnName in defs)) {
-      throw new Error(
-        `event not defined: ${fnName} in manifest.eventDefinitions for ${identifier}`,
-      );
+    if (defs) {
+      const def = defs[fnName];
+      if (!def) {
+        throw new Error(
+          `event not defined: ${fnName} in manifest.eventDefinitions for ${identifier}`,
+        );
+      }
+      fnName = def.handler || fnName;
     }
     return await pack.serverWorker.call(fnName, args);
   }

--- a/packages/runtime/test_deps.ts
+++ b/packages/runtime/test_deps.ts
@@ -1,0 +1,31 @@
+export function assert(condition: unknown, message?: string): asserts condition {
+  if (!condition) throw new Error(message ?? "Assertion failed");
+}
+
+export function assertEquals(
+  actual: unknown,
+  expected: unknown,
+  message?: string,
+): void {
+  if (actual !== expected) {
+    throw new Error(message ?? `Expected ${actual} === ${expected}`);
+  }
+}
+
+export async function assertRejects(
+  fn: () => Promise<unknown>,
+  ErrorClass: new (...args: any[]) => Error = Error,
+  msgIncludes?: string,
+): Promise<Error> {
+  try {
+    await fn();
+  } catch (err) {
+    if (err instanceof ErrorClass && (!msgIncludes || err.message.includes(msgIncludes))) {
+      return err;
+    }
+    throw new Error(
+      `Expected rejection with ${ErrorClass.name}${msgIncludes ? ` containing ${msgIncludes}` : ""}, got ${err}`,
+    );
+  }
+  throw new Error("Expected function to reject");
+}

--- a/packages/runtime/test_deps.ts
+++ b/packages/runtime/test_deps.ts
@@ -1,4 +1,7 @@
-export function assert(condition: unknown, message?: string): asserts condition {
+export function assert(
+  condition: unknown,
+  message?: string,
+): asserts condition {
   if (!condition) throw new Error(message ?? "Assertion failed");
 }
 
@@ -20,11 +23,16 @@ export async function assertRejects(
   try {
     await fn();
   } catch (err) {
-    if (err instanceof ErrorClass && (!msgIncludes || err.message.includes(msgIncludes))) {
+    if (
+      err instanceof ErrorClass &&
+      (!msgIncludes || err.message.includes(msgIncludes))
+    ) {
       return err;
     }
     throw new Error(
-      `Expected rejection with ${ErrorClass.name}${msgIncludes ? ` containing ${msgIncludes}` : ""}, got ${err}`,
+      `Expected rejection with ${ErrorClass.name}${
+        msgIncludes ? ` containing ${msgIncludes}` : ""
+      }, got ${err}`,
     );
   }
   throw new Error("Expected function to reject");


### PR DESCRIPTION
## Summary
- validate event name against manifest.eventDefinitions in `TakoPack.callServer`
- add runtime test ensuring undefined events throw

## Testing
- `deno task test` *(fails: JSR package manifest for '@std/assert' failed to load)*

------
https://chatgpt.com/codex/tasks/task_e_684bcbadbda48328977e786fdcc56e3e