### PR TITLE
docs: add API usage table

### DIFF
--- a/docs/takopack/v3.md
+++ b/docs/takopack/v3.md
@@ -282,11 +282,27 @@ if (api2) {
 その他の API も `takos.*` 名前空間に集約されています。
 ActivityPub API は `takos.activitypub` のほか、短縮形の `takos.ap` からも利用できます。
 
+### レイヤー別 API 利用可否
+
+以下の表は、主要 API を各レイヤーから利用できるかを示します。
+
+| API | server.js | client.js (background) | index.html (UI) |
+| --- | --- | --- | --- |
+| `fetch` | ✓ | ✓ | ✓ |
+| `kv` | ✓ | ✓ | ✓ |
+| `cdn` | ✓ | ✓ | ✓ |
+| `events` | ✓ | ✓ | ✓ |
+| `activitypub` | ✓ | ― | ― |
+| `extensions` / `activateExtension` | ✓ | ✓ | ✓ |
+| UI URL helpers (`getURL`, `pushURL`, `setURL`, `changeURL`) | ― | ― | ✓ |
+
+
 ---
 
 ## ActivityPub フック
 
 `activityPub.objects.accepts` に指定したオブジェクトを受信すると、各 Pack の `canAccept` → `onReceive` が順に呼ばれます。`serial: true` を指定すると優先度順に逐次実行されます。
+これらの API はサーバーレイヤー専用です。利用可能なレイヤーについては[レイヤー別 API 利用可否](#レイヤー別-api-利用可否)を参照してください。
 
 ```javascript
 const afterA = await PackA.onReceive(obj);
@@ -315,7 +331,7 @@ const afterB = await PackB.onReceive(afterA);
 
 サーバー側ハンドラーは `[200|400|500, body]` を返します。
 
-定義したイベントは、どのレイヤーからも共通の `takos.events.publish(eventName, payload)` で発行できます。
+定義したイベントは、どのレイヤーからも共通の `takos.events.publish(eventName, payload)` で発行できます。利用可能レイヤーのまとめは[レイヤー別 API 利用可否](#レイヤー別-api-利用可否)を参照してください。
 
 ---
 
@@ -361,6 +377,7 @@ TypeScript で型安全に連携でき、npm-semver 準拠で依存解決され�
 ## UI URL操作
 
 UI レイヤーで画面遷移を制御するための API です。サーバーやバックグラウンドからは利用できません。
+利用できるレイヤーの一覧は[レイヤー別 API 利用可否](#レイヤー別-api-利用可否)も参照してください。
 
 - **getURL**: `takos.getURL(): string[]`
   - 現在の URL パスを配列で取得します。


### PR DESCRIPTION
## Summary
- document API availability per layer
- reference table from ActivityPub hooks, event section and UI URL helpers

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684c52259b088328a82f4fa541149a5d