### PR TITLE
Improve API test UI readability

### DIFF
--- a/examples/api-test-extension/README.md
+++ b/examples/api-test-extension/README.md
@@ -1,0 +1,12 @@
+# API Test Extension
+
+This example extension provides a quick way to verify each Takopack runtime API.
+The UI page lists buttons for the APIs exposed to the server, client and UI
+layers individually. Click a button to run that API call and see the returned
+value in the output panel.
+
+Use the provided build task to generate a `.takopack` archive:
+
+```bash
+deno task build
+```

--- a/examples/api-test-extension/deno.json
+++ b/examples/api-test-extension/deno.json
@@ -1,0 +1,23 @@
+{
+  "tasks": {
+    "dev": "deno run --watch main.ts",
+    "build": "deno run -A -r ../../packages/cli/cli.ts build"
+  },
+  "nodeModulesDir": "auto",
+  "imports": {
+    "@takopack/builder": "../../packages/builder/mod.ts",
+    "@takopack/builder/src/api-helpers.ts": "../../packages/builder/src/api-helpers.ts",
+    "@takopack/builder/src/classes.ts": "../../packages/builder/src/classes.ts",
+    "@typescript-eslint/typescript-estree": "npm:@typescript-eslint/typescript-estree@8.18.0",
+    "@zip-js/zip-js": "jsr:@zip-js/zip-js@^2.7.62",
+    "@luca/esbuild-deno-loader": "jsr:@luca/esbuild-deno-loader@^0.11.1",
+    "esbuild": "npm:esbuild@0.20.2",
+    "@std/path": "jsr:@std/path@1",
+    "@std/fs": "jsr:@std/fs@1",
+    "@std/cli": "jsr:@std/cli@1"
+  },
+  "compilerOptions": {
+    "lib": ["deno.ns", "dom", "es2022"],
+    "strict": true
+  }
+}

--- a/examples/api-test-extension/deno.lock
+++ b/examples/api-test-extension/deno.lock
@@ -1,0 +1,324 @@
+{
+  "version": "5",
+  "specifiers": {
+    "npm:@typescript-eslint/typescript-estree@8.18.0": "8.18.0_typescript@5.7.3",
+    "npm:esbuild@0.20.2": "0.20.2"
+  },
+  "npm": {
+    "@esbuild/aix-ppc64@0.20.2": {
+      "integrity": "sha512-D+EBOJHXdNZcLJRBkhENNG8Wji2kgc9AZ9KiPr1JuZjsNtyHzrsfLRrY0tk2H2aoFu6RANO1y1iPPUCDYWkb5g==",
+      "os": ["aix"],
+      "cpu": ["ppc64"]
+    },
+    "@esbuild/android-arm64@0.20.2": {
+      "integrity": "sha512-mRzjLacRtl/tWU0SvD8lUEwb61yP9cqQo6noDZP/O8VkwafSYwZ4yWy24kan8jE/IMERpYncRt2dw438LP3Xmg==",
+      "os": ["android"],
+      "cpu": ["arm64"]
+    },
+    "@esbuild/android-arm@0.20.2": {
+      "integrity": "sha512-t98Ra6pw2VaDhqNWO2Oph2LXbz/EJcnLmKLGBJwEwXX/JAN83Fym1rU8l0JUWK6HkIbWONCSSatf4sf2NBRx/w==",
+      "os": ["android"],
+      "cpu": ["arm"]
+    },
+    "@esbuild/android-x64@0.20.2": {
+      "integrity": "sha512-btzExgV+/lMGDDa194CcUQm53ncxzeBrWJcncOBxuC6ndBkKxnHdFJn86mCIgTELsooUmwUm9FkhSp5HYu00Rg==",
+      "os": ["android"],
+      "cpu": ["x64"]
+    },
+    "@esbuild/darwin-arm64@0.20.2": {
+      "integrity": "sha512-4J6IRT+10J3aJH3l1yzEg9y3wkTDgDk7TSDFX+wKFiWjqWp/iCfLIYzGyasx9l0SAFPT1HwSCR+0w/h1ES/MjA==",
+      "os": ["darwin"],
+      "cpu": ["arm64"]
+    },
+    "@esbuild/darwin-x64@0.20.2": {
+      "integrity": "sha512-tBcXp9KNphnNH0dfhv8KYkZhjc+H3XBkF5DKtswJblV7KlT9EI2+jeA8DgBjp908WEuYll6pF+UStUCfEpdysA==",
+      "os": ["darwin"],
+      "cpu": ["x64"]
+    },
+    "@esbuild/freebsd-arm64@0.20.2": {
+      "integrity": "sha512-d3qI41G4SuLiCGCFGUrKsSeTXyWG6yem1KcGZVS+3FYlYhtNoNgYrWcvkOoaqMhwXSMrZRl69ArHsGJ9mYdbbw==",
+      "os": ["freebsd"],
+      "cpu": ["arm64"]
+    },
+    "@esbuild/freebsd-x64@0.20.2": {
+      "integrity": "sha512-d+DipyvHRuqEeM5zDivKV1KuXn9WeRX6vqSqIDgwIfPQtwMP4jaDsQsDncjTDDsExT4lR/91OLjRo8bmC1e+Cw==",
+      "os": ["freebsd"],
+      "cpu": ["x64"]
+    },
+    "@esbuild/linux-arm64@0.20.2": {
+      "integrity": "sha512-9pb6rBjGvTFNira2FLIWqDk/uaf42sSyLE8j1rnUpuzsODBq7FvpwHYZxQ/It/8b+QOS1RYfqgGFNLRI+qlq2A==",
+      "os": ["linux"],
+      "cpu": ["arm64"]
+    },
+    "@esbuild/linux-arm@0.20.2": {
+      "integrity": "sha512-VhLPeR8HTMPccbuWWcEUD1Az68TqaTYyj6nfE4QByZIQEQVWBB8vup8PpR7y1QHL3CpcF6xd5WVBU/+SBEvGTg==",
+      "os": ["linux"],
+      "cpu": ["arm"]
+    },
+    "@esbuild/linux-ia32@0.20.2": {
+      "integrity": "sha512-o10utieEkNPFDZFQm9CoP7Tvb33UutoJqg3qKf1PWVeeJhJw0Q347PxMvBgVVFgouYLGIhFYG0UGdBumROyiig==",
+      "os": ["linux"],
+      "cpu": ["ia32"]
+    },
+    "@esbuild/linux-loong64@0.20.2": {
+      "integrity": "sha512-PR7sp6R/UC4CFVomVINKJ80pMFlfDfMQMYynX7t1tNTeivQ6XdX5r2XovMmha/VjR1YN/HgHWsVcTRIMkymrgQ==",
+      "os": ["linux"],
+      "cpu": ["loong64"]
+    },
+    "@esbuild/linux-mips64el@0.20.2": {
+      "integrity": "sha512-4BlTqeutE/KnOiTG5Y6Sb/Hw6hsBOZapOVF6njAESHInhlQAghVVZL1ZpIctBOoTFbQyGW+LsVYZ8lSSB3wkjA==",
+      "os": ["linux"],
+      "cpu": ["mips64el"]
+    },
+    "@esbuild/linux-ppc64@0.20.2": {
+      "integrity": "sha512-rD3KsaDprDcfajSKdn25ooz5J5/fWBylaaXkuotBDGnMnDP1Uv5DLAN/45qfnf3JDYyJv/ytGHQaziHUdyzaAg==",
+      "os": ["linux"],
+      "cpu": ["ppc64"]
+    },
+    "@esbuild/linux-riscv64@0.20.2": {
+      "integrity": "sha512-snwmBKacKmwTMmhLlz/3aH1Q9T8v45bKYGE3j26TsaOVtjIag4wLfWSiZykXzXuE1kbCE+zJRmwp+ZbIHinnVg==",
+      "os": ["linux"],
+      "cpu": ["riscv64"]
+    },
+    "@esbuild/linux-s390x@0.20.2": {
+      "integrity": "sha512-wcWISOobRWNm3cezm5HOZcYz1sKoHLd8VL1dl309DiixxVFoFe/o8HnwuIwn6sXre88Nwj+VwZUvJf4AFxkyrQ==",
+      "os": ["linux"],
+      "cpu": ["s390x"]
+    },
+    "@esbuild/linux-x64@0.20.2": {
+      "integrity": "sha512-1MdwI6OOTsfQfek8sLwgyjOXAu+wKhLEoaOLTjbijk6E2WONYpH9ZU2mNtR+lZ2B4uwr+usqGuVfFT9tMtGvGw==",
+      "os": ["linux"],
+      "cpu": ["x64"]
+    },
+    "@esbuild/netbsd-x64@0.20.2": {
+      "integrity": "sha512-K8/DhBxcVQkzYc43yJXDSyjlFeHQJBiowJ0uVL6Tor3jGQfSGHNNJcWxNbOI8v5k82prYqzPuwkzHt3J1T1iZQ==",
+      "os": ["netbsd"],
+      "cpu": ["x64"]
+    },
+    "@esbuild/openbsd-x64@0.20.2": {
+      "integrity": "sha512-eMpKlV0SThJmmJgiVyN9jTPJ2VBPquf6Kt/nAoo6DgHAoN57K15ZghiHaMvqjCye/uU4X5u3YSMgVBI1h3vKrQ==",
+      "os": ["openbsd"],
+      "cpu": ["x64"]
+    },
+    "@esbuild/sunos-x64@0.20.2": {
+      "integrity": "sha512-2UyFtRC6cXLyejf/YEld4Hajo7UHILetzE1vsRcGL3earZEW77JxrFjH4Ez2qaTiEfMgAXxfAZCm1fvM/G/o8w==",
+      "os": ["sunos"],
+      "cpu": ["x64"]
+    },
+    "@esbuild/win32-arm64@0.20.2": {
+      "integrity": "sha512-GRibxoawM9ZCnDxnP3usoUDO9vUkpAxIIZ6GQI+IlVmr5kP3zUq+l17xELTHMWTWzjxa2guPNyrpq1GWmPvcGQ==",
+      "os": ["win32"],
+      "cpu": ["arm64"]
+    },
+    "@esbuild/win32-ia32@0.20.2": {
+      "integrity": "sha512-HfLOfn9YWmkSKRQqovpnITazdtquEW8/SoHW7pWpuEeguaZI4QnCRW6b+oZTztdBnZOS2hqJ6im/D5cPzBTTlQ==",
+      "os": ["win32"],
+      "cpu": ["ia32"]
+    },
+    "@esbuild/win32-x64@0.20.2": {
+      "integrity": "sha512-N49X4lJX27+l9jbLKSqZ6bKNjzQvHaT8IIFUy+YIqmXQdjYCToGWwOItDrfby14c78aDd5NHQl29xingXfCdLQ==",
+      "os": ["win32"],
+      "cpu": ["x64"]
+    },
+    "@nodelib/fs.scandir@2.1.5": {
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dependencies": [
+        "@nodelib/fs.stat",
+        "run-parallel"
+      ]
+    },
+    "@nodelib/fs.stat@2.0.5": {
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="
+    },
+    "@nodelib/fs.walk@1.2.8": {
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dependencies": [
+        "@nodelib/fs.scandir",
+        "fastq"
+      ]
+    },
+    "@typescript-eslint/types@8.18.0": {
+      "integrity": "sha512-FNYxgyTCAnFwTrzpBGq+zrnoTO4x0c1CKYY5MuUTzpScqmY5fmsh2o3+57lqdI3NZucBDCzDgdEbIaNfAjAHQA=="
+    },
+    "@typescript-eslint/typescript-estree@8.18.0_typescript@5.7.3": {
+      "integrity": "sha512-rqQgFRu6yPkauz+ms3nQpohwejS8bvgbPyIDq13cgEDbkXt4LH4OkDMT0/fN1RUtzG8e8AKJyDBoocuQh8qNeg==",
+      "dependencies": [
+        "@typescript-eslint/types",
+        "@typescript-eslint/visitor-keys",
+        "debug",
+        "fast-glob",
+        "is-glob",
+        "minimatch",
+        "semver",
+        "ts-api-utils",
+        "typescript"
+      ]
+    },
+    "@typescript-eslint/visitor-keys@8.18.0": {
+      "integrity": "sha512-pCh/qEA8Lb1wVIqNvBke8UaRjJ6wrAWkJO5yyIbs8Yx6TNGYyfNjOo61tLv+WwLvoLPp4BQ8B7AHKijl8NGUfw==",
+      "dependencies": [
+        "@typescript-eslint/types",
+        "eslint-visitor-keys"
+      ]
+    },
+    "balanced-match@1.0.2": {
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+    },
+    "brace-expansion@2.0.1": {
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dependencies": [
+        "balanced-match"
+      ]
+    },
+    "braces@3.0.3": {
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dependencies": [
+        "fill-range"
+      ]
+    },
+    "debug@4.4.1": {
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "dependencies": [
+        "ms"
+      ]
+    },
+    "esbuild@0.20.2": {
+      "integrity": "sha512-WdOOppmUNU+IbZ0PaDiTst80zjnrOkyJNHoKupIcVyU8Lvla3Ugx94VzkQ32Ijqd7UhHJy75gNWDMUekcrSJ6g==",
+      "optionalDependencies": [
+        "@esbuild/aix-ppc64",
+        "@esbuild/android-arm",
+        "@esbuild/android-arm64",
+        "@esbuild/android-x64",
+        "@esbuild/darwin-arm64",
+        "@esbuild/darwin-x64",
+        "@esbuild/freebsd-arm64",
+        "@esbuild/freebsd-x64",
+        "@esbuild/linux-arm",
+        "@esbuild/linux-arm64",
+        "@esbuild/linux-ia32",
+        "@esbuild/linux-loong64",
+        "@esbuild/linux-mips64el",
+        "@esbuild/linux-ppc64",
+        "@esbuild/linux-riscv64",
+        "@esbuild/linux-s390x",
+        "@esbuild/linux-x64",
+        "@esbuild/netbsd-x64",
+        "@esbuild/openbsd-x64",
+        "@esbuild/sunos-x64",
+        "@esbuild/win32-arm64",
+        "@esbuild/win32-ia32",
+        "@esbuild/win32-x64"
+      ],
+      "scripts": true,
+      "bin": true
+    },
+    "eslint-visitor-keys@4.2.0": {
+      "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw=="
+    },
+    "fast-glob@3.3.3": {
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dependencies": [
+        "@nodelib/fs.stat",
+        "@nodelib/fs.walk",
+        "glob-parent",
+        "merge2",
+        "micromatch"
+      ]
+    },
+    "fastq@1.19.1": {
+      "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
+      "dependencies": [
+        "reusify"
+      ]
+    },
+    "fill-range@7.1.1": {
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dependencies": [
+        "to-regex-range"
+      ]
+    },
+    "glob-parent@5.1.2": {
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dependencies": [
+        "is-glob"
+      ]
+    },
+    "is-extglob@2.1.1": {
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="
+    },
+    "is-glob@4.0.3": {
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dependencies": [
+        "is-extglob"
+      ]
+    },
+    "is-number@7.0.0": {
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
+    },
+    "merge2@1.4.1": {
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="
+    },
+    "micromatch@4.0.8": {
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dependencies": [
+        "braces",
+        "picomatch"
+      ]
+    },
+    "minimatch@9.0.5": {
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dependencies": [
+        "brace-expansion"
+      ]
+    },
+    "ms@2.1.3": {
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "picomatch@2.3.1": {
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
+    },
+    "queue-microtask@1.2.3": {
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="
+    },
+    "reusify@1.1.0": {
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="
+    },
+    "run-parallel@1.2.0": {
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dependencies": [
+        "queue-microtask"
+      ]
+    },
+    "semver@7.7.2": {
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "bin": true
+    },
+    "to-regex-range@5.0.1": {
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dependencies": [
+        "is-number"
+      ]
+    },
+    "ts-api-utils@1.4.3_typescript@5.7.3": {
+      "integrity": "sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==",
+      "dependencies": [
+        "typescript"
+      ]
+    },
+    "typescript@5.7.3": {
+      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
+      "bin": true
+    }
+  },
+  "workspace": {
+    "dependencies": [
+      "jsr:@luca/esbuild-deno-loader@~0.11.1",
+      "jsr:@std/cli@1",
+      "jsr:@std/fs@1",
+      "jsr:@std/path@1",
+      "jsr:@zip-js/zip-js@^2.7.62",
+      "npm:@typescript-eslint/typescript-estree@8.18.0",
+      "npm:esbuild@0.20.2"
+    ]
+  }
+}

--- a/examples/api-test-extension/src/client/api.ts
+++ b/examples/api-test-extension/src/client/api.ts
@@ -1,0 +1,77 @@
+import { ClientExtension } from "@takopack/builder/src/classes.ts";
+import { getTakosClientAPI } from "@takopack/builder/src/api-helpers.ts";
+
+export const ApiClient = new ClientExtension();
+
+async function run<T>(fn: () => Promise<T>): Promise<[number, T | { error: string }]> {
+  try {
+    return [200, await fn()];
+  } catch (err) {
+    return [500, { error: String(err) }];
+  }
+}
+
+async function testKv() {
+  const t = getTakosClientAPI();
+  await t?.kv.write("client:test", "ok");
+  const value = await t?.kv.read("client:test");
+  await t?.kv.delete("client:test");
+  return { value };
+}
+
+async function testCdn() {
+  const t = getTakosClientAPI();
+  await t?.cdn.write("client.txt", "hello", { cacheTTL: 0 });
+  const data = await t?.cdn.read("client.txt");
+  await t?.cdn.delete("client.txt");
+  return { data };
+}
+
+async function testEvents() {
+  const t = getTakosClientAPI();
+  let flag = false;
+  const unsub = t?.events.subscribe("clientPing", () => { flag = true; });
+  await t?.events.publish("clientPing", {});
+  unsub?.();
+  return { received: flag };
+}
+
+
+async function testExtensions() {
+  const t = getTakosClientAPI();
+  const ext = t?.extensions.get("com.example.api-test");
+  const api = await t?.activateExtension("com.example.api-test");
+  return { has: !!ext, activated: typeof api?.publish === "function" };
+}
+
+async function testFetch() {
+  const t = getTakosClientAPI();
+  const res = await t?.fetch("https://example.com");
+  return { ok: res?.ok ?? false };
+}
+
+/** @event("clientKv", { source: "ui" }) */
+ApiClient.onClientKv = async (): Promise<[number, Record<string, unknown>]> => {
+  return await run(testKv);
+};
+
+/** @event("clientCdn", { source: "ui" }) */
+ApiClient.onClientCdn = async (): Promise<[number, Record<string, unknown>]> => {
+  return await run(testCdn);
+};
+
+/** @event("clientEvents", { source: "ui" }) */
+ApiClient.onClientEvents = async (): Promise<[number, Record<string, unknown>]> => {
+  return await run(testEvents);
+};
+
+
+/** @event("clientExtensions", { source: "ui" }) */
+ApiClient.onClientExtensions = async (): Promise<[number, Record<string, unknown>]> => {
+  return await run(testExtensions);
+};
+
+/** @event("clientFetch", { source: "ui" }) */
+ApiClient.onClientFetch = async (): Promise<[number, Record<string, unknown>]> => {
+  return await run(testFetch);
+};

--- a/examples/api-test-extension/src/server/api.ts
+++ b/examples/api-test-extension/src/server/api.ts
@@ -1,0 +1,107 @@
+import { ServerExtension } from "@takopack/builder/src/classes.ts";
+import { getTakosServerAPI } from "@takopack/builder/src/api-helpers.ts";
+
+export const ApiServer = new ServerExtension();
+
+async function run<T>(fn: () => Promise<T>): Promise<[number, T | { error: string }]> {
+  try {
+    return [200, await fn()];
+  } catch (err) {
+    return [500, { error: String(err) }];
+  }
+}
+
+function getApi() {
+  return getTakosServerAPI();
+}
+
+async function testKv() {
+  const t = getApi();
+  await t?.kv.write("server:test", "ok");
+  const value = await t?.kv.read("server:test");
+  const list = await t?.kv.list();
+  await t?.kv.delete("server:test");
+  return { value, list };
+}
+
+async function testCdn() {
+  const t = getApi();
+  await t?.cdn.write("srv.txt", "hello", { cacheTTL: 0 });
+  const data = await t?.cdn.read("srv.txt");
+  const list = await t?.cdn.list();
+  await t?.cdn.delete("srv.txt");
+  return { data, list };
+}
+
+async function testEvents() {
+  const t = getApi();
+  let flag = false;
+  const unsub = t?.events.subscribe("srvPing", () => { flag = true; });
+  await t?.events.publish("srvPing", {});
+  unsub?.();
+  return { received: flag };
+}
+
+async function testActivityPub() {
+  const t = getApi();
+  await t?.activitypub.send("srv", { type: "Note" });
+  await t?.activitypub.read("id:srv");
+  await t?.activitypub.delete("id:srv");
+  await t?.activitypub.list("srv");
+  await t?.activitypub.actor.read("srv");
+  await t?.activitypub.actor.update("srv", "k", "v");
+  await t?.activitypub.actor.delete("srv", "k");
+  await t?.activitypub.follow("srv", "you");
+  await t?.activitypub.unfollow("srv", "you");
+  await t?.activitypub.listFollowers("srv");
+  await t?.activitypub.listFollowing("srv");
+  await t?.activitypub.pluginActor.create("bot", {});
+  await t?.activitypub.pluginActor.read("bot");
+  await t?.activitypub.pluginActor.update("bot", {});
+  await t?.activitypub.pluginActor.delete("bot");
+  await t?.activitypub.pluginActor.list();
+  return { ok: true };
+}
+
+async function testExtensions() {
+  const t = getApi();
+  const ext = t?.extensions.get("com.example.api-test");
+  const api = await t?.activateExtension("com.example.api-test");
+  return { has: !!ext, activated: typeof api?.publish === "function" };
+}
+
+async function testFetch() {
+  const t = getApi();
+  const res = await t?.fetch("https://example.com");
+  return { ok: res?.ok ?? false };
+}
+
+/** @event("serverKv", { source: "ui" }) */
+ApiServer.onServerKv = async (): Promise<[number, Record<string, unknown>]> => {
+  return await run(testKv);
+};
+
+/** @event("serverCdn", { source: "ui" }) */
+ApiServer.onServerCdn = async (): Promise<[number, Record<string, unknown>]> => {
+  return await run(testCdn);
+};
+
+/** @event("serverEvents", { source: "ui" }) */
+ApiServer.onServerEvents = async (): Promise<[number, Record<string, unknown>]> => {
+  return await run(testEvents);
+};
+
+/** @event("serverActivityPub", { source: "ui" }) */
+ApiServer.onServerActivityPub = async (): Promise<[number, Record<string, unknown>]> => {
+  return await run(testActivityPub);
+};
+
+/** @event("serverExtensions", { source: "ui" }) */
+ApiServer.onServerExtensions = async (): Promise<[number, Record<string, unknown>]> => {
+  return await run(testExtensions);
+};
+
+/** @event("serverFetch", { source: "ui" }) */
+ApiServer.onServerFetch = async (): Promise<[number, Record<string, unknown>]> => {
+  return await run(testFetch);
+};

--- a/examples/api-test-extension/src/ui/index.html
+++ b/examples/api-test-extension/src/ui/index.html
@@ -1,0 +1,158 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>API Test</title>
+    <style>
+      body {
+        font-family: sans-serif;
+        background: #fff;
+        color: #333;
+      }
+      section { margin-bottom: 1rem; }
+      button { margin: 2px; }
+      #output {
+        border: 1px solid #ccc;
+        padding: 0.25rem;
+        background: #fafafa;
+      }
+      #output pre {
+        margin: 0.25rem 0;
+        padding: 0.25rem;
+        background: #f4f4f4;
+      }
+      #output pre.error {
+        background: #fee;
+        color: #b00;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Takopack API Test</h1>
+    <section>
+      <h2>Server</h2>
+      <div id="server"></div>
+    </section>
+    <section>
+      <h2>Client</h2>
+      <div id="client"></div>
+    </section>
+    <section>
+      <h2>UI</h2>
+      <div id="ui"></div>
+    </section>
+    <section>
+      <h2>Results</h2>
+      <div id="output"></div>
+    </section>
+    <script>
+      const serverTests = [
+        'serverKv',
+        'serverCdn',
+        'serverEvents',
+        'serverActivityPub',
+        'serverExtensions',
+        'serverFetch'
+      ];
+      const clientTests = [
+        'clientKv',
+        'clientCdn',
+        'clientEvents',
+        'clientExtensions',
+        'clientFetch'
+      ];
+      const uiTests = [
+        'uiKv',
+        'uiCdn',
+        'uiEvents',
+        'uiFetch',
+        'uiExtensions',
+        'uiUrl'
+      ];
+
+      function addButtons(container, tests, runner) {
+        tests.forEach(name => {
+          const b = document.createElement('button');
+          b.textContent = name;
+          b.onclick = () => runner(name);
+          container.appendChild(b);
+        });
+      }
+
+      async function runEvent(name) {
+        if (typeof takos === 'undefined') return;
+        try {
+          const res = await takos.events.publish(name, {});
+          if (Array.isArray(res)) {
+            const [status, body] = res;
+            if (status >= 200 && status < 300) {
+              print(name, body);
+            } else {
+              printError(name, body);
+            }
+          }
+        } catch (err) {
+          printError(name, err);
+        }
+      }
+
+      async function runUi(name) {
+        try {
+          if (name === 'uiKv') {
+            await takos.kv.write('ui:test', 'ok');
+            const value = await takos.kv.read('ui:test');
+            await takos.kv.delete('ui:test');
+            print(name, { value });
+          } else if (name === 'uiCdn') {
+            await takos.cdn.write('ui.txt', 'hello', { cacheTTL: 0 });
+            const data = await takos.cdn.read('ui.txt');
+            await takos.cdn.delete('ui.txt');
+            print(name, { data });
+          } else if (name === 'uiEvents') {
+            let received = false;
+            const u = takos.events.subscribe('uiPing', () => { received = true; });
+            await takos.events.publish('uiPing', {});
+            u();
+            print(name, { received });
+          } else if (name === 'uiFetch') {
+            const res = await takos.fetch('https://example.com');
+            print(name, { ok: res.ok });
+          } else if (name === 'uiExtensions') {
+            const ext = takos.extensions.get('com.example.api-test');
+            const api = await takos.activateExtension('com.example.api-test');
+            print(name, { has: !!ext, activated: typeof api?.publish === 'function' });
+          } else if (name === 'uiUrl') {
+            const before = takos.getURL();
+            let changed = false;
+            const off = takos.changeURL(() => { changed = true; });
+            takos.pushURL('tmp', { showBar: false });
+            takos.setURL(before, { showBar: false });
+            off();
+            print(name, { before, changed, after: takos.getURL() });
+          }
+        } catch (err) {
+          printError(name, err);
+        }
+      }
+
+      function print(name, res) {
+        const out = document.getElementById('output');
+        const pre = document.createElement('pre');
+        pre.textContent = name + '\n' + JSON.stringify(res, null, 2);
+        out.prepend(pre);
+      }
+
+      function printError(name, err) {
+        const out = document.getElementById('output');
+        const pre = document.createElement('pre');
+        pre.className = 'error';
+        pre.textContent = name + '\n' + String(err);
+        out.prepend(pre);
+      }
+
+      addButtons(document.getElementById('server'), serverTests, runEvent);
+      addButtons(document.getElementById('client'), clientTests, runEvent);
+      addButtons(document.getElementById('ui'), uiTests, runUi);
+    </script>
+  </body>
+</html>

--- a/examples/api-test-extension/takopack.config.ts
+++ b/examples/api-test-extension/takopack.config.ts
@@ -1,0 +1,50 @@
+import { defineConfig } from "../../packages/builder/mod.ts";
+
+export default defineConfig({
+  manifest: {
+    name: "API Test Extension",
+    identifier: "com.example.api-test",
+    version: "1.0.0",
+    description: "Runs a suite of API calls to verify Takopack runtime.",
+    permissions: [
+      "fetch:net",
+      "activitypub:send",
+      "activitypub:read",
+      "activitypub:receive:hook",
+      "activitypub:actor:read",
+      "activitypub:actor:write",
+      "plugin-actor:create",
+      "plugin-actor:read",
+      "plugin-actor:write",
+      "plugin-actor:delete",
+      "kv:read",
+      "kv:write",
+      "cdn:read",
+      "cdn:write",
+      "events:publish",
+      "events:subscribe",
+      "extensions:invoke",
+      "extensions:export",
+      "deno:read",
+      "deno:write",
+      "deno:net",
+      "deno:env",
+      "deno:run",
+      "deno:sys",
+      "deno:ffi",
+    ],
+  },
+
+  entries: {
+    server: ["src/server/api.ts"],
+    client: ["src/client/api.ts"],
+    ui: ["src/ui/index.html"],
+  },
+
+  build: {
+    target: "es2022",
+    dev: false,
+    analysis: true,
+    outDir: "dist",
+  },
+});


### PR DESCRIPTION
## Summary
- style API test page with lighter colors and error display
- handle errors in server, client and UI tests

## Testing
- `deno task test` in `packages/unpack` *(fails: invalid peer certificate)*
- `deno test -A --unstable --unstable-worker-options` in `packages/runtime` *(fails to load @types/node)*
- `deno task test` in `packages/registry` *(fails to load JSR package manifest)*
- `deno task test` in `packages/builder` *(fails: invalid peer certificate)*

------
https://chatgpt.com/codex/tasks/task_e_684fdb91bddc83289f21f23c2f78965a