### PR TITLE
Fix extension API method bindings

### DIFF
--- a/examples/api-test-extension/src/server/api.ts
+++ b/examples/api-test-extension/src/server/api.ts
@@ -82,9 +82,8 @@ ApiServer.onRunServerTests = async (): Promise<
 
   // Extensions API
   try {
-    const self = takos?.extensions.get("test.api");
-    if (self) {
-      const api = await self.activate();
+    const api = await takos?.activateExtension("test.api");
+    if (api) {
       // deno-lint-ignore no-explicit-any
       await (api as any).ping();
     }

--- a/packages/runtime/mod.ts
+++ b/packages/runtime/mod.ts
@@ -259,10 +259,10 @@ export class Takos {
   ) {
     this.extProvider = p;
   }
-  fetch(url: string, options?: RequestInit): Promise<Response> {
+  fetch = (url: string, options?: RequestInit): Promise<Response> => {
     const fn = this.opts.fetch ?? fetch;
     return fn(url, options);
-  }
+  };
   kv = {
     read: async (_key: string) => undefined as unknown,
     write: async (_key: string, _value: unknown) => {},
@@ -532,7 +532,7 @@ class RuntimeExtension implements Extension {
   get isActive() {
     return !!this.#pack.activated;
   }
-  async activate(): Promise<unknown> {
+  activate = async (): Promise<unknown> => {
     if (this.#pack.activated) return this.#pack.activated;
     const exportsList =
       Array.isArray((this.#pack.manifest as any)?.exports?.server)
@@ -548,7 +548,7 @@ class RuntimeExtension implements Extension {
     }
     this.#pack.activated = api;
     return api;
-  }
+  };
 }
 
 export interface TakoPackInitOptions {


### PR DESCRIPTION
## Summary
- fix Takos.fetch to keep correct `this`
- use arrow function for RuntimeExtension.activate

## Testing
- `deno task test` *(fails: Unstable API 'Worker.deno.permissions')*
- `deno task test` in packages/unpack *(fails to download npm packages: invalid peer certificate)*

------
https://chatgpt.com/codex/tasks/task_e_684c26b6741c83288f65059b43177385