### PR TITLE
Serve registry downloads under /api

### DIFF
--- a/app/registry/README.md
+++ b/app/registry/README.md
@@ -23,7 +23,7 @@
     レコードとして追加してから実行します
 - `GET /api/domains` - 登録済みドメイン一覧を取得
 - `POST /api/packages` - パッケージ登録（ドメイン確認済みが必要）
-- `GET /<file>` - `.takopack` アーカイブのダウンロード
+- `GET /api/<file>` - `.takopack` アーカイブのダウンロード
 
 ## サーバーの起動方法
 

--- a/app/registry/index.ts
+++ b/app/registry/index.ts
@@ -498,7 +498,7 @@ app.post("/api/packages", auth, async (c) => {
       .join("");
     const filename = `${identifier}-${version}.takopack`;
     await Deno.writeFile(join(rootDir, filename), bytes);
-    const downloadUrl = `/${filename}`;
+    const downloadUrl = `/api/${filename}`;
     await Package.create({
       identifier,
       name,
@@ -545,7 +545,7 @@ app.get("/_takopack/packages/:id", async (c) => {
   });
 });
 
-app.get("/:file", async (c) => {
+app.get("/api/:file", async (c) => {
   const file = c.req.param("file");
   const path = join(rootDir, file);
   try {


### PR DESCRIPTION
## Summary
- move `.takopack` archive download route to `/api/:file`
- update `downloadUrl` in package creation
- document new endpoint

## Testing
- `deno test -A` *(fails: JSR package manifest failed to load)*

------
https://chatgpt.com/codex/tasks/task_e_684f0981231083289e831b4abd658a5a