### PR TITLE
Fix logout cookie for registry

### DIFF
--- a/app/registry/index.ts
+++ b/app/registry/index.ts
@@ -221,7 +221,8 @@ app.post("/api/login", async (c) => {
       { ok: true },
       {
         headers: {
-          "Set-Cookie": `session=${id}; HttpOnly; Path=/; Max-Age=3600`,
+          "Set-Cookie":
+            `session=${id}; HttpOnly; Path=/; Max-Age=3600; SameSite=Lax`,
         },
       },
     );
@@ -237,7 +238,11 @@ app.post("/api/logout", async (c) => {
   }
   return c.json(
     { ok: true },
-    { headers: { "Set-Cookie": "session=; HttpOnly; Path=/; Max-Age=0" } },
+    {
+      headers: {
+        "Set-Cookie": "session=; HttpOnly; Path=/; Max-Age=0; SameSite=Lax",
+      },
+    },
   );
 });
 


### PR DESCRIPTION
## Summary
- set `SameSite=Lax` on session cookie in registry login
- include the same `SameSite` attribute when clearing the cookie at logout

## Testing
- `deno test -A` *(fails: JSR package manifest for '@std/assert' failed to load)*

------
https://chatgpt.com/codex/tasks/task_e_684efefa357c8328ad20778cd83afaf5