### PR TITLE
Fix fetch context in runtime

### DIFF
--- a/packages/runtime/mod.ts
+++ b/packages/runtime/mod.ts
@@ -259,10 +259,10 @@ export class Takos {
   ) {
     this.extProvider = p;
   }
-  fetch(url: string, options?: RequestInit): Promise<Response> {
+  fetch = (url: string, options?: RequestInit): Promise<Response> => {
     const fn = this.opts.fetch ?? fetch;
     return fn(url, options);
-  }
+  };
   kv = {
     read: async (_key: string) => undefined as unknown,
     write: async (_key: string, _value: unknown) => {},


### PR DESCRIPTION
## Summary
- bind the runtime `fetch` method as an arrow function
- rebuild `examples/api-test-extension`

## Testing
- `deno task build` in `examples/api-test-extension`
- `deno run -A --unstable-worker-options examples/api-test-extension/run.ts`
- `deno test -A --unstable-worker-options`

------
https://chatgpt.com/codex/tasks/task_e_684c39ea99ec83288a465fd757279ea0