### PR TITLE
Enable registry extension management

### DIFF
--- a/app/api/.env
+++ b/app/api/.env
@@ -2,3 +2,4 @@ MONGO_URI=mongodb://localhost:27017/takos-hono
 hashedPassword=dda47e55945d0a9b8a81cdb2abac13b18698a3a1b19252013f5a9fe3fa0fb340
 salt=88fffa6cabe7f4ae67fb0d1ba8eab619
 ACTIVITYPUB_DOMAIN=dev.takos.jp
+REGISTRY_URL=http://localhost:8080/_takopack

--- a/app/api/deno.json
+++ b/app/api/deno.json
@@ -5,6 +5,8 @@
     "@std/fs": "jsr:@std/fs@^1.0.18",
     "@std/path": "jsr:@std/path@^1.1.0",
     "@takopack/builder": "jsr:@takopack/builder@^4.0.1",
+    "@takopack/registry": "../../packages/registry/mod.ts",
+    "@takopack/unpack": "../../packages/unpack/mod.ts",
     "hono": "npm:hono@^4.7.11",
     "mongoose": "npm:mongoose@^8.15.1",
     "zod": "npm:zod@^3.25.56"

--- a/app/api/events/extensions.ts
+++ b/app/api/events/extensions.ts
@@ -4,6 +4,7 @@ import { unpackTakoPack } from "../../../packages/unpack/mod.ts";
 import {
   fetchPackageInfo,
   downloadAndUnpack,
+  fetchRegistryIndex,
   searchRegistry,
 } from "../../../packages/registry/mod.ts";
 import { Extension } from "../models/extension.ts";
@@ -59,7 +60,13 @@ eventManager.add(
   async (c, { q, limit } = {}) => {
     const url = c.env.REGISTRY_URL;
     if (!url) throw new Error("REGISTRY_URL not configured");
-    const { index } = await searchRegistry(url, { q, limit });
+    if (q) {
+      const searchUrl = url.endsWith("/") ? `${url}search` : `${url}/search`;
+      const { index } = await searchRegistry(searchUrl, { q, limit });
+      return index;
+    }
+    const indexUrl = url.endsWith("/") ? `${url}index.json` : `${url}/index.json`;
+    const { index } = await fetchRegistryIndex(indexUrl);
     return index;
   },
 );

--- a/app/api/events/extensions.ts
+++ b/app/api/events/extensions.ts
@@ -1,6 +1,11 @@
 import { z } from "zod";
 import { eventManager } from "../eventManager.ts";
 import { unpackTakoPack } from "../../../packages/unpack/mod.ts";
+import {
+  fetchPackageInfo,
+  downloadAndUnpack,
+  searchRegistry,
+} from "../../../packages/registry/mod.ts";
 import { Extension } from "../models/extension.ts";
 import { getRuntime, loadExtension } from "../utils/extensionsRuntime.ts";
 
@@ -43,6 +48,55 @@ eventManager.add(
       icon: result.icon,
     });
 
+    return { success: true };
+  },
+);
+
+eventManager.add(
+  "takos",
+  "extensions:search",
+  z.object({ q: z.string().optional(), limit: z.number().optional() }).optional(),
+  async (c, { q, limit } = {}) => {
+    const url = c.env.REGISTRY_URL;
+    if (!url) throw new Error("REGISTRY_URL not configured");
+    const { index } = await searchRegistry(url, { q, limit });
+    return index;
+  },
+);
+
+eventManager.add(
+  "takos",
+  "extensions:install",
+  z.object({ id: z.string(), registry: z.string().url().optional() }),
+  async (c, { id, registry }) => {
+    const url = registry ?? c.env.REGISTRY_URL;
+    if (!url) throw new Error("REGISTRY_URL not configured");
+    const { pkg } = await fetchPackageInfo(url, id);
+    if (!pkg) throw new Error("Package not found");
+    const result = await downloadAndUnpack(pkg);
+    const manifest = typeof result.manifest === "string"
+      ? JSON.parse(result.manifest)
+      : result.manifest;
+    await Extension.findOneAndUpdate(
+      { identifier: manifest.identifier },
+      {
+        identifier: manifest.identifier,
+        manifest,
+        server: result.server,
+        client: result.client,
+        ui: result.ui,
+        icon: result.icon,
+      },
+      { upsert: true },
+    );
+    await loadExtension({
+      identifier: manifest.identifier,
+      manifest,
+      server: result.server,
+      client: result.client,
+      ui: result.ui,
+      icon: result.icon,
+    });
     return { success: true };
   },
 );

--- a/app/api/index.ts
+++ b/app/api/index.ts
@@ -29,4 +29,5 @@ export interface Env {
   hashedPassword: string;
   salt: string;
   ACTIVITYPUB_DOMAIN: string;
+  REGISTRY_URL?: string;
 }

--- a/app/client/src/components/DashBoard.tsx
+++ b/app/client/src/components/DashBoard.tsx
@@ -6,8 +6,7 @@ import {
   onMount,
   Show,
 } from "solid-js";
-import ExtensionUpload from "./ExtensionUpload.tsx";
-import ExtensionRegistry from "./ExtensionRegistry.tsx";
+import ExtensionManager from "./ExtensionManager.tsx";
 
 // アカウントデータの型定義
 type Account = {
@@ -823,13 +822,9 @@ export function Dashboard() {
               <NotificationsContent isMobileView={false} />
             </div>
 
-            {/* Extension upload */}
+            {/* Extensions */}
             <div class="bg-[#181818]/90 rounded-lg shadow-md p-4 min-h-[600px]">
-              <ExtensionUpload />
-            </div>
-            {/* Extension registry */}
-            <div class="bg-[#181818]/90 rounded-lg shadow-md p-4 min-h-[600px]">
-              <ExtensionRegistry />
+              <ExtensionManager />
             </div>
           </div>
         </div>

--- a/app/client/src/components/DashBoard.tsx
+++ b/app/client/src/components/DashBoard.tsx
@@ -7,6 +7,7 @@ import {
   Show,
 } from "solid-js";
 import ExtensionUpload from "./ExtensionUpload.tsx";
+import ExtensionRegistry from "./ExtensionRegistry.tsx";
 
 // アカウントデータの型定義
 type Account = {
@@ -825,6 +826,10 @@ export function Dashboard() {
             {/* Extension upload */}
             <div class="bg-[#181818]/90 rounded-lg shadow-md p-4 min-h-[600px]">
               <ExtensionUpload />
+            </div>
+            {/* Extension registry */}
+            <div class="bg-[#181818]/90 rounded-lg shadow-md p-4 min-h-[600px]">
+              <ExtensionRegistry />
             </div>
           </div>
         </div>

--- a/app/client/src/components/ExtensionManager.tsx
+++ b/app/client/src/components/ExtensionManager.tsx
@@ -1,0 +1,13 @@
+import ExtensionUpload from "./ExtensionUpload.tsx";
+import ExtensionRegistry from "./ExtensionRegistry.tsx";
+
+export default function ExtensionManager() {
+  return (
+    <div>
+      <h3 class="text-lg mb-2">拡張機能</h3>
+      <ExtensionUpload hideHeader />
+      <hr class="my-4 border-gray-700" />
+      <ExtensionRegistry hideHeader />
+    </div>
+  );
+}

--- a/app/client/src/components/ExtensionRegistry.tsx
+++ b/app/client/src/components/ExtensionRegistry.tsx
@@ -9,7 +9,11 @@ interface PackageInfo {
   sha256?: string;
 }
 
-export default function ExtensionRegistry() {
+interface Props {
+  hideHeader?: boolean;
+}
+
+export default function ExtensionRegistry(props: Props = {}) {
   const [packages, setPackages] = createSignal<PackageInfo[]>([]);
   const [query, setQuery] = createSignal("");
 
@@ -51,7 +55,7 @@ export default function ExtensionRegistry() {
 
   return (
     <div>
-      <h3 class="text-lg mb-2">Registry</h3>
+      {!props.hideHeader && <h3 class="text-lg mb-2">Registry</h3>}
       <input
         type="text"
         value={query()}

--- a/app/client/src/components/ExtensionRegistry.tsx
+++ b/app/client/src/components/ExtensionRegistry.tsx
@@ -1,0 +1,77 @@
+import { createSignal, For, onMount } from "solid-js";
+
+interface PackageInfo {
+  identifier: string;
+  name: string;
+  version: string;
+  description?: string;
+  downloadUrl: string;
+  sha256?: string;
+}
+
+export default function ExtensionRegistry() {
+  const [packages, setPackages] = createSignal<PackageInfo[]>([]);
+  const [query, setQuery] = createSignal("");
+
+  const fetchPackages = async (q = "") => {
+    const body = {
+      events: [
+        {
+          identifier: "takos",
+          eventId: "extensions:search",
+          payload: q ? { q } : {},
+        },
+      ],
+    };
+    const res = await fetch("/api/event", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    if (res.ok) {
+      const data = await res.json();
+      setPackages(data[0]?.result?.packages ?? []);
+    }
+  };
+
+  const install = async (id: string) => {
+    const body = {
+      events: [
+        { identifier: "takos", eventId: "extensions:install", payload: { id } },
+      ],
+    };
+    await fetch("/api/event", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+  };
+
+  onMount(() => fetchPackages());
+
+  return (
+    <div>
+      <h3 class="text-lg mb-2">Registry</h3>
+      <input
+        type="text"
+        value={query()}
+        onInput={(e) => setQuery(e.currentTarget.value)}
+        onKeyDown={(e) => e.key === "Enter" && fetchPackages(query())}
+        class="border px-2 py-1 mb-2 bg-transparent"
+      />
+      <ul class="space-y-1">
+        <For each={packages()}>{(pkg) => (
+          <li class="flex justify-between items-center">
+            <span>{pkg.name}</span>
+            <button
+              class="text-sm text-blue-500 underline"
+              onClick={() => install(pkg.identifier)}
+            >
+              Install
+            </button>
+          </li>
+        )}</For>
+      </ul>
+    </div>
+  );
+}

--- a/app/client/src/components/ExtensionRegistry.tsx
+++ b/app/client/src/components/ExtensionRegistry.tsx
@@ -17,8 +17,10 @@ export default function ExtensionRegistry(props: Props = {}) {
   const [packages, setPackages] = createSignal<PackageInfo[]>([]);
   const [installed, setInstalled] = createSignal<string[]>([]);
   const [query, setQuery] = createSignal("");
+  const [isLoading, setIsLoading] = createSignal(false);
 
   const fetchPackages = async (q = "") => {
+    setIsLoading(true);
     const body = {
       events: [
         {
@@ -36,7 +38,10 @@ export default function ExtensionRegistry(props: Props = {}) {
     if (res.ok) {
       const data = await res.json();
       setPackages(data[0]?.result?.packages ?? []);
+    } else {
+      setPackages([]);
     }
+    setIsLoading(false);
   };
 
   const fetchInstalled = async () => {
@@ -81,41 +86,50 @@ export default function ExtensionRegistry(props: Props = {}) {
   return (
     <div>
       {!props.hideHeader && <h3 class="text-lg mb-2">Registry</h3>}
-      <div class="mb-2">
+      <div class="mb-2 flex gap-2">
         <input
           type="text"
           placeholder="Search extensions"
           value={query()}
           onInput={(e) => setQuery(e.currentTarget.value)}
           onKeyDown={(e) => e.key === "Enter" && fetchPackages(query())}
-          class="border px-2 py-1 bg-transparent w-full"
+          class="flex-1 border px-2 py-1 bg-transparent"
         />
+        <button
+          class="border px-2 py-1"
+          onClick={() => fetchPackages(query())}
+          disabled={isLoading()}
+        >
+          Search
+        </button>
       </div>
       <ul class="space-y-2 max-h-96 overflow-y-auto">
-        <For each={packages()}>
-          {(pkg) => (
-            <li class="p-2 border border-gray-700 rounded">
-              <div class="flex justify-between">
-                <div class="pr-2">
-                  <p class="font-semibold">{pkg.name}</p>
-                  <p class="text-xs text-gray-400">{pkg.description}</p>
-                  <p class="text-xs text-gray-500">v{pkg.version}</p>
+        <Show when={packages().length > 0} fallback={<li>No packages found</li>}>
+          <For each={packages()}>
+            {(pkg) => (
+              <li class="p-2 border border-gray-700 rounded">
+                <div class="flex justify-between">
+                  <div class="pr-2">
+                    <p class="font-semibold">{pkg.name}</p>
+                    <p class="text-xs text-gray-400">{pkg.description}</p>
+                    <p class="text-xs text-gray-500">v{pkg.version}</p>
+                  </div>
+                  <div class="flex items-start">
+                    <button
+                      class="text-sm text-blue-500 underline disabled:text-gray-500"
+                      disabled={installed().includes(pkg.identifier)}
+                      onClick={() => install(pkg.identifier)}
+                    >
+                      {installed().includes(pkg.identifier)
+                        ? "Installed"
+                        : "Install"}
+                    </button>
+                  </div>
                 </div>
-                <div class="flex items-start">
-                  <button
-                    class="text-sm text-blue-500 underline disabled:text-gray-500"
-                    disabled={installed().includes(pkg.identifier)}
-                    onClick={() => install(pkg.identifier)}
-                  >
-                    {installed().includes(pkg.identifier)
-                      ? "Installed"
-                      : "Install"}
-                  </button>
-                </div>
-              </div>
-            </li>
-          )}
-        </For>
+              </li>
+            )}
+          </For>
+        </Show>
       </ul>
     </div>
   );

--- a/app/client/src/components/ExtensionUpload.tsx
+++ b/app/client/src/components/ExtensionUpload.tsx
@@ -1,6 +1,10 @@
 import { createSignal, For, onMount } from "solid-js";
 
-export default function ExtensionUpload() {
+interface Props {
+  hideHeader?: boolean;
+}
+
+export default function ExtensionUpload(props: Props = {}) {
   const [message, setMessage] = createSignal("");
   const [extensions, setExtensions] = createSignal<
     { identifier: string; name: string; icon?: string }[]
@@ -57,7 +61,7 @@ export default function ExtensionUpload() {
 
   return (
     <div>
-      <h3 class="text-lg mb-2">Upload Extension</h3>
+      {!props.hideHeader && <h3 class="text-lg mb-2">Upload Extension</h3>}
       <input type="file" onChange={handleChange} />
       <p>{message()}</p>
       <ul class="mt-3 space-y-2">


### PR DESCRIPTION
## Summary
- add `REGISTRY_URL` env
- implement `extensions:search` and `extensions:install` events
- expose registry UI in dashboard
- add simple registry browser component

## Testing
- `deno test -A` *(fails: JSR package manifest for '@std/assert' failed to load)*

------
https://chatgpt.com/codex/tasks/task_e_684f1cf5bf588328982c2665569f8b23