### PR TITLE
Add buttons for per-API tests

### DIFF
--- a/examples/api-test-extension/README.md
+++ b/examples/api-test-extension/README.md
@@ -1,0 +1,12 @@
+# API Test Extension
+
+This example extension provides a quick way to verify each Takopack runtime API.
+The UI page lists buttons for the APIs exposed to the server, client and UI
+layers individually. Click a button to run that API call and see the returned
+value in the output panel.
+
+Use the provided build task to generate a `.takopack` archive:
+
+```bash
+deno task build
+```

--- a/examples/api-test-extension/deno.json
+++ b/examples/api-test-extension/deno.json
@@ -1,0 +1,23 @@
+{
+  "tasks": {
+    "dev": "deno run --watch main.ts",
+    "build": "deno run -A -r ../../packages/cli/cli.ts build"
+  },
+  "nodeModulesDir": "auto",
+  "imports": {
+    "@takopack/builder": "../../packages/builder/mod.ts",
+    "@takopack/builder/src/api-helpers.ts": "../../packages/builder/src/api-helpers.ts",
+    "@takopack/builder/src/classes.ts": "../../packages/builder/src/classes.ts",
+    "@typescript-eslint/typescript-estree": "npm:@typescript-eslint/typescript-estree@8.18.0",
+    "@zip-js/zip-js": "jsr:@zip-js/zip-js@^2.7.62",
+    "@luca/esbuild-deno-loader": "jsr:@luca/esbuild-deno-loader@^0.11.1",
+    "esbuild": "npm:esbuild@0.20.2",
+    "@std/path": "jsr:@std/path@1",
+    "@std/fs": "jsr:@std/fs@1",
+    "@std/cli": "jsr:@std/cli@1"
+  },
+  "compilerOptions": {
+    "lib": ["deno.ns", "dom", "es2022"],
+    "strict": true
+  }
+}

--- a/examples/api-test-extension/src/client/api.ts
+++ b/examples/api-test-extension/src/client/api.ts
@@ -1,0 +1,69 @@
+import { ClientExtension } from "@takopack/builder/src/classes.ts";
+import { getTakosClientAPI } from "@takopack/builder/src/api-helpers.ts";
+
+export const ApiClient = new ClientExtension();
+
+async function testKv() {
+  const t = getTakosClientAPI();
+  await t?.kv.write("client:test", "ok");
+  const value = await t?.kv.read("client:test");
+  await t?.kv.delete("client:test");
+  return { value };
+}
+
+async function testCdn() {
+  const t = getTakosClientAPI();
+  await t?.cdn.write("client.txt", "hello", { cacheTTL: 0 });
+  const data = await t?.cdn.read("client.txt");
+  await t?.cdn.delete("client.txt");
+  return { data };
+}
+
+async function testEvents() {
+  const t = getTakosClientAPI();
+  let flag = false;
+  const unsub = t?.events.subscribe("clientPing", () => { flag = true; });
+  await t?.events.publish("clientPing", {});
+  unsub?.();
+  return { received: flag };
+}
+
+
+async function testExtensions() {
+  const t = getTakosClientAPI();
+  const ext = t?.extensions.get("com.example.api-test");
+  const api = await t?.activateExtension("com.example.api-test");
+  return { has: !!ext, activated: typeof api?.publish === "function" };
+}
+
+async function testFetch() {
+  const t = getTakosClientAPI();
+  const res = await t?.fetch("https://example.com");
+  return { ok: res?.ok ?? false };
+}
+
+/** @event("clientKv", { source: "ui" }) */
+ApiClient.onClientKv = async (): Promise<[number, Record<string, unknown>]> => {
+  return [200, await testKv()];
+};
+
+/** @event("clientCdn", { source: "ui" }) */
+ApiClient.onClientCdn = async (): Promise<[number, Record<string, unknown>]> => {
+  return [200, await testCdn()];
+};
+
+/** @event("clientEvents", { source: "ui" }) */
+ApiClient.onClientEvents = async (): Promise<[number, Record<string, unknown>]> => {
+  return [200, await testEvents()];
+};
+
+
+/** @event("clientExtensions", { source: "ui" }) */
+ApiClient.onClientExtensions = async (): Promise<[number, Record<string, unknown>]> => {
+  return [200, await testExtensions()];
+};
+
+/** @event("clientFetch", { source: "ui" }) */
+ApiClient.onClientFetch = async (): Promise<[number, Record<string, unknown>]> => {
+  return [200, await testFetch()];
+};

--- a/examples/api-test-extension/src/server/api.ts
+++ b/examples/api-test-extension/src/server/api.ts
@@ -1,0 +1,99 @@
+import { ServerExtension } from "@takopack/builder/src/classes.ts";
+import { getTakosServerAPI } from "@takopack/builder/src/api-helpers.ts";
+
+export const ApiServer = new ServerExtension();
+
+function getApi() {
+  return getTakosServerAPI();
+}
+
+async function testKv() {
+  const t = getApi();
+  await t?.kv.write("server:test", "ok");
+  const value = await t?.kv.read("server:test");
+  const list = await t?.kv.list();
+  await t?.kv.delete("server:test");
+  return { value, list };
+}
+
+async function testCdn() {
+  const t = getApi();
+  await t?.cdn.write("srv.txt", "hello", { cacheTTL: 0 });
+  const data = await t?.cdn.read("srv.txt");
+  const list = await t?.cdn.list();
+  await t?.cdn.delete("srv.txt");
+  return { data, list };
+}
+
+async function testEvents() {
+  const t = getApi();
+  let flag = false;
+  const unsub = t?.events.subscribe("srvPing", () => { flag = true; });
+  await t?.events.publish("srvPing", {});
+  unsub?.();
+  return { received: flag };
+}
+
+async function testActivityPub() {
+  const t = getApi();
+  await t?.activitypub.send("srv", { type: "Note" });
+  await t?.activitypub.read("id:srv");
+  await t?.activitypub.delete("id:srv");
+  await t?.activitypub.list("srv");
+  await t?.activitypub.actor.read("srv");
+  await t?.activitypub.actor.update("srv", "k", "v");
+  await t?.activitypub.actor.delete("srv", "k");
+  await t?.activitypub.follow("srv", "you");
+  await t?.activitypub.unfollow("srv", "you");
+  await t?.activitypub.listFollowers("srv");
+  await t?.activitypub.listFollowing("srv");
+  await t?.activitypub.pluginActor.create("bot", {});
+  await t?.activitypub.pluginActor.read("bot");
+  await t?.activitypub.pluginActor.update("bot", {});
+  await t?.activitypub.pluginActor.delete("bot");
+  await t?.activitypub.pluginActor.list();
+  return { ok: true };
+}
+
+async function testExtensions() {
+  const t = getApi();
+  const ext = t?.extensions.get("com.example.api-test");
+  const api = await t?.activateExtension("com.example.api-test");
+  return { has: !!ext, activated: typeof api?.publish === "function" };
+}
+
+async function testFetch() {
+  const t = getApi();
+  const res = await t?.fetch("https://example.com");
+  return { ok: res?.ok ?? false };
+}
+
+/** @event("serverKv", { source: "ui" }) */
+ApiServer.onServerKv = async (): Promise<[number, Record<string, unknown>]> => {
+  return [200, await testKv()];
+};
+
+/** @event("serverCdn", { source: "ui" }) */
+ApiServer.onServerCdn = async (): Promise<[number, Record<string, unknown>]> => {
+  return [200, await testCdn()];
+};
+
+/** @event("serverEvents", { source: "ui" }) */
+ApiServer.onServerEvents = async (): Promise<[number, Record<string, unknown>]> => {
+  return [200, await testEvents()];
+};
+
+/** @event("serverActivityPub", { source: "ui" }) */
+ApiServer.onServerActivityPub = async (): Promise<[number, Record<string, unknown>]> => {
+  return [200, await testActivityPub()];
+};
+
+/** @event("serverExtensions", { source: "ui" }) */
+ApiServer.onServerExtensions = async (): Promise<[number, Record<string, unknown>]> => {
+  return [200, await testExtensions()];
+};
+
+/** @event("serverFetch", { source: "ui" }) */
+ApiServer.onServerFetch = async (): Promise<[number, Record<string, unknown>]> => {
+  return [200, await testFetch()];
+};

--- a/examples/api-test-extension/src/ui/index.html
+++ b/examples/api-test-extension/src/ui/index.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>API Test</title>
+    <style>
+      section { margin-bottom: 1rem; }
+      button { margin: 2px; }
+    </style>
+  </head>
+  <body>
+    <h1>Takopack API Test</h1>
+    <section>
+      <h2>Server</h2>
+      <div id="server"></div>
+    </section>
+    <section>
+      <h2>Client</h2>
+      <div id="client"></div>
+    </section>
+    <section>
+      <h2>UI</h2>
+      <div id="ui"></div>
+    </section>
+    <pre id="output"></pre>
+    <script>
+      const serverTests = [
+        'serverKv',
+        'serverCdn',
+        'serverEvents',
+        'serverActivityPub',
+        'serverExtensions',
+        'serverFetch'
+      ];
+      const clientTests = [
+        'clientKv',
+        'clientCdn',
+        'clientEvents',
+        'clientExtensions',
+        'clientFetch'
+      ];
+      const uiTests = [
+        'uiKv',
+        'uiCdn',
+        'uiEvents',
+        'uiFetch',
+        'uiExtensions',
+        'uiUrl'
+      ];
+
+      function addButtons(container, tests, runner) {
+        tests.forEach(name => {
+          const b = document.createElement('button');
+          b.textContent = name;
+          b.onclick = () => runner(name);
+          container.appendChild(b);
+        });
+      }
+
+      async function runEvent(name) {
+        if (typeof takos === 'undefined') return;
+        const res = await takos.events.publish(name, {});
+        if (Array.isArray(res)) {
+          const [, body] = res;
+          print(name, body);
+        }
+      }
+
+      async function runUi(name) {
+        if (name === 'uiKv') {
+          await takos.kv.write('ui:test', 'ok');
+          const value = await takos.kv.read('ui:test');
+          await takos.kv.delete('ui:test');
+          print(name, { value });
+        } else if (name === 'uiCdn') {
+          await takos.cdn.write('ui.txt', 'hello', { cacheTTL: 0 });
+          const data = await takos.cdn.read('ui.txt');
+          await takos.cdn.delete('ui.txt');
+          print(name, { data });
+        } else if (name === 'uiEvents') {
+          let received = false;
+          const u = takos.events.subscribe('uiPing', () => { received = true; });
+          await takos.events.publish('uiPing', {});
+          u();
+          print(name, { received });
+        } else if (name === 'uiFetch') {
+          const res = await takos.fetch('https://example.com');
+          print(name, { ok: res.ok });
+        } else if (name === 'uiExtensions') {
+          const ext = takos.extensions.get('com.example.api-test');
+          const api = await takos.activateExtension('com.example.api-test');
+          print(name, { has: !!ext, activated: typeof api?.publish === 'function' });
+        } else if (name === 'uiUrl') {
+          const before = takos.getURL();
+          let changed = false;
+          const off = takos.changeURL(() => { changed = true; });
+          takos.pushURL('tmp', { showBar: false });
+          takos.setURL(before, { showBar: false });
+          off();
+          print(name, { before, changed, after: takos.getURL() });
+        }
+      }
+
+      function print(name, res) {
+        const out = document.getElementById('output');
+        out.textContent = name + '\n' + JSON.stringify(res, null, 2);
+      }
+
+      addButtons(document.getElementById('server'), serverTests, runEvent);
+      addButtons(document.getElementById('client'), clientTests, runEvent);
+      addButtons(document.getElementById('ui'), uiTests, runUi);
+    </script>
+  </body>
+</html>

--- a/examples/api-test-extension/takopack.config.ts
+++ b/examples/api-test-extension/takopack.config.ts
@@ -1,0 +1,50 @@
+import { defineConfig } from "../../packages/builder/mod.ts";
+
+export default defineConfig({
+  manifest: {
+    name: "API Test Extension",
+    identifier: "com.example.api-test",
+    version: "1.0.0",
+    description: "Runs a suite of API calls to verify Takopack runtime.",
+    permissions: [
+      "fetch:net",
+      "activitypub:send",
+      "activitypub:read",
+      "activitypub:receive:hook",
+      "activitypub:actor:read",
+      "activitypub:actor:write",
+      "plugin-actor:create",
+      "plugin-actor:read",
+      "plugin-actor:write",
+      "plugin-actor:delete",
+      "kv:read",
+      "kv:write",
+      "cdn:read",
+      "cdn:write",
+      "events:publish",
+      "events:subscribe",
+      "extensions:invoke",
+      "extensions:export",
+      "deno:read",
+      "deno:write",
+      "deno:net",
+      "deno:env",
+      "deno:run",
+      "deno:sys",
+      "deno:ffi",
+    ],
+  },
+
+  entries: {
+    server: ["src/server/api.ts"],
+    client: ["src/client/api.ts"],
+    ui: ["src/ui/index.html"],
+  },
+
+  build: {
+    target: "es2022",
+    dev: false,
+    analysis: true,
+    outDir: "dist",
+  },
+});


### PR DESCRIPTION
## Summary
- extend API test example with client code and per-API server handlers
- add UI buttons for each API in server, client and UI contexts
- wire up new client entry in takopack config
- trim unavailable ActivityPub client/UI tests and add URL helper checks

## Testing
- `deno task test` in `packages/unpack` *(fails: invalid peer certificate)*
- `deno test -A --unstable --unstable-worker-options` in `packages/runtime` *(fails to load @types/node)*
- `deno task test` in `packages/registry` *(fails to load JSR package manifest)*
- `deno task test` in `packages/builder` *(fails: invalid peer certificate)*

------
https://chatgpt.com/codex/tasks/task_e_684fdb91bddc83289f21f23c2f78965a