### PR TITLE
Update extension API

### DIFF
--- a/docs/takopack/v3.md
+++ b/docs/takopack/v3.md
@@ -258,7 +258,9 @@ interface Extension {
   identifier: string;
   version: string;
   isActive: boolean;
-  activate(): Promise<any>;
+  activate(): Promise<{
+    publish(name: string, payload?: unknown): Promise<unknown>;
+  }>;
 }
 function activateExtension(identifier: string): Promise<any>;
 ```
@@ -270,13 +272,13 @@ function activateExtension(identifier: string): Promise<any>;
 const ext = takos.extensions.get("com.example.lib");
 if (ext) {
   const api = await ext.activate();
-  const hash = await api.calculateHash("hello");
+  const hash = await api.publish("calculateHash", "hello");
 }
 
 // 直接有効化する方法
 const api2 = await takos.activateExtension("com.example.lib");
 if (api2) {
-  const hash2 = await api2.calculateHash("world");
+  const hash2 = await api2.publish("calculateHash", "world");
 }
 ```
 
@@ -369,7 +371,7 @@ const afterB = await PackB.onReceive(afterA);
 const ext = takos.extensions.get("com.example.lib");
 if (ext) {
   const api = await ext.activate();
-  await api.doSomething();
+  await api.publish("doSomething");
 }
 ```
 

--- a/docs/takopack/v3.md
+++ b/docs/takopack/v3.md
@@ -217,8 +217,8 @@ awesome-pack.takopack
 
 ### 拡張間 API
 - `takos.extensions.get(identifier: string): Extension | undefined`
-- `Extension.activate(): Promise<any>`
-- `takos.activateExtension(identifier: string): Promise<any>`
+- `Extension.activate(): Promise<{ publish(name: string, payload?: unknown): Promise<unknown> }>`
+- `takos.activateExtension(identifier: string): Promise<{ publish(name: string, payload?: unknown): Promise<unknown> } | undefined>`
   - **必要権限**: `extensions:invoke` / `extensions:export`
 
 権限はすべて `manifest.permissions` に列挙し、必要最低限を宣言してください。
@@ -262,7 +262,7 @@ interface Extension {
     publish(name: string, payload?: unknown): Promise<unknown>;
   }>;
 }
-function activateExtension(identifier: string): Promise<any>;
+function activateExtension(identifier: string): Promise<{ publish(name: string, payload?: unknown): Promise<unknown> }>;
 ```
 
 利用例:

--- a/examples/api-test-extension/src/server/api.ts
+++ b/examples/api-test-extension/src/server/api.ts
@@ -90,7 +90,7 @@ ApiServer.onRunServerTests = async (): Promise<
     const api = ext ? await ext.activate() : undefined;
     if (api) {
       // deno-lint-ignore no-explicit-any
-      await (api as any).ping();
+      const res = await (api as any).publish("ping");
     }
     results.extensions = takos?.extensions.all.length ?? 0;
   } catch (e) {

--- a/packages/runtime/mod.test.ts
+++ b/packages/runtime/mod.test.ts
@@ -87,7 +87,7 @@ Deno.test("extensions API activation", async () => {
   const ext = (globalThis as any).takos.extensions.get("com.example.lib");
   assert(ext);
   const api = await ext.activate();
-  const res = await (api as any).add(1, 2);
+  const res = await (api as any).publish("add", [1, 2]);
   assertEquals(res, 3);
   const all = (globalThis as any).takos.extensions.all;
   assert(Array.isArray(all));
@@ -114,7 +114,7 @@ Deno.test("activateExtension from worker", async () => {
       icon: "./icon.png",
     }),
     server:
-      `export async function run(){ const api = await globalThis.takos.activateExtension('com.example.lib2'); return await api.mul(2,3); }`,
+      `export async function run(){ const api = await globalThis.takos.activateExtension('com.example.lib2'); return await api.publish('mul', [2,3]); }`,
   };
   const takopack = new TakoPack([lib, user]);
   await takopack.init();

--- a/packages/runtime/mod.ts
+++ b/packages/runtime/mod.ts
@@ -286,7 +286,9 @@ export class Takos {
       },
     };
   }
-  activateExtension(id: string): Promise<unknown> {
+  activateExtension(
+    id: string,
+  ): Promise<{ publish(name: string, payload?: unknown): Promise<unknown> } | undefined> {
     const ext = this.extProvider?.get(id);
     return ext ? ext.activate() : Promise.resolve(undefined);
   }


### PR DESCRIPTION
## Summary
- document new `api.publish()` call pattern
- support `publish()` in runtime extension activation
- adjust examples and tests to use `publish`

## Testing
- `deno test -A --unstable-worker-options` *(fails: Failed loading https://registry.npmjs.org/@types%2fnode)*

------
https://chatgpt.com/codex/tasks/task_e_684c8a529ab483289624cc7027f90865