### PR TITLE
Add theme toggle and refine login UI

### DIFF
--- a/app/client/index.html
+++ b/app/client/index.html
@@ -1,10 +1,14 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="ja" class="dark">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + Solid + TS</title>
+    <title>takos</title>
+    <meta
+      name="description"
+      content="takos - ActivityPub で Web 自主するためのソフトウェア"
+    />
   </head>
   <body>
     <div id="root"></div>

--- a/app/client/index.html
+++ b/app/client/index.html
@@ -9,6 +9,7 @@
       name="description"
       content="takos - ActivityPub で Web 自主するためのソフトウェア"
     />
+    <meta name="theme-color" content="#181818" />
   </head>
   <body>
     <div id="root"></div>

--- a/app/client/src/App.css
+++ b/app/client/src/App.css
@@ -18,11 +18,11 @@ body {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   background-color: #ffffff;
-  color: #1a1a1a;
+  color: #181818;
 }
 
 html.dark body {
-  background-color: #1a1a1a;
+  background-color: #181818;
   color: #f3f4f6;
 }
 

--- a/app/client/src/App.css
+++ b/app/client/src/App.css
@@ -17,6 +17,11 @@ body {
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  background-color: #ffffff;
+  color: #1a1a1a;
+}
+
+html.dark body {
   background-color: #1a1a1a;
   color: #f3f4f6;
 }

--- a/app/client/src/components/LoginForm.tsx
+++ b/app/client/src/components/LoginForm.tsx
@@ -48,9 +48,9 @@ export function LoginForm(props: LoginFormProps) {
   };
 
   return (
-    <div class="min-h-screen flex flex-col bg-[#181818] text-gray-100">
+    <div class="min-h-screen flex flex-col bg-gray-50 text-gray-900 dark:bg-[#181818] dark:text-gray-100">
       <main class="flex-grow flex items-center justify-center px-4 py-12">
-        <div class="w-full max-w-md bg-[#212121] p-8 rounded-lg shadow-xl">
+        <div class="w-full max-w-md bg-white dark:bg-[#212121] p-8 rounded-lg shadow-xl">
           <div class="mb-8 text-center">
             <h2 class="text-3xl font-semibold mb-2 text-white">ようこそ</h2>
             <p class="text-gray-400">
@@ -77,7 +77,7 @@ export function LoginForm(props: LoginFormProps) {
                 id="password"
                 value={password()}
                 onInput={(e) => setPassword(e.currentTarget.value)}
-                class="w-full px-4 py-3 bg-gray-700 border border-gray-600 rounded-md text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 placeholder-gray-500 transition-colors"
+                class="w-full px-4 py-3 bg-gray-50 border border-gray-300 rounded-md text-gray-900 placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition-colors dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100"
                 disabled={isLoading()}
                 placeholder="パスワードを入力"
                 required
@@ -123,7 +123,7 @@ export function LoginForm(props: LoginFormProps) {
         </div>
       </main>
 
-      <footer class="py-6 border-t border-gray-700">
+      <footer class="py-6 border-t border-gray-300 dark:border-gray-700">
         <div class="container mx-auto px-4 text-center">
           <p class="text-gray-500 text-sm">
             © 2023 takos. All rights reserved.

--- a/app/client/src/components/ThemeToggle.tsx
+++ b/app/client/src/components/ThemeToggle.tsx
@@ -1,0 +1,68 @@
+import { createSignal, onMount } from "solid-js";
+
+export default function ThemeToggle() {
+  const [dark, setDark] = createSignal(true);
+
+  onMount(() => {
+    const stored = localStorage.getItem("theme");
+    if (stored === "light") {
+      setDark(false);
+      document.documentElement.classList.remove("dark");
+    }
+  });
+
+  const toggle = () => {
+    const next = !dark();
+    setDark(next);
+    if (next) {
+      document.documentElement.classList.add("dark");
+      localStorage.setItem("theme", "dark");
+    } else {
+      document.documentElement.classList.remove("dark");
+      localStorage.setItem("theme", "light");
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      class="p-2 rounded hover:bg-gray-700/70"
+      aria-label="toggle theme"
+      onClick={toggle}
+    >
+      {dark()
+        ? (
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            class="h-5 w-5"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M12 3v1m0 16v1m8.66-8.66h-1m-16 0H3m15.07 6.07l-.71-.71M6.64 6.64l-.71-.71m0 12.73l.71-.71M17.36 6.64l.71-.71M12 8a4 4 0 100 8 4 4 0 000-8z"
+            />
+          </svg>
+        )
+        : (
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            class="h-5 w-5"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z"
+            />
+          </svg>
+        )}
+    </button>
+  );
+}

--- a/app/client/src/components/header/header.tsx
+++ b/app/client/src/components/header/header.tsx
@@ -5,6 +5,7 @@ import {
   selectedExtensionState,
 } from "../../states/extensions.ts";
 import { For, onMount } from "solid-js";
+import ThemeToggle from "../ThemeToggle.tsx";
 
 export default function ChatHeader() {
   const setSelectedApp = useSetAtom(selectedAppState);
@@ -71,6 +72,9 @@ export default function ChatHeader() {
               </li>
             )}
           </For>
+          <li class="l-header__ul-item">
+            <ThemeToggle />
+          </li>
         </ul>
       </header>
     </>

--- a/app/client/tailwind.config.ts
+++ b/app/client/tailwind.config.ts
@@ -1,4 +1,4 @@
-import type { Config } from "tailwindcss";
+import type { Config } from "npm:tailwindcss";
 
 export default {
   darkMode: "class",
@@ -7,7 +7,11 @@ export default {
     "./src/**/*.{ts,tsx,html}",
   ],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        base: "#181818",
+      },
+    },
   },
   plugins: [],
 } satisfies Config;

--- a/app/client/tailwind.config.ts
+++ b/app/client/tailwind.config.ts
@@ -1,0 +1,13 @@
+import type { Config } from "tailwindcss";
+
+export default {
+  darkMode: "class",
+  content: [
+    "./index.html",
+    "./src/**/*.{ts,tsx,html}",
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+} satisfies Config;


### PR DESCRIPTION
## Summary
- support dark/light themes via Tailwind config
- simplify login page styling
- add theme toggle button to header
- update default HTML metadata

## Testing
- `deno fmt app/client/src/components/ThemeToggle.tsx app/client/src/components/header/header.tsx app/client/src/components/LoginForm.tsx app/client/src/App.css app/client/tailwind.config.ts app/client/index.html`
- `deno check app/client/src/components/ThemeToggle.tsx` *(fails: Relative import path error)*

------
https://chatgpt.com/codex/tasks/task_e_684ef74b5dd48328aa87c159e7a60773