### PR TITLE
Allow push option for events.publish

### DIFF
--- a/app/api/utils/extensionsRuntime.ts
+++ b/app/api/utils/extensionsRuntime.ts
@@ -83,8 +83,12 @@ export async function loadExtension(
     await pack.init();
 
     // Forward client events to the server runtime
-    pack.clientTakos.events.publish = (name: string, payload: unknown) => {
-      return pack.callServer(doc.identifier, name, [payload]);
+    pack.clientTakos.events.publish = (
+      name: string,
+      payload: unknown,
+      options?: { push?: boolean },
+    ) => {
+      return pack.callServer(doc.identifier, name, [payload, options]);
     };
     runtimes.set(doc.identifier, pack);
   } catch (err) {

--- a/app/client/builder/types/takos-api.ts
+++ b/app/client/builder/types/takos-api.ts
@@ -52,7 +52,11 @@ export interface CdnManager {
 }
 
 export interface EventManager {
-  publish(eventName: string, payload: unknown): Promise<[number, unknown] | void>;
+  publish(
+    eventName: string,
+    payload: unknown,
+    options?: { push?: boolean },
+  ): Promise<[number, unknown] | void>;
   subscribe(eventName: string, handler: (payload: unknown) => void): () => void;
 }
 

--- a/docs/builder/README.md
+++ b/docs/builder/README.md
@@ -364,7 +364,7 @@ type Permission =
 
 // UI更新処理
 .clientFunction("updateUI", async (data: any) => {
-  await globalThis.takos.events.publish("dataUpdate", data);
+  await globalThis.takos.events.publish("dataUpdate", data, { push: true });
 })
 ```
 
@@ -386,7 +386,7 @@ type Permission =
 .addServerToClientEvent("dataChanged", async (newData: any) => {
   console.log("Data updated:", newData);
   // UIに通知
-  await globalThis.takos.events.publish("refresh", newData);
+  await globalThis.takos.events.publish("refresh", newData, { push: true });
 })
 ```
 
@@ -565,7 +565,7 @@ const memoExtension = new FunctionBasedTakopack()
         <script>
           async function saveMemo() {
             const memo = document.getElementById('memo').value;
-            await takos.events.publish('saveMemo', memo);
+            await takos.events.publish('saveMemo', memo, { push: true });
           }
         </script>
       </body>

--- a/docs/takopack/v3.md
+++ b/docs/takopack/v3.md
@@ -211,8 +211,9 @@ awesome-pack.takopack
 ### events
 イベントは manifest.json の `eventDefinitions` で宣言します。各レイヤー (server, client, background, ui) からは同じ API で実行できます。
 
-- `takos.events.publish(eventName: string, payload: any): Promise<[number, object]> | Promise<void>`
+- `takos.events.publish(eventName: string, payload: any, options?: { push?: boolean }): Promise<[number, object]> | Promise<void>`
   - 送信先が `server` の場合、ハンドラーが返す `[status, body]` を取得します。その他のレイヤー向けは `void` を返します。
+  - `options.push` を `true` にすると、クライアントがオフラインでも FCM などの Push 通知経由でイベントを配信できます。
 
 ### 拡張間 API
 - `takos.extensions.get(identifier: string): Extension | undefined`
@@ -331,7 +332,7 @@ const afterB = await PackB.onReceive(afterA);
 
 サーバー側ハンドラーは `[200|400|500, body]` を返します。
 
-定義したイベントは、どのレイヤーからも共通の `takos.events.publish(eventName, payload)` で発行できます。利用可能レイヤーのまとめは[レイヤー別 API 利用可否](#レイヤー別-api-利用可否)を参照してください。
+定義したイベントは、どのレイヤーからも共通の `takos.events.publish(eventName, payload, options?)` で発行できます。利用可能レイヤーのまとめは[レイヤー別 API 利用可否](#レイヤー別-api-利用可否)を参照してください。
 
 ---
 

--- a/packages/builder/src/api-helpers.ts
+++ b/packages/builder/src/api-helpers.ts
@@ -109,7 +109,8 @@ export function getTakosAPI(): TakosServerAPI | TakosClientAPI | TakosUIAPI | un
 export async function publishEvent<T = unknown>(
   eventName: string,
   payload: T,
-  context: 'server' | 'client' | 'ui' = 'client'
+  context: 'server' | 'client' | 'ui' = 'client',
+  options?: { push?: boolean },
 ): Promise<void> {
   const api =
     context === 'server'
@@ -121,7 +122,7 @@ export async function publishEvent<T = unknown>(
     console.warn(`Takos API not available in ${context} context`);
     return;
   }
-  await api.events.publish(eventName, payload);
+  await api.events.publish(eventName, payload, options);
 }
 
 /**

--- a/packages/builder/src/types.ts
+++ b/packages/builder/src/types.ts
@@ -24,7 +24,7 @@ export type Permission =
   | "deno:sys"
   | "deno:ffi"
   | "extensions:invoke"
-  | "extensions:export"
+  | "extensions:export";
 
 /**
  * AST解析結果
@@ -384,6 +384,7 @@ export interface TakosEventsAPI {
   publish(
     eventName: string,
     payload: SerializableValue,
+    options?: { push?: boolean },
   ): Promise<[200 | 400 | 500, SerializableObject] | void>;
   subscribe<T = SerializableValue>(
     eventName: string,

--- a/packages/runtime/mod.test.ts
+++ b/packages/runtime/mod.test.ts
@@ -53,7 +53,7 @@ Deno.test("override new event APIs", async () => {
       icon: "./icon.png",
     }),
     server:
-      `export async function send(){ await globalThis.takos.events.publish('ev', {}); return 1; }`,
+      `export async function send(){ await globalThis.takos.events.publish('ev', {}, { push: true }); return 1; }`,
   };
 
   let called = false;

--- a/packages/runtime/mod.ts
+++ b/packages/runtime/mod.ts
@@ -13,7 +13,11 @@ export interface TakosKV {
 }
 
 export interface TakosEvents {
-  publish(name: string, payload: unknown): Promise<unknown>;
+  publish(
+    name: string,
+    payload: unknown,
+    options?: { push?: boolean },
+  ): Promise<unknown>;
   subscribe(name: string, handler: (payload: unknown) => void): () => void;
 }
 
@@ -300,7 +304,11 @@ export class Takos {
     list: async () => [] as string[],
   };
   events = {
-    publish: async (_name: string, _payload: unknown) => {},
+    publish: async (
+      _name: string,
+      _payload: unknown,
+      _options?: { push?: boolean },
+    ) => {},
     subscribe: (
       _name: string,
       _handler: (payload: unknown) => void,


### PR DESCRIPTION
## Summary
- add optional push option to `events.publish` for notifying offline clients
- document `push` option in v3 spec and builder docs
- update builder runtime APIs and types for third argument
- forward options through extension runtime
- adjust tests for new param

## Testing
- `deno task test` *(fails: Worker permissions)*
- `deno task test` in packages/builder *(fails: invalid peer certificate)*

------
https://chatgpt.com/codex/tasks/task_e_684c6073a0888328b68f1267d53aa866