### PR TITLE
Fix extension fetch permissions

### DIFF
--- a/app/api/utils/extensionsRuntime.ts
+++ b/app/api/utils/extensionsRuntime.ts
@@ -37,6 +37,14 @@ export async function loadExtension(
       },
     ], {
       server: {
+        fetch: (url: string, options?: RequestInit) => {
+          if (!url.startsWith("http://") && !url.startsWith("https://")) {
+            return Promise.reject(
+              new Error("only http(s) protocol is allowed"),
+            );
+          }
+          return fetch(url, options);
+        },
         events: {
           publish: (name: string, payload: unknown) => {
             wss?.distributeEvent(name, payload);


### PR DESCRIPTION
## Summary
- pass a restricted fetch to extensions runtime so they can make HTTP requests without needing `deno:net`

## Testing
- `deno lint utils/extensionsRuntime.ts`
- `deno test -A --unstable-worker-options packages/runtime` *(fails: Failed loading https://registry.npmjs.org/@types%2fnode)*

------
https://chatgpt.com/codex/tasks/task_e_684c499b4d808328a42e33fa18b96588