### PR TITLE
Fix Takos events.publish return type

### DIFF
--- a/app/api/utils/extensionsRuntime.ts
+++ b/app/api/utils/extensionsRuntime.ts
@@ -83,13 +83,15 @@ export async function loadExtension(
     await pack.init();
 
     // Forward client events to the server runtime
-    pack.clientTakos.events.publish = (
-      name: string,
-      payload: unknown,
-      options?: { push?: boolean },
-    ) => {
-      return pack.callServer(doc.identifier, name, [payload, options]);
-    };
+    pack.setClientPublish(
+      (
+        name: string,
+        payload: unknown,
+        options?: { push?: boolean },
+      ) => {
+        return pack.callServer(doc.identifier, name, [payload, options]);
+      },
+    );
     runtimes.set(doc.identifier, pack);
   } catch (err) {
     console.error(`Failed to initialize extension ${doc.identifier}:`, err);

--- a/packages/builder/src/api-helpers.ts
+++ b/packages/builder/src/api-helpers.ts
@@ -75,6 +75,7 @@ export interface TakosExtensionsAPI {
 // コンテキスト別API定義
 export interface TakosServerAPI {
   kv: TakosKVAPI;
+  activitypub: TakosActivityPubAPI;
   ap: TakosActivityPubAPI;
   cdn: TakosCdnAPI;
   events: TakosEventsAPI;
@@ -87,6 +88,7 @@ export interface TakosServerAPI {
 
 export interface TakosClientAPI {
   kv: TakosKVAPI;
+  activitypub: TakosActivityPubAPI;
   cdn: TakosCdnAPI;
   events: TakosEventsAPI;
   extensions: TakosExtensionsAPI;
@@ -98,6 +100,7 @@ export interface TakosClientAPI {
 
 export interface TakosUIAPI {
   events: TakosEventsAPI;
+  activitypub: TakosActivityPubAPI;
   extensions: TakosExtensionsAPI;
   activateExtension(
     identifier: string,

--- a/packages/builder/src/api-helpers.ts
+++ b/packages/builder/src/api-helpers.ts
@@ -40,6 +40,10 @@ export interface TakosActivityPubAPI {
   read(id: string): Promise<Record<string, unknown>>;
   delete(id: string): Promise<void>;
   list(userId?: string): Promise<string[]>;
+  follow(followerId: string, followeeId: string): Promise<void>;
+  unfollow(followerId: string, followeeId: string): Promise<void>;
+  listFollowers(actorId: string): Promise<string[]>;
+  listFollowing(actorId: string): Promise<string[]>;
   actor: {
     read(userId: string): Promise<Record<string, unknown>>;
     update(userId: string, key: string, value: string): Promise<void>;
@@ -54,12 +58,30 @@ export interface TakosActivityPubAPI {
   };
 }
 
+export interface Extension {
+  identifier: string;
+  version: string;
+  isActive: boolean;
+  activate(): Promise<{
+    publish(name: string, payload?: unknown): Promise<unknown>;
+  }>;
+}
+
+export interface TakosExtensionsAPI {
+  get(identifier: string): Extension | undefined;
+  readonly all: Extension[];
+}
+
 // コンテキスト別API定義
 export interface TakosServerAPI {
   kv: TakosKVAPI;
   ap: TakosActivityPubAPI;
   cdn: TakosCdnAPI;
   events: TakosEventsAPI;
+  extensions: TakosExtensionsAPI;
+  activateExtension(
+    identifier: string,
+  ): Promise<{ publish(name: string, payload?: unknown): Promise<unknown> } | undefined>;
   fetch(url: string, options?: RequestInit): Promise<Response>;
 }
 
@@ -67,11 +89,19 @@ export interface TakosClientAPI {
   kv: TakosKVAPI;
   cdn: TakosCdnAPI;
   events: TakosEventsAPI;
+  extensions: TakosExtensionsAPI;
+  activateExtension(
+    identifier: string,
+  ): Promise<{ publish(name: string, payload?: unknown): Promise<unknown> } | undefined>;
   fetch(url: string, options?: RequestInit): Promise<Response>;
 }
 
 export interface TakosUIAPI {
   events: TakosEventsAPI;
+  extensions: TakosExtensionsAPI;
+  activateExtension(
+    identifier: string,
+  ): Promise<{ publish(name: string, payload?: unknown): Promise<unknown> } | undefined>;
 }
 
 // 型安全なTakos APIアクセス関数群

--- a/packages/builder/src/types.ts
+++ b/packages/builder/src/types.ts
@@ -368,6 +368,20 @@ export interface TakosActivityPubAPI {
   pluginActor: TakosActivityPubPluginActorAPI;
 }
 
+export interface Extension {
+  identifier: string;
+  version: string;
+  isActive: boolean;
+  activate(): Promise<{
+    publish(name: string, payload?: SerializableValue): Promise<SerializableValue>;
+  }>;
+}
+
+export interface TakosExtensionsAPI {
+  get(identifier: string): Extension | undefined;
+  readonly all: Extension[];
+}
+
 export interface TakosCdnAPI {
   read(path: string): Promise<string>;
   write(
@@ -403,14 +417,32 @@ export interface TakosAPI {
 
 export interface TakosServerAPI extends TakosAPI {
   events: TakosEventsAPI;
+  extensions: TakosExtensionsAPI;
+  activateExtension(
+    identifier: string,
+  ): Promise<
+    { publish(name: string, payload?: SerializableValue): Promise<SerializableValue> } | undefined
+  >;
 }
 
 export interface TakosClientAPI extends TakosAPI {
   events: TakosEventsAPI;
+  extensions: TakosExtensionsAPI;
+  activateExtension(
+    identifier: string,
+  ): Promise<
+    { publish(name: string, payload?: SerializableValue): Promise<SerializableValue> } | undefined
+  >;
 }
 
 export interface TakosUIAPI {
   events: TakosEventsAPI;
+  extensions: TakosExtensionsAPI;
+  activateExtension(
+    identifier: string,
+  ): Promise<
+    { publish(name: string, payload?: SerializableValue): Promise<SerializableValue> } | undefined
+  >;
   // UI環境では一部のAPIは制限される
 }
 

--- a/packages/runtime/mod.ts
+++ b/packages/runtime/mod.ts
@@ -316,12 +316,14 @@ export class Takos {
     delete: async (_key: string) => {},
     list: async () => [] as string[],
   };
-  events = {
+  events: TakosEvents = {
     publish: async (
       _name: string,
       _payload: unknown,
       _options?: { push?: boolean },
-    ) => {},
+    ): Promise<unknown> => {
+      return undefined;
+    },
     subscribe: (
       _name: string,
       _handler: (payload: unknown) => void,

--- a/packages/runtime/mod.ts
+++ b/packages/runtime/mod.ts
@@ -536,7 +536,7 @@ class PackWorker {
         result = {
           status: (result as Response).status,
           statusText: (result as Response).statusText,
-          headers: Array.from((result as Response).headers.entries()),
+          headers: Array.from((result as Response).headers),
           body: arr,
         };
       } else if (d.path[0] === "extensions" && d.path[1] === "get") {

--- a/packages/runtime/mod.ts
+++ b/packages/runtime/mod.ts
@@ -743,6 +743,16 @@ export class TakoPack {
     }
   }
 
+  setClientPublish(
+    fn: (
+      name: string,
+      payload: unknown,
+      options?: { push?: boolean },
+    ) => Promise<unknown>,
+  ): void {
+    this.clientTakos.events.publish = fn;
+  }
+
   async callServer(
     identifier: string,
     fnName: string,

--- a/packages/runtime/mod.ts
+++ b/packages/runtime/mod.ts
@@ -533,10 +533,14 @@ class PackWorker {
       }
       if (d.path[0] === "fetch") {
         const arr = new Uint8Array(await (result as Response).arrayBuffer());
+        const headersArr: [string, string][] = [];
+        (result as Response).headers.forEach((value, key) => {
+          headersArr.push([key, value]);
+        });
         result = {
           status: (result as Response).status,
           statusText: (result as Response).statusText,
-          headers: Array.from((result as Response).headers),
+          headers: headersArr,
           body: arr,
         };
       } else if (d.path[0] === "extensions" && d.path[1] === "get") {


### PR DESCRIPTION
## Summary
- make `Takos.events` implement `TakosEvents` so publish returns `Promise<unknown>`

## Testing
- `deno test -A --unstable-worker-options packages/runtime/mod.test.ts` *(fails: Failed loading https://registry.npmjs.org/@types%2fnode for package "@types/node")*

------
https://chatgpt.com/codex/tasks/task_e_684dc836bb5083289da0baf46cf05ea3