### PR TITLE
Add activateExtension API support

### DIFF
--- a/docs/takopack/v3.md
+++ b/docs/takopack/v3.md
@@ -217,6 +217,7 @@ awesome-pack.takopack
 ### 拡張間 API
 - `takos.extensions.get(identifier: string): Extension | undefined`
 - `Extension.activate(): Promise<any>`
+- `takos.activateExtension(identifier: string): Promise<any>`
   - **必要権限**: `extensions:invoke` / `extensions:export`
 
 権限はすべて `manifest.permissions` に列挙し、必要最低限を宣言してください。
@@ -243,6 +244,7 @@ const { takos } = globalThis;
 | `cdn` | CDN へのファイル保存・取得 |
 | `events` | レイヤー間イベントの発行・購読 |
 | `extensions` | 他拡張の取得と `activate()` 実行 |
+| `activateExtension` | ID 指定で拡張の `activate()` を実行 |
 | `fetch` | 権限制御付きの `fetch` ラッパー |
 
 
@@ -257,15 +259,23 @@ interface Extension {
   isActive: boolean;
   activate(): Promise<any>;
 }
+function activateExtension(identifier: string): Promise<any>;
 ```
 
 利用例:
 
 ```javascript
+// 従来の取得方法
 const ext = takos.extensions.get("com.example.lib");
 if (ext) {
   const api = await ext.activate();
   const hash = await api.calculateHash("hello");
+}
+
+// 直接有効化する方法
+const api2 = await takos.activateExtension("com.example.lib");
+if (api2) {
+  const hash2 = await api2.calculateHash("world");
 }
 ```
 


### PR DESCRIPTION
## Summary
- expose `takos.activateExtension` in worker runtime
- support activation via `PackWorker`
- document new API
- test activation from worker

## Testing
- `deno test --unstable-worker-options packages/runtime/mod.test.ts` *(fails: Failed loading https://registry.npmjs.org/@types%2fnode)*

------
https://chatgpt.com/codex/tasks/task_e_684c39e7feac8328acdf3cba720bb63f