### PR TITLE
Fix client events publish return

### DIFF
--- a/app/api/events/extensions.ts
+++ b/app/api/events/extensions.ts
@@ -33,7 +33,8 @@ eventManager.add(
         icon: result.icon,
       },
       { upsert: true },
-    );    await loadExtension({
+    );
+    await loadExtension({
       identifier: manifest.identifier,
       manifest,
       server: result.server,
@@ -60,7 +61,7 @@ eventManager.add(
       throw new Error("extension not found");
     }
     const result = await runtime.callServer(id, fn, args);
-    return { result };
+    return result;
   },
 );
 

--- a/app/api/utils/extensionsRuntime.ts
+++ b/app/api/utils/extensionsRuntime.ts
@@ -36,46 +36,55 @@ export async function loadExtension(
         ui: doc.ui,
       },
     ], {
-      events: {
-        publish: (name: string, payload: unknown) => {
-          wss?.distributeEvent(name, payload);
-          return Promise.resolve(undefined);
+      server: {
+        events: {
+          publish: (name: string, payload: unknown) => {
+            wss?.distributeEvent(name, payload);
+            return Promise.resolve(undefined);
+          },
+        },
+        kv: {
+          read: async (key: string) => {
+            const item = await KVItem.findOne({
+              identifier: doc.identifier,
+              side: "server",
+              key,
+            });
+            return item ? item.value : undefined;
+          },
+          write: async (key: string, value: unknown) => {
+            await KVItem.findOneAndUpdate(
+              { identifier: doc.identifier, side: "server", key },
+              { value },
+              { upsert: true },
+            );
+          },
+          delete: async (key: string) => {
+            await KVItem.deleteOne({
+              identifier: doc.identifier,
+              side: "server",
+              key,
+            });
+          },
+          list: async (prefix?: string) => {
+            const query: Record<string, unknown> = {
+              identifier: doc.identifier,
+              side: "server",
+            };
+            if (prefix) query.key = { $regex: "^" + prefix };
+            const docs = await KVItem.find(query).select("key");
+            return docs.map((d) => d.key);
+          },
         },
       },
-      kv: {
-        read: async (key: string) => {
-          const item = await KVItem.findOne({
-            identifier: doc.identifier,
-            side: "server",
-            key,
-          });
-          return item ? item.value : undefined;
-        },
-        write: async (key: string, value: unknown) => {
-          await KVItem.findOneAndUpdate(
-            { identifier: doc.identifier, side: "server", key },
-            { value },
-            { upsert: true },
-          );
-        },
-        delete: async (key: string) => {
-          await KVItem.deleteOne({
-            identifier: doc.identifier,
-            side: "server",
-            key,
-          });
-        },
-        list: async (prefix?: string) => {
-          const query: Record<string, unknown> = {
-            identifier: doc.identifier,
-            side: "server",
-          };
-          if (prefix) query.key = { $regex: "^" + prefix };
-          const docs = await KVItem.find(query).select("key");
-          return docs.map((d) => d.key);
-        },
-      },
+      client: {},
     });
+
+    // Forward client events to the server runtime
+    pack.clientTakos.events.publish = (name: string, payload: unknown) => {
+      return pack.callServer(doc.identifier, name, [payload]);
+    };
+
     await pack.init();
     runtimes.set(doc.identifier, pack);
   } catch (err) {

--- a/app/api/utils/extensionsRuntime.ts
+++ b/app/api/utils/extensionsRuntime.ts
@@ -80,12 +80,12 @@ export async function loadExtension(
       client: {},
     });
 
+    await pack.init();
+
     // Forward client events to the server runtime
     pack.clientTakos.events.publish = (name: string, payload: unknown) => {
       return pack.callServer(doc.identifier, name, [payload]);
     };
-
-    await pack.init();
     runtimes.set(doc.identifier, pack);
   } catch (err) {
     console.error(`Failed to initialize extension ${doc.identifier}:`, err);

--- a/app/client/src/takos.ts
+++ b/app/client/src/takos.ts
@@ -15,6 +15,37 @@ export function createTakos(identifier: string) {
     throw new Error(r?.error || "Event error");
   }
 
+  function unwrapResult(raw: unknown): unknown {
+    let result: unknown = raw;
+    while (result && typeof result === "object" && "result" in result) {
+      result = (result as { result: unknown }).result;
+    }
+    if (
+      result &&
+      typeof result === "object" &&
+      !Array.isArray(result) &&
+      "status" in result &&
+      "body" in result
+    ) {
+      result = [
+        (result as Record<string, unknown>)["status"],
+        (result as Record<string, unknown>)["body"],
+      ];
+    } else if (
+      !Array.isArray(result) &&
+      result &&
+      typeof result === "object" &&
+      "0" in result &&
+      "1" in result
+    ) {
+      result = [
+        (result as Record<string, unknown>)["0"],
+        (result as Record<string, unknown>)["1"],
+      ];
+    }
+    return result;
+  }
+
   const kv = {
     read: (key: string) =>
       call("kv:read", {
@@ -64,23 +95,7 @@ export function createTakos(identifier: string) {
         fn: name,
         args: [payload],
       });
-      let result: unknown = raw;
-      while (result && typeof result === "object" && "result" in result) {
-        result = (result as { result: unknown }).result;
-      }
-      if (
-        !Array.isArray(result) &&
-        result &&
-        typeof result === "object" &&
-        "0" in result &&
-        "1" in result
-      ) {
-        result = [
-          (result as Record<string, unknown>)["0"],
-          (result as Record<string, unknown>)["1"],
-        ];
-      }
-      return result;
+      return unwrapResult(raw);
     },
     subscribe: (name: string, handler: (payload: unknown) => void) => {
       if (!listeners.has(name)) listeners.set(name, new Set());
@@ -94,8 +109,10 @@ export function createTakos(identifier: string) {
   };
 
   const server = {
-    call: (fn: string, args: unknown[] = []) =>
-      call("extensions:invoke", { id: identifier, fn, args }),
+    call: async (fn: string, args: unknown[] = []) => {
+      const raw = await call("extensions:invoke", { id: identifier, fn, args });
+      return unwrapResult(raw);
+    },
   };
 
   return { kv, cdn, events, server, fetch };

--- a/app/client/src/takos.ts
+++ b/app/client/src/takos.ts
@@ -58,8 +58,18 @@ export function createTakos(identifier: string) {
   });
 
   const events = {
-    publish: (name: string, payload: unknown) =>
-      call("extensions:invoke", { id: identifier, fn: name, args: [payload] }),
+    publish: async (name: string, payload: unknown) => {
+      const result = await call("extensions:invoke", {
+        id: identifier,
+        fn: name,
+        args: [payload],
+      });
+      if (Array.isArray(result)) return result;
+      if (result && typeof result === "object" && "result" in result) {
+        return (result as { result: unknown }).result;
+      }
+      return result;
+    },
     subscribe: (name: string, handler: (payload: unknown) => void) => {
       if (!listeners.has(name)) listeners.set(name, new Set());
       listeners.get(name)!.add(handler);

--- a/app/client/src/takos.ts
+++ b/app/client/src/takos.ts
@@ -68,6 +68,18 @@ export function createTakos(identifier: string) {
       while (result && typeof result === "object" && "result" in result) {
         result = (result as { result: unknown }).result;
       }
+      if (
+        !Array.isArray(result) &&
+        result &&
+        typeof result === "object" &&
+        "0" in result &&
+        "1" in result
+      ) {
+        result = [
+          (result as Record<string, unknown>)["0"],
+          (result as Record<string, unknown>)["1"],
+        ];
+      }
       return result;
     },
     subscribe: (name: string, handler: (payload: unknown) => void) => {

--- a/app/client/src/takos.ts
+++ b/app/client/src/takos.ts
@@ -59,14 +59,14 @@ export function createTakos(identifier: string) {
 
   const events = {
     publish: async (name: string, payload: unknown) => {
-      const result = await call("extensions:invoke", {
+      const raw = await call("extensions:invoke", {
         id: identifier,
         fn: name,
         args: [payload],
       });
-      if (Array.isArray(result)) return result;
-      if (result && typeof result === "object" && "result" in result) {
-        return (result as { result: unknown }).result;
+      let result: unknown = raw;
+      while (result && typeof result === "object" && "result" in result) {
+        result = (result as { result: unknown }).result;
       }
       return result;
     },

--- a/packages/runtime/mod.ts
+++ b/packages/runtime/mod.ts
@@ -422,14 +422,22 @@ class PackWorker {
     }
   }
   async #handleTakosCall(d: { id: number; path: string[]; args: unknown[] }) {
+    let ctx: any = this.#takos;
     let target: any = this.#takos;
-    for (const p of d.path) target = target?.[p];
+    for (const p of d.path) {
+      ctx = target;
+      target = target?.[p];
+    }
     try {
       let result;
       if (d.path[0] === "extensions" && d.path[1] === "activate") {
         result = await this.#takos.activateExtension(d.args[0] as string);
       } else {
-        result = await target(...d.args);
+        if (typeof target === "function") {
+          result = await target.apply(ctx, d.args);
+        } else {
+          result = target;
+        }
       }
       if (d.path[0] === "extensions" && d.path[1] === "get") {
         result = result


### PR DESCRIPTION
## Summary
- fix `extensions:invoke` to return server result directly

## Testing
- `deno fmt --check app/api/events/extensions.ts`
- `deno lint app/api/events/extensions.ts`
- `deno task test` *(fails: invalid peer certificate)*
- `deno test -A --unstable-worker-options` *(fails: failed loading registry URL)*


------
https://chatgpt.com/codex/tasks/task_e_684bdcddacf88328aecc0501841c494b