### PR TITLE
Fix ping export in API test extension

### DIFF
--- a/examples/api-test-extension/src/server/api.ts
+++ b/examples/api-test-extension/src/server/api.ts
@@ -4,9 +4,11 @@ import type { SerializableObject } from "@takopack/builder";
 
 const ApiServer = new ServerExtension();
 
-ApiServer.ping = (): string => {
+export function ping(): string {
   return "pong";
-};
+}
+
+ApiServer.ping = ping;
 
 /** @event("runServerTests", { source: "ui" }) */
 ApiServer.onRunServerTests = async (): Promise<
@@ -100,4 +102,4 @@ ApiServer.onRunServerTests = async (): Promise<
   return [200, results as SerializableObject];
 };
 
-export { ApiServer };
+export { ApiServer, ping };

--- a/examples/api-test-extension/takopack.config.ts
+++ b/examples/api-test-extension/takopack.config.ts
@@ -27,7 +27,7 @@ export default defineConfig({
       "extensions:invoke",
       "extensions:export",
     ],
-    exports: { server: ["ping", "testAll"] },
+    exports: { server: ["ping"] },
   },
 
   entries: {


### PR DESCRIPTION
## Summary
- ensure `ping` function is exported from example server API
- align manifest to only export `ping`

## Testing
- `deno test packages/builder/src/generator.test.ts`
- `deno test packages/runtime/mod.test.ts` *(fails: Failed loading https://registry.npmjs.org/@types%2fnode)*
- `deno test packages/unpack/mod.test.ts` *(fails: JSR package manifest failed to load)*
- `deno test app/client/builder/examples/simple-test.ts` *(fails: Relative import path "esbuild" not prefixed)*

------
https://chatgpt.com/codex/tasks/task_e_684c80085f90832888400980e17faea4