### PR TITLE
Implement registry domain management

### DIFF
--- a/app/registry/.gitignore
+++ b/app/registry/.gitignore
@@ -1,1 +1,2 @@
 .env
+registry/

--- a/app/registry/deno.json
+++ b/app/registry/deno.json
@@ -6,7 +6,7 @@
     "nodemailer": "npm:nodemailer@^7.0.3"
   },
   "tasks": {
-    "start": "deno run -A index.ts",
+    "start": "deno run -A --watch index.ts",
     "ui-dev": "deno run -A npm:vite --config ui/vite.config.ts",
     "ui-build": "deno run -A npm:vite build --config ui/vite.config.ts"
   }

--- a/app/registry/deno.lock
+++ b/app/registry/deno.lock
@@ -2,7 +2,9 @@
   "version": "5",
   "specifiers": {
     "jsr:@std/dotenv@*": "0.225.5",
+    "jsr:@std/fs@*": "1.0.18",
     "jsr:@std/path@^1.1.0": "1.1.0",
+    "jsr:@zip-js/zip-js@^2.7.62": "2.7.62",
     "npm:@types/node@*": "22.15.15",
     "npm:create-vite-extra@latest": "2.2.0",
     "npm:hono@^4.7.11": "4.7.11",
@@ -14,8 +16,17 @@
     "@std/dotenv@0.225.5": {
       "integrity": "9ce6f9d0ec3311f74a32535aa1b8c62ed88b1ab91b7f0815797d77a6f60c922f"
     },
+    "@std/fs@1.0.18": {
+      "integrity": "24bcad99eab1af4fde75e05da6e9ed0e0dce5edb71b7e34baacf86ffe3969f3a",
+      "dependencies": [
+        "jsr:@std/path"
+      ]
+    },
     "@std/path@1.1.0": {
       "integrity": "ddc94f8e3c275627281cbc23341df6b8bcc874d70374f75fec2533521e3d6886"
+    },
+    "@zip-js/zip-js@2.7.62": {
+      "integrity": "11cbe0746fa1e52e6e0a601c89ba97365f16e38a07f139b9d9914f988aec9081"
     }
   },
   "npm": {

--- a/app/registry/index.ts
+++ b/app/registry/index.ts
@@ -230,6 +230,17 @@ app.post("/api/login", async (c) => {
   }
 });
 
+app.post("/api/logout", async (c) => {
+  const token = getCookie(c.req.raw, "session");
+  if (token) {
+    await Session.deleteOne({ token });
+  }
+  return c.json(
+    { ok: true },
+    { headers: { "Set-Cookie": "session=; HttpOnly; Path=/; Max-Age=0" } },
+  );
+});
+
 app.get("/api/verify/:token", async (c) => {
   const token = c.req.param("token");
   const user = await User.findOne({ verificationToken: token });

--- a/app/registry/index.ts
+++ b/app/registry/index.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 import type { Context, Next } from "hono";
 import { dirname, fromFileUrl, join } from "@std/path";
+import { ensureDir } from "@std/fs";
 import mongoose from "mongoose";
 import { sendEmail } from "./sendMail.ts";
 import { load } from "jsr:@std/dotenv";
@@ -87,6 +88,7 @@ app.use("/api/domains/*", auth);
 app.use("/api/domains", auth);
 
 const rootDir = env["REGISTRY_DIR"] ?? "./registry";
+await ensureDir(rootDir);
 const uiDir = join(
   dirname(fromFileUrl(import.meta.url)),
   "public",

--- a/app/registry/index.ts
+++ b/app/registry/index.ts
@@ -133,7 +133,7 @@ function hash(value: string): Promise<string> {
 function identifierDomain(id: string): string | null {
   const parts = id.split(".");
   if (parts.length < 2) return null;
-  return `${parts[1]}.${parts[0]}`;
+  return parts.slice(0, -1).reverse().join(".");
 }
 
 function contentType(path: string): string {
@@ -290,6 +290,18 @@ app.get("/api/domains", async (c) => {
       verified: d.verified,
     })),
   });
+});
+
+app.delete("/api/domains/:name", async (c) => {
+  const userId = c.get("userId");
+  const name = c.req.param("name");
+  const entry = await Domain.findOne({
+    name,
+    userId: new mongoose.Types.ObjectId(userId),
+  });
+  if (!entry) return c.json({ error: "Not found" }, 404);
+  await entry.deleteOne();
+  return c.json({ ok: true });
 });
 
 app.get("/", async (c) => {

--- a/app/registry/index.ts
+++ b/app/registry/index.ts
@@ -1,7 +1,7 @@
 import { Hono } from "hono";
 import type { Context, Next } from "hono";
 import { dirname, fromFileUrl, join } from "@std/path";
-import { ensureDir } from "@std/fs";
+import { ensureDir } from "jsr:@std/fs";
 import mongoose from "mongoose";
 import { sendEmail } from "./sendMail.ts";
 import { load } from "jsr:@std/dotenv";

--- a/app/registry_ui/src/App.tsx
+++ b/app/registry_ui/src/App.tsx
@@ -1,4 +1,4 @@
-import { createSignal, Show, onMount } from "solid-js";
+import { createSignal, onMount, Show } from "solid-js";
 import { req } from "./api.ts";
 import LoginFormModal from "./components/LoginFormModal.tsx";
 import NavHeader from "./components/NavHeader.tsx";
@@ -28,10 +28,15 @@ export default function App() {
     setShowLoginModal(true);
   };
 
-  const handleLogout = () => {
-    setAuthed(false);
-    setActiveTab("packages");
-    // 実際のログアウト処理をここに実装
+  const handleLogout = async () => {
+    try {
+      await req("/api/logout", "POST");
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setAuthed(false);
+      setActiveTab("packages");
+    }
   };
 
   const handleLoginSuccess = () => {

--- a/app/registry_ui/src/api.ts
+++ b/app/registry_ui/src/api.ts
@@ -1,13 +1,15 @@
 export async function req<T>(
   path: string,
   method = "GET",
-  body?: unknown,
+  body?: FormData | unknown,
 ): Promise<T> {
-  const opts: RequestInit = {
-    method,
-    headers: { "Content-Type": "application/json" },
-  };
-  if (body) opts.body = JSON.stringify(body);
+  const opts: RequestInit = { method };
+  if (body instanceof FormData) {
+    opts.body = body;
+  } else if (body !== undefined) {
+    opts.headers = { "Content-Type": "application/json" };
+    opts.body = JSON.stringify(body);
+  }
   const res = await fetch(path, opts);
   if (!res.ok) {
     let data: unknown = null;

--- a/app/registry_ui/src/components/Alert.tsx
+++ b/app/registry_ui/src/components/Alert.tsx
@@ -1,0 +1,47 @@
+export default function Alert(props: {
+  message: string;
+  type?: "info" | "error";
+  onClose?: () => void;
+}) {
+  const color = props.type === "error" ? "red" : "blue";
+  const icon = props.type === "error"
+    ? "M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7 4a1 1 0 11-2 0 1 1 0 012 0zm-1-9a1 1 0 00-1 1v4a1 1 0 102 0V6a1 1 0 00-1-1z"
+    : "M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z";
+  return (
+    <div
+      class={`bg-${color}-500/10 border border-${color}-500/30 rounded-xl p-4`}
+    >
+      <div class="flex items-start space-x-2">
+        <svg
+          class={`w-5 h-5 text-${color}-400`}
+          fill="currentColor"
+          viewBox="0 0 20 20"
+        >
+          <path d={icon} />
+        </svg>
+        <p class={`text-${color}-300 text-sm flex-1`}>{props.message}</p>
+        {props.onClose && (
+          <button
+            type="button"
+            onClick={props.onClose}
+            class={`text-${color}-400 hover:text-${color}-300`}
+          >
+            <svg
+              class="w-4 h-4"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M6 18L18 6M6 6l12 12"
+              />
+            </svg>
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/registry_ui/src/components/DomainSection.tsx
+++ b/app/registry_ui/src/components/DomainSection.tsx
@@ -37,7 +37,7 @@ export default function DomainSection() {
           domain: domainInput.value,
         },
       );
-      setToken(`認証トークン: ${data.token}`);
+      setToken(`認証トークン: takopack-verify=${data.token}`);
       domainInput.value = "";
       setShowAddModal(false);
       await refresh();
@@ -66,7 +66,7 @@ export default function DomainSection() {
       const data = await req<{ token: string }>(
         `/api/domains/${encodeURIComponent(name)}/token`,
       );
-      setToken(`認証トークン: ${data.token}`);
+      setToken(`認証トークン: takopack-verify=${data.token}`);
     } catch (error) {
       console.error("Failed to fetch token:", error);
     } finally {

--- a/app/registry_ui/src/components/DomainSection.tsx
+++ b/app/registry_ui/src/components/DomainSection.tsx
@@ -1,5 +1,6 @@
 import { createSignal, For, Show } from "solid-js";
 import { req } from "../api.ts";
+import Alert from "./Alert.tsx";
 
 interface Domain {
   name: string;
@@ -14,103 +15,60 @@ export default function DomainSection() {
   const [showAddModal, setShowAddModal] = createSignal(false);
   let domainInput!: HTMLInputElement;
 
-  const refresh = async () => {
+  const run = async (fn: () => Promise<void>) => {
     setIsLoading(true);
     setError("");
     try {
-      const data = await req<{ domains: Domain[] }>("/api/domains");
-      setDomains(data.domains);
-    } catch (error) {
-      console.error("Failed to fetch domains:", error);
-      const message = error instanceof Error
-        ? error.message
-        : "ドメイン取得に失敗しました";
-      setError(message);
+      await fn();
+    } catch (err) {
+      console.error(err);
+      setError(err instanceof Error ? err.message : "エラーが発生しました");
     } finally {
       setIsLoading(false);
     }
   };
+
+  const refresh = () =>
+    run(async () => {
+      const data = await req<{ domains: Domain[] }>("/api/domains");
+      setDomains(data.domains);
+    });
 
   const requestDomain = async () => {
     if (!domainInput.value.trim()) return;
-
-    setIsLoading(true);
-    setError("");
-    try {
+    await run(async () => {
       const data = await req<{ token: string }>(
         "/api/domains/request",
         "POST",
-        {
-          domain: domainInput.value,
-        },
+        { domain: domainInput.value },
       );
-      setToken(`認証トークン: takopack-verify=${data.token}`);
+      setToken(data.token);
       domainInput.value = "";
       setShowAddModal(false);
       await refresh();
-    } catch (error) {
-      console.error("Failed to request domain:", error);
-      const message = error instanceof Error
-        ? error.message
-        : "ドメイン登録に失敗しました";
-      setError(message);
-    } finally {
-      setIsLoading(false);
-    }
+    });
   };
 
-  const verifyDomain = async (name: string) => {
-    setIsLoading(true);
-    setError("");
-    try {
+  const verifyDomain = (name: string) =>
+    run(async () => {
       await req("/api/domains/verify", "POST", { domain: name });
       await refresh();
-    } catch (error) {
-      console.error("Failed to verify domain:", error);
-      const message = error instanceof Error
-        ? error.message
-        : "ドメイン認証に失敗しました";
-      setError(message);
-    } finally {
-      setIsLoading(false);
-    }
-  };
+    });
 
-  const viewToken = async (name: string) => {
-    setIsLoading(true);
-    setError("");
-    try {
+  const viewToken = (name: string) =>
+    run(async () => {
       const data = await req<{ token: string }>(
         `/api/domains/${encodeURIComponent(name)}/token`,
       );
-      setToken(`認証トークン: takopack-verify=${data.token}`);
-    } catch (error) {
-      console.error("Failed to fetch token:", error);
-      const message = error instanceof Error
-        ? error.message
-        : "トークン取得に失敗しました";
-      setError(message);
-    } finally {
-      setIsLoading(false);
-    }
-  };
+      setToken(data.token);
+    });
 
   const deleteDomain = async (name: string) => {
     if (!confirm(`${name} を削除しますか?`)) return;
-    setIsLoading(true);
-    setError("");
-    try {
+    await run(async () => {
       await req(`/api/domains/${encodeURIComponent(name)}`, "DELETE");
       await refresh();
-    } catch (error) {
-      console.error("Failed to delete domain:", error);
-      const message = error instanceof Error
-        ? error.message
-        : "ドメイン削除に失敗しました";
-      setError(message);
-    } finally {
-      setIsLoading(false);
-    }
+    });
   };
 
   // 初期読み込み
@@ -173,22 +131,7 @@ export default function DomainSection() {
 
       {/* エラーメッセージ */}
       <Show when={error()}>
-        <div class="bg-red-500/10 border border-red-500/30 rounded-xl p-4">
-          <div class="flex items-center space-x-2">
-            <svg
-              class="w-5 h-5 text-red-400"
-              fill="currentColor"
-              viewBox="0 0 20 20"
-            >
-              <path
-                fill-rule="evenodd"
-                d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7 4a1 1 0 11-2 0 1 1 0 012 0zm-1-9a1 1 0 00-1 1v4a1 1 0 102 0V6a1 1 0 00-1-1z"
-                clip-rule="evenodd"
-              />
-            </svg>
-            <p class="text-red-300 text-sm">{error()}</p>
-          </div>
-        </div>
+        <Alert type="error" message={error()!} />
       </Show>
 
       {/* 統計情報 */}
@@ -432,49 +375,10 @@ export default function DomainSection() {
 
       {/* 認証トークン表示 */}
       <Show when={token()}>
-        <div class="bg-blue-500/10 border border-blue-500/30 rounded-xl p-4">
-          <div class="flex items-start space-x-3">
-            <svg
-              class="w-5 h-5 text-blue-400 mt-0.5"
-              fill="currentColor"
-              viewBox="0 0 20 20"
-            >
-              <path
-                fill-rule="evenodd"
-                d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z"
-                clip-rule="evenodd"
-              />
-            </svg>
-            <div class="flex-1">
-              <h4 class="text-sm font-medium text-blue-300">認証トークン</h4>
-              <p class="text-sm text-blue-200 mt-1 font-mono bg-blue-500/20 px-2 py-1 rounded">
-                {token()}
-              </p>
-              <p class="text-xs text-blue-300 mt-2">
-                このトークンをドメインのDNS TXTレコードに追加してください。
-              </p>
-            </div>{" "}
-            <button
-              type="button"
-              onClick={() => setToken("")}
-              class="p-1 text-blue-400 hover:text-blue-300"
-            >
-              <svg
-                class="w-4 h-4"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-              >
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  d="M6 18L18 6M6 6l12 12"
-                />
-              </svg>
-            </button>
-          </div>
-        </div>
+        <Alert
+          message={`認証トークン: takopack-verify=${token()}`}
+          onClose={() => setToken("")}
+        />
       </Show>
 
       {/* ドメイン追加モーダル */}

--- a/app/registry_ui/src/components/DomainSection.tsx
+++ b/app/registry_ui/src/components/DomainSection.tsx
@@ -48,6 +48,31 @@ export default function DomainSection() {
     }
   };
 
+  const verifyDomain = async (name: string) => {
+    setIsLoading(true);
+    try {
+      await req("/api/domains/verify", "POST", { domain: name });
+      await refresh();
+    } catch (error) {
+      console.error("Failed to verify domain:", error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const deleteDomain = async (name: string) => {
+    if (!confirm(`${name} を削除しますか?`)) return;
+    setIsLoading(true);
+    try {
+      await req(`/api/domains/${encodeURIComponent(name)}`, "DELETE");
+      await refresh();
+    } catch (error) {
+      console.error("Failed to delete domain:", error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
   // 初期読み込み
   refresh();
 
@@ -301,13 +326,15 @@ export default function DomainSection() {
                         <Show when={!domain.verified}>
                           <button
                             type="button"
+                            onClick={() => verifyDomain(domain.name)}
                             class="px-3 py-1.5 text-xs font-medium text-yellow-300 border border-yellow-500/30 rounded-lg hover:bg-yellow-500/10 transition-colors duration-200"
                           >
-                            認証手順を確認
+                            認証確認
                           </button>
                         </Show>
                         <button
                           type="button"
+                          onClick={() => deleteDomain(domain.name)}
                           class="p-2 text-gray-400 hover:text-gray-300 rounded-lg hover:bg-gray-700/50 transition-colors duration-200"
                         >
                           <svg
@@ -320,7 +347,7 @@ export default function DomainSection() {
                               stroke-linecap="round"
                               stroke-linejoin="round"
                               stroke-width="2"
-                              d="M12 5v.01M12 12v.01M12 19v.01M12 6a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2z"
+                              d="M6 18L18 6M6 6l12 12"
                             />
                           </svg>
                         </button>

--- a/app/registry_ui/src/components/DomainSection.tsx
+++ b/app/registry_ui/src/components/DomainSection.tsx
@@ -60,6 +60,20 @@ export default function DomainSection() {
     }
   };
 
+  const viewToken = async (name: string) => {
+    setIsLoading(true);
+    try {
+      const data = await req<{ token: string }>(
+        `/api/domains/${encodeURIComponent(name)}/token`,
+      );
+      setToken(`認証トークン: ${data.token}`);
+    } catch (error) {
+      console.error("Failed to fetch token:", error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
   const deleteDomain = async (name: string) => {
     if (!confirm(`${name} を削除しますか?`)) return;
     setIsLoading(true);
@@ -324,13 +338,22 @@ export default function DomainSection() {
 
                       <div class="flex items-center space-x-2">
                         <Show when={!domain.verified}>
-                          <button
-                            type="button"
-                            onClick={() => verifyDomain(domain.name)}
-                            class="px-3 py-1.5 text-xs font-medium text-yellow-300 border border-yellow-500/30 rounded-lg hover:bg-yellow-500/10 transition-colors duration-200"
-                          >
-                            認証確認
-                          </button>
+                          <div class="flex items-center space-x-2">
+                            <button
+                              type="button"
+                              onClick={() => verifyDomain(domain.name)}
+                              class="px-3 py-1.5 text-xs font-medium text-yellow-300 border border-yellow-500/30 rounded-lg hover:bg-yellow-500/10 transition-colors duration-200"
+                            >
+                              認証確認
+                            </button>
+                            <button
+                              type="button"
+                              onClick={() => viewToken(domain.name)}
+                              class="px-3 py-1.5 text-xs font-medium text-blue-300 border border-blue-500/30 rounded-lg hover:bg-blue-500/10 transition-colors duration-200"
+                            >
+                              トークン表示
+                            </button>
+                          </div>
                         </Show>
                         <button
                           type="button"

--- a/app/registry_ui/src/components/PackageSection.tsx
+++ b/app/registry_ui/src/components/PackageSection.tsx
@@ -13,12 +13,7 @@ export default function PackageSection() {
   >(null);
   const [showPublishModal, setShowPublishModal] = createSignal(false);
   // フォーム用の参照
-  let idInput!: HTMLInputElement;
-  let nameInput!: HTMLInputElement;
-  let versionInput!: HTMLInputElement;
-  let descInput!: HTMLTextAreaElement;
-  let urlInput!: HTMLInputElement;
-  let shaInput!: HTMLInputElement;
+  let fileInput!: HTMLInputElement;
 
   const filteredAndSortedPackages = createMemo(() => {
     let filtered = packages();
@@ -67,22 +62,13 @@ export default function PackageSection() {
   const addPackage = async () => {
     setIsLoading(true);
     try {
-      await req("/api/packages", "POST", {
-        identifier: idInput.value,
-        name: nameInput.value,
-        version: versionInput.value,
-        description: descInput.value,
-        downloadUrl: urlInput.value,
-        sha256: shaInput.value || undefined,
-      });
+      if (!fileInput.files?.[0]) throw new Error("no file");
+      const form = new FormData();
+      form.append("file", fileInput.files[0]);
+      await req("/api/packages", "POST", form);
 
       // フォームをリセット
-      idInput.value = "";
-      nameInput.value = "";
-      versionInput.value = "";
-      descInput.value = "";
-      urlInput.value = "";
-      shaInput.value = "";
+      if (fileInput) fileInput.value = "";
 
       setShowPublishModal(false);
       await refresh();
@@ -345,71 +331,15 @@ export default function PackageSection() {
             </div>
 
             <div class="p-6 space-y-6">
-              <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-                <div>
-                  <label class="block text-sm font-medium text-gray-300 mb-2">
-                    識別子
-                  </label>
-                  <input
-                    ref={idInput!}
-                    placeholder="com.example.package"
-                    class="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-lg text-gray-100 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent"
-                  />
-                </div>
-                <div>
-                  <label class="block text-sm font-medium text-gray-300 mb-2">
-                    パッケージ名
-                  </label>
-                  <input
-                    ref={nameInput!}
-                    placeholder="My Package"
-                    class="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-lg text-gray-100 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent"
-                  />
-                </div>
-              </div>
-
               <div>
                 <label class="block text-sm font-medium text-gray-300 mb-2">
-                  バージョン
+                  Takopack ファイル
                 </label>
                 <input
-                  ref={versionInput!}
-                  placeholder="1.0.0"
-                  class="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-lg text-gray-100 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent"
-                />
-              </div>
-
-              <div>
-                <label class="block text-sm font-medium text-gray-300 mb-2">
-                  説明
-                </label>
-                <textarea
-                  ref={descInput!}
-                  placeholder="パッケージの説明を入力してください..."
-                  rows={3}
-                  class="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-lg text-gray-100 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent resize-none"
-                />
-              </div>
-
-              <div>
-                <label class="block text-sm font-medium text-gray-300 mb-2">
-                  ダウンロードURL
-                </label>
-                <input
-                  ref={urlInput!}
-                  placeholder="https://example.com/package.zip"
-                  class="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-lg text-gray-100 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent"
-                />
-              </div>
-
-              <div>
-                <label class="block text-sm font-medium text-gray-300 mb-2">
-                  SHA256ハッシュ（オプション）
-                </label>
-                <input
-                  ref={shaInput!}
-                  placeholder="ファイルのSHA256ハッシュ値"
-                  class="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-lg text-gray-100 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent"
+                  type="file"
+                  ref={fileInput!}
+                  class="w-full text-gray-100"
+                  accept=".takopack"
                 />
               </div>
             </div>

--- a/app/registry_ui/src/components/PackageSection.tsx
+++ b/app/registry_ui/src/components/PackageSection.tsx
@@ -8,6 +8,7 @@ export default function PackageSection() {
   const [searchQuery, setSearchQuery] = createSignal("");
   const [sortBy, setSortBy] = createSignal("name");
   const [isLoading, setIsLoading] = createSignal(false);
+  const [error, setError] = createSignal("");
   const [selectedPackage, setSelectedPackage] = createSignal<
     PackageInfo | null
   >(null);
@@ -49,11 +50,16 @@ export default function PackageSection() {
 
   const refresh = async () => {
     setIsLoading(true);
+    setError("");
     try {
       const data = await req<{ packages: PackageInfo[] }>("/_takopack/search");
       setPackages(data.packages);
     } catch (error) {
       console.error("Failed to fetch packages:", error);
+      const message = error instanceof Error
+        ? error.message
+        : "パッケージ取得に失敗しました";
+      setError(message);
     } finally {
       setIsLoading(false);
     }
@@ -61,6 +67,7 @@ export default function PackageSection() {
 
   const addPackage = async () => {
     setIsLoading(true);
+    setError("");
     try {
       if (!fileInput.files?.[0]) throw new Error("no file");
       const form = new FormData();
@@ -74,6 +81,10 @@ export default function PackageSection() {
       await refresh();
     } catch (error) {
       console.error("Failed to add package:", error);
+      const message = error instanceof Error
+        ? error.message
+        : "パッケージ公開に失敗しました";
+      setError(message);
     } finally {
       setIsLoading(false);
     }
@@ -102,6 +113,25 @@ export default function PackageSection() {
         packageCount={filteredAndSortedPackages().length}
         isLoading={isLoading()}
       />
+
+      <Show when={error()}>
+        <div class="bg-red-500/10 border border-red-500/30 rounded-lg p-4 mt-4">
+          <div class="flex items-center space-x-2">
+            <svg
+              class="w-5 h-5 text-red-400"
+              fill="currentColor"
+              viewBox="0 0 20 20"
+            >
+              <path
+                fill-rule="evenodd"
+                d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7 4a1 1 0 11-2 0 1 1 0 012 0zm-1-9a1 1 0 00-1 1v4a1 1 0 102 0V6a1 1 0 00-1-1z"
+                clip-rule="evenodd"
+              />
+            </svg>
+            <p class="text-red-300 text-sm">{error()}</p>
+          </div>
+        </div>
+      </Show>
 
       {/* メインコンテンツ */}
       <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">

--- a/examples/api-test-extension/takopack.config.ts
+++ b/examples/api-test-extension/takopack.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from "../../packages/builder/mod.ts";
 export default defineConfig({
   manifest: {
     name: "API Test Extension",
-    identifier: "test.api",
+    identifier: "jp.takos.api-test",
     version: "1.0.0",
     icon: "./icon.png",
     description: "docs/takopack/v3.mdのAPIを検証する拡張機能",


### PR DESCRIPTION
## Summary
- improve domain extraction for arbitrary reverse-domain identifiers
- expose domain deletion API on registry server
- add UI actions to verify and delete domains

## Testing
- `deno task test` *(fails: JSR package manifest download blocked)*

------
https://chatgpt.com/codex/tasks/task_e_684ee40dfe408328971c8da517063a53