### PR TITLE
Fix extension activation example

### DIFF
--- a/examples/api-test-extension/src/server/api.ts
+++ b/examples/api-test-extension/src/server/api.ts
@@ -82,9 +82,9 @@ ApiServer.onRunServerTests = async (): Promise<
 
   // Extensions API
   try {
-    const self = takos?.extensions.get("test.api");
-    if (self) {
-      const api = await self.activate();
+    const ext = takos?.extensions.get("test.api");
+    const api = ext ? await ext.activate() : undefined;
+    if (api) {
       // deno-lint-ignore no-explicit-any
       await (api as any).ping();
     }


### PR DESCRIPTION
## Summary
- update API test extension example to safely activate extension

## Testing
- `DENO_TLS_CA_STORE=system deno task build` in `examples/api-test-extension`
- `DENO_TLS_CA_STORE=system deno run -A --unstable-worker-options test_runtime.ts`

------
https://chatgpt.com/codex/tasks/task_e_684c39d901c483289aa5b04d653b0401