### PR TITLE
Add registry base URL env

### DIFF
--- a/app/registry/README.md
+++ b/app/registry/README.md
@@ -37,6 +37,8 @@ deno task start
 `REGISTRY_PASS` を設定すると `/api/login` で取得するセッションに利用されます。
 このセッションはドメイン登録とパッケージ公開の際だけ必要です。
 メール認証に使用する確認リンクは `VERIFY_BASE_URL` 環境変数で生成されます。
+パッケージのダウンロードURLは `REGISTRY_BASE_URL`（デフォルト
+`http://localhost:8080`）で指定したドメインを用いて絶対URLとして保存されます。
 SMTP 設定は `SMTP_HOST`、`SMTP_PORT`、`SMTP_USER`、`SMTP_PASS`、`SMTP_FROM`
 を用意すると送信に利用されます。これらが未設定の場合は確認リンクが
 コンソールに表示されるだけです。

--- a/app/registry/index.ts
+++ b/app/registry/index.ts
@@ -88,6 +88,7 @@ app.use("/api/domains/*", auth);
 app.use("/api/domains", auth);
 
 const rootDir = env["REGISTRY_DIR"] ?? "./registry";
+const registryBaseUrl = env["REGISTRY_BASE_URL"] ?? "http://localhost:8080";
 await ensureDir(rootDir);
 const uiDir = join(
   dirname(fromFileUrl(import.meta.url)),
@@ -498,7 +499,7 @@ app.post("/api/packages", auth, async (c) => {
       .join("");
     const filename = `${identifier}-${version}.takopack`;
     await Deno.writeFile(join(rootDir, filename), bytes);
-    const downloadUrl = `/api/${filename}`;
+    const downloadUrl = `${registryBaseUrl}/api/${filename}`;
     await Package.create({
       identifier,
       name,


### PR DESCRIPTION
## Summary
- make package download URLs absolute using `REGISTRY_BASE_URL`
- document the new `REGISTRY_BASE_URL` env var

## Testing
- `deno task -c packages/registry/deno.json test` *(fails: JSR package manifest failed to load)*

------
https://chatgpt.com/codex/tasks/task_e_684f19394154832899a47a57a9647f14