### PR TITLE
Add icon support to Takopack registry

### DIFF
--- a/app/registry/index.ts
+++ b/app/registry/index.ts
@@ -28,6 +28,7 @@ interface PackageDoc extends mongoose.Document {
   name: string;
   version: string;
   description?: string;
+  icon?: string;
   downloadUrl: string;
   sha256?: string;
   createdAt?: Date;
@@ -107,6 +108,7 @@ const Package = mongoose.model(
     name: { type: String, required: true },
     version: { type: String, required: true },
     description: String,
+    icon: String,
     downloadUrl: { type: String, required: true },
     sha256: String,
   }, { timestamps: true }),
@@ -368,6 +370,7 @@ async function getIndex(): Promise<{
       name: p.name,
       version: p.version,
       description: p.description,
+      icon: p.icon,
       downloadUrl: p.downloadUrl,
       sha256: p.sha256,
     })),
@@ -431,6 +434,7 @@ app.get("/_takopack/search", async (c) => {
       name: p.name,
       version: p.version,
       description: p.description,
+      icon: p.icon,
       downloadUrl: p.downloadUrl,
       sha256: p.sha256,
     })),
@@ -505,6 +509,7 @@ app.post("/api/packages", auth, async (c) => {
       name,
       version,
       description,
+      icon: result.icon,
       downloadUrl,
       sha256,
     });

--- a/app/registry_ui/src/components/PackageBrowser.tsx
+++ b/app/registry_ui/src/components/PackageBrowser.tsx
@@ -261,9 +261,18 @@ export default function PackageBrowser() {
             <div class="p-6 border-b border-gray-700">
               <div class="flex items-center justify-between">
                 <div class="flex items-center space-x-4">
-                  <div class="w-16 h-16 bg-gradient-to-br from-purple-500 to-blue-600 rounded-xl flex items-center justify-center text-white font-bold text-2xl">
-                    {selectedPackage()?.name.charAt(0).toUpperCase()}
-                  </div>
+                  <Show
+                    when={selectedPackage()?.icon}
+                    fallback={
+                      <div class="w-16 h-16 bg-gradient-to-br from-purple-500 to-blue-600 rounded-xl flex items-center justify-center text-white font-bold text-2xl">
+                        {selectedPackage()?.name.charAt(0).toUpperCase()}
+                      </div>
+                    }
+                  >
+                    {(icon) => (
+                      <img src={icon()} alt="icon" class="w-16 h-16 rounded-xl" />
+                    )}
+                  </Show>
                   <div>
                     <h3 class="text-2xl font-bold text-gray-100">
                       {selectedPackage()?.name}

--- a/app/registry_ui/src/components/PackageCard.tsx
+++ b/app/registry_ui/src/components/PackageCard.tsx
@@ -5,6 +5,7 @@ export interface PackageInfo {
   name: string;
   version: string;
   description?: string;
+  icon?: string;
   downloadUrl: string;
   sha256?: string;
   createdAt?: string;
@@ -44,9 +45,18 @@ export default function PackageCard(props: PackageCardProps) {
     <div class="group bg-gray-800/50 backdrop-blur-sm border border-gray-700/50 rounded-xl p-6 hover:border-purple-500/30 hover:bg-gray-800/70 transition-all duration-300 hover:shadow-lg hover:shadow-purple-500/10 animate-fade-in">
       <div class="flex items-start justify-between mb-4">
         <div class="flex items-center space-x-3">
-          <div class="w-12 h-12 bg-gradient-to-br from-purple-500 to-blue-600 rounded-lg flex items-center justify-center text-white font-semibold text-lg shadow-lg">
-            {getInitials(props.package.name)}
-          </div>
+          <Show
+            when={props.package.icon}
+            fallback={
+              <div class="w-12 h-12 bg-gradient-to-br from-purple-500 to-blue-600 rounded-lg flex items-center justify-center text-white font-semibold text-lg shadow-lg">
+                {getInitials(props.package.name)}
+              </div>
+            }
+          >
+            {(icon) => (
+              <img src={icon()} alt="icon" class="w-12 h-12 rounded-lg shadow-lg" />
+            )}
+          </Show>
           <div class="flex-1 min-w-0">
             <h3 class="text-lg font-semibold text-gray-100 truncate group-hover:text-purple-300 transition-colors">
               {props.package.name}

--- a/packages/registry/README.md
+++ b/packages/registry/README.md
@@ -15,6 +15,7 @@
       "name": "Foo Extension",
       "version": "1.0.0",
       "description": "サンプル拡張",
+      "icon": "data:image/png;base64,......",
       "downloadUrl": "https://registry.example.com/com.example.foo-1.0.0.takopack",
       "sha256": "..." // 任意の整合性ハッシュ
     }

--- a/packages/registry/mod.test.ts
+++ b/packages/registry/mod.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "jsr:@std/assert@1.0.13";
+import { assert, assertEquals } from "jsr:@std/assert@1.0.13";
 import { BlobWriter, TextReader, ZipWriter } from "jsr:@zip-js/zip-js@2.7.62";
 import { serve } from "jsr:@std/http@1.0.6";
 import {
@@ -44,6 +44,7 @@ Deno.test("fetch index and download", async () => {
             identifier: "com.test",
             name: "Test",
             version: "0.1.0",
+            icon: "data:image/png;base64,aWNvbg==",
             downloadUrl: `http://localhost:${
               (server.listener.addr as Deno.NetAddr).port
             }/test.takopack`,
@@ -68,6 +69,7 @@ Deno.test("fetch index and download", async () => {
   const pkg = index.packages[0];
   const result = await downloadAndUnpack(pkg);
   assertEquals(result.manifest.name, "test");
+  assert(result.icon && result.icon.startsWith("data:image/png;base64,"));
 
   // second call with If-None-Match should return null
   const cached = await fetchRegistryIndex(
@@ -90,8 +92,8 @@ Deno.test("search registry", async () => {
     if (url.pathname === "/_takopack/search") {
       const q = url.searchParams.get("q") ?? "";
       const list = [
-        { identifier: "com.foo", name: "Foo", version: "1" },
-        { identifier: "com.bar", name: "Bar", version: "1" },
+        { identifier: "com.foo", name: "Foo", version: "1", icon: "i" },
+        { identifier: "com.bar", name: "Bar", version: "1", icon: "i" },
       ];
       const result = list.filter((p) =>
         (p.name + p.identifier).toLowerCase().includes(q.toLowerCase())
@@ -131,7 +133,7 @@ Deno.test("fetch package info", async () => {
     const url = new URL(req.url);
     if (url.pathname === "/_takopack/packages/com.test") {
       return new Response(
-        JSON.stringify({ identifier: "com.test", version: "1" }),
+        JSON.stringify({ identifier: "com.test", version: "1", icon: "x" }),
       );
     }
     return new Response("Not found", { status: 404 });

--- a/packages/registry/mod.ts
+++ b/packages/registry/mod.ts
@@ -5,6 +5,8 @@ export interface RegistryPackage {
   name: string;
   version: string;
   description?: string;
+  /** Data URL for icon image if available */
+  icon?: string;
   downloadUrl: string;
   sha256?: string;
 }


### PR DESCRIPTION
## Summary
- support icon field in registry package model and API
- include package icons when publishing packs
- display icons in registry UI
- document icon field in registry README
- adjust registry client types and tests

## Testing
- `deno test -A packages/registry/mod.test.ts` *(fails: JSR package manifest failed to load)*
- `deno test -A packages/unpack/mod.test.ts` *(fails: JSR package manifest failed to load)*
- `deno test -A packages/builder/src/generator.test.ts`
- `deno test -A --unstable-worker-options packages/runtime/mod.test.ts` *(fails: failed loading @types/node)*

------
https://chatgpt.com/codex/tasks/task_e_684f542061f483289f49f41cec3e2bb9