### PR TITLE
Fix registry_ui login persistence

### DIFF
--- a/app/registry_ui/src/App.tsx
+++ b/app/registry_ui/src/App.tsx
@@ -1,4 +1,5 @@
-import { createSignal, Show } from "solid-js";
+import { createSignal, Show, onMount } from "solid-js";
+import { req } from "./api.ts";
 import LoginFormModal from "./components/LoginFormModal.tsx";
 import NavHeader from "./components/NavHeader.tsx";
 import PublicNavHeader from "./components/PublicNavHeader.tsx";
@@ -13,6 +14,15 @@ export default function App() {
     "packages",
   );
   const [showLoginModal, setShowLoginModal] = createSignal(false);
+
+  onMount(async () => {
+    try {
+      await req("/api/domains");
+      setAuthed(true);
+    } catch {
+      setAuthed(false);
+    }
+  });
 
   const handleLogin = () => {
     setShowLoginModal(true);


### PR DESCRIPTION
## Summary
- check session status when registry UI loads

## Testing
- `deno test -A` *(fails: JSR package manifest failed to load)*

------
https://chatgpt.com/codex/tasks/task_e_684ec93db15883289d066f43fc51d1e4