### PR TITLE
Improve Takos UI API implementation

### DIFF
--- a/app/client/src/takos.ts
+++ b/app/client/src/takos.ts
@@ -90,12 +90,29 @@ export function createTakos(identifier: string) {
 
   const events = {
     publish: async (name: string, payload: unknown) => {
-      const raw = await call("extensions:invoke", {
-        id: identifier,
-        fn: name,
-        args: [payload],
+      const handlers = listeners.get(name);
+      handlers?.forEach((h) => {
+        try {
+          h(payload);
+        } catch (_e) {
+          /* ignore */
+        }
       });
-      return unwrapResult(raw);
+      try {
+        const raw = await call("extensions:invoke", {
+          id: identifier,
+          fn: name,
+          args: [payload],
+        });
+        return unwrapResult(raw);
+      } catch (err) {
+        if (
+          err instanceof Error && err.message.includes("function not found")
+        ) {
+          return undefined;
+        }
+        throw err;
+      }
     },
     subscribe: (name: string, handler: (payload: unknown) => void) => {
       if (!listeners.has(name)) listeners.set(name, new Set());
@@ -115,5 +132,69 @@ export function createTakos(identifier: string) {
     },
   };
 
-  return { kv, cdn, events, server, fetch };
+  const fetchFn = (input: RequestInfo | URL, init?: RequestInit) =>
+    fetch(input, init);
+
+  const extensionObj = {
+    identifier,
+    version: "",
+    get isActive() {
+      return true;
+    },
+    activate: () => ({
+      publish: async (name: string, payload?: unknown) => {
+        const raw = await call("extensions:invoke", {
+          id: identifier,
+          fn: name,
+          args: [payload],
+        });
+        return unwrapResult(raw);
+      },
+    }),
+  };
+
+  const extensions = {
+    get(id: string) {
+      return id === identifier ? extensionObj : undefined;
+    },
+    get all() {
+      return [extensionObj];
+    },
+  };
+
+  function getURL() {
+    return location.hash.slice(1).split("/").filter((p) => p);
+  }
+
+  function setURL(segments: string[], _opts?: { showBar?: boolean }) {
+    location.hash = "#" + segments.join("/");
+  }
+
+  function pushURL(segment: string, opts?: { showBar?: boolean }) {
+    const segments = getURL();
+    segments.push(segment);
+    setURL(segments, opts);
+  }
+
+  function changeURL(
+    listener: (e: { url: string[] }) => void,
+  ): () => void {
+    const handler = () => listener({ url: getURL() });
+    globalThis.addEventListener("hashchange", handler);
+    return () => globalThis.removeEventListener("hashchange", handler);
+  }
+
+  return {
+    kv,
+    cdn,
+    events,
+    server,
+    fetch: fetchFn,
+    extensions,
+    activateExtension: extensionObj.activate,
+    getURL,
+    pushURL,
+    setURL,
+    changeURL,
+  };
 }

--- a/examples/api-test-extension/src/client/api.ts
+++ b/examples/api-test-extension/src/client/api.ts
@@ -22,12 +22,13 @@ async function testCdn() {
 async function testEvents() {
   const t = getTakosClientAPI();
   let flag = false;
-  const unsub = t?.events.subscribe("clientPing", () => { flag = true; });
+  const unsub = t?.events.subscribe("clientPing", () => {
+    flag = true;
+  });
   await t?.events.publish("clientPing", {});
   unsub?.();
   return { received: flag };
 }
-
 
 async function testExtensions() {
   const t = getTakosClientAPI();
@@ -48,22 +49,46 @@ ApiClient.onClientKv = async (): Promise<[number, Record<string, unknown>]> => {
 };
 
 /** @event("clientCdn", { source: "ui" }) */
-ApiClient.onClientCdn = async (): Promise<[number, Record<string, unknown>]> => {
+ApiClient.onClientCdn = async (): Promise<
+  [number, Record<string, unknown>]
+> => {
   return [200, await testCdn()];
 };
 
 /** @event("clientEvents", { source: "ui" }) */
-ApiClient.onClientEvents = async (): Promise<[number, Record<string, unknown>]> => {
+ApiClient.onClientEvents = async (): Promise<
+  [number, Record<string, unknown>]
+> => {
   return [200, await testEvents()];
 };
 
-
 /** @event("clientExtensions", { source: "ui" }) */
-ApiClient.onClientExtensions = async (): Promise<[number, Record<string, unknown>]> => {
+ApiClient.onClientExtensions = async (): Promise<
+  [number, Record<string, unknown>]
+> => {
   return [200, await testExtensions()];
 };
 
 /** @event("clientFetch", { source: "ui" }) */
-ApiClient.onClientFetch = async (): Promise<[number, Record<string, unknown>]> => {
+ApiClient.onClientFetch = async (): Promise<
+  [number, Record<string, unknown>]
+> => {
   return [200, await testFetch()];
 };
+
+// Direct wrappers for event names when not using builder-generated wrappers
+export function clientKv(): Promise<[number, Record<string, unknown>]> {
+  return ApiClient.onClientKv();
+}
+export function clientCdn(): Promise<[number, Record<string, unknown>]> {
+  return ApiClient.onClientCdn();
+}
+export function clientEvents(): Promise<[number, Record<string, unknown>]> {
+  return ApiClient.onClientEvents();
+}
+export function clientExtensions(): Promise<[number, Record<string, unknown>]> {
+  return ApiClient.onClientExtensions();
+}
+export function clientFetch(): Promise<[number, Record<string, unknown>]> {
+  return ApiClient.onClientFetch();
+}

--- a/examples/api-test-extension/src/server/api.ts
+++ b/examples/api-test-extension/src/server/api.ts
@@ -28,7 +28,9 @@ async function testCdn() {
 async function testEvents() {
   const t = getApi();
   let flag = false;
-  const unsub = t?.events.subscribe("srvPing", () => { flag = true; });
+  const unsub = t?.events.subscribe("srvPing", () => {
+    flag = true;
+  });
   await t?.events.publish("srvPing", {});
   unsub?.();
   return { received: flag };
@@ -74,26 +76,58 @@ ApiServer.onServerKv = async (): Promise<[number, Record<string, unknown>]> => {
 };
 
 /** @event("serverCdn", { source: "ui" }) */
-ApiServer.onServerCdn = async (): Promise<[number, Record<string, unknown>]> => {
+ApiServer.onServerCdn = async (): Promise<
+  [number, Record<string, unknown>]
+> => {
   return [200, await testCdn()];
 };
 
 /** @event("serverEvents", { source: "ui" }) */
-ApiServer.onServerEvents = async (): Promise<[number, Record<string, unknown>]> => {
+ApiServer.onServerEvents = async (): Promise<
+  [number, Record<string, unknown>]
+> => {
   return [200, await testEvents()];
 };
 
 /** @event("serverActivityPub", { source: "ui" }) */
-ApiServer.onServerActivityPub = async (): Promise<[number, Record<string, unknown>]> => {
+ApiServer.onServerActivityPub = async (): Promise<
+  [number, Record<string, unknown>]
+> => {
   return [200, await testActivityPub()];
 };
 
 /** @event("serverExtensions", { source: "ui" }) */
-ApiServer.onServerExtensions = async (): Promise<[number, Record<string, unknown>]> => {
+ApiServer.onServerExtensions = async (): Promise<
+  [number, Record<string, unknown>]
+> => {
   return [200, await testExtensions()];
 };
 
 /** @event("serverFetch", { source: "ui" }) */
-ApiServer.onServerFetch = async (): Promise<[number, Record<string, unknown>]> => {
+ApiServer.onServerFetch = async (): Promise<
+  [number, Record<string, unknown>]
+> => {
   return [200, await testFetch()];
 };
+
+// Direct wrappers for event names when not using the builder-generated wrappers
+export function serverKv(): Promise<[number, Record<string, unknown>]> {
+  return ApiServer.onServerKv();
+}
+export function serverCdn(): Promise<[number, Record<string, unknown>]> {
+  return ApiServer.onServerCdn();
+}
+export function serverEvents(): Promise<[number, Record<string, unknown>]> {
+  return ApiServer.onServerEvents();
+}
+export function serverActivityPub(): Promise<
+  [number, Record<string, unknown>]
+> {
+  return ApiServer.onServerActivityPub();
+}
+export function serverExtensions(): Promise<[number, Record<string, unknown>]> {
+  return ApiServer.onServerExtensions();
+}
+export function serverFetch(): Promise<[number, Record<string, unknown>]> {
+  return ApiServer.onServerFetch();
+}

--- a/examples/api-test-extension/src/ui/index.html
+++ b/examples/api-test-extension/src/ui/index.html
@@ -4,9 +4,17 @@
     <meta charset="UTF-8" />
     <title>API Test</title>
     <style>
-      body { font-family: sans-serif; }
-      section { margin-bottom: 1rem; }
-      button { margin: 2px; }
+      body {
+        font-family: sans-serif;
+        background: #fff;
+        color: #333;
+      }
+      section {
+        margin-bottom: 1rem;
+      }
+      button {
+        margin: 2px;
+      }
       #output {
         border: 1px solid #ccc;
         padding: 0.25rem;
@@ -15,6 +23,10 @@
         margin: 0.25rem 0;
         padding: 0.25rem;
         background: #f0f0f0;
+      }
+      #output pre.error {
+        color: #b00020;
+        background: #fff0f0;
       }
     </style>
   </head>
@@ -38,32 +50,32 @@
     </section>
     <script>
       const serverTests = [
-        'serverKv',
-        'serverCdn',
-        'serverEvents',
-        'serverActivityPub',
-        'serverExtensions',
-        'serverFetch'
+        "serverKv",
+        "serverCdn",
+        "serverEvents",
+        "serverActivityPub",
+        "serverExtensions",
+        "serverFetch",
       ];
       const clientTests = [
-        'clientKv',
-        'clientCdn',
-        'clientEvents',
-        'clientExtensions',
-        'clientFetch'
+        "clientKv",
+        "clientCdn",
+        "clientEvents",
+        "clientExtensions",
+        "clientFetch",
       ];
       const uiTests = [
-        'uiKv',
-        'uiCdn',
-        'uiEvents',
-        'uiFetch',
-        'uiExtensions',
-        'uiUrl'
+        "uiKv",
+        "uiCdn",
+        "uiEvents",
+        "uiFetch",
+        "uiExtensions",
+        "uiUrl",
       ];
 
       function addButtons(container, tests, runner) {
-        tests.forEach(name => {
-          const b = document.createElement('button');
+        tests.forEach((name) => {
+          const b = document.createElement("button");
           b.textContent = name;
           b.onclick = () => runner(name);
           container.appendChild(b);
@@ -71,59 +83,89 @@
       }
 
       async function runEvent(name) {
-        if (typeof takos === 'undefined') return;
-        const res = await takos.events.publish(name, {});
-        if (Array.isArray(res)) {
-          const [, body] = res;
-          print(name, body);
+        if (typeof takos === "undefined") return;
+        try {
+          const res = await takos.events.publish(name, {});
+          if (Array.isArray(res)) {
+            const [, body] = res;
+            print(name, body);
+          }
+        } catch (err) {
+          print(name, String(err), true);
         }
       }
 
       async function runUi(name) {
-        if (name === 'uiKv') {
-          await takos.kv.write('ui:test', 'ok');
-          const value = await takos.kv.read('ui:test');
-          await takos.kv.delete('ui:test');
-          print(name, { value });
-        } else if (name === 'uiCdn') {
-          await takos.cdn.write('ui.txt', 'hello', { cacheTTL: 0 });
-          const data = await takos.cdn.read('ui.txt');
-          await takos.cdn.delete('ui.txt');
-          print(name, { data });
-        } else if (name === 'uiEvents') {
-          let received = false;
-          const u = takos.events.subscribe('uiPing', () => { received = true; });
-          await takos.events.publish('uiPing', {});
-          u();
-          print(name, { received });
-        } else if (name === 'uiFetch') {
-          const res = await takos.fetch('https://example.com');
-          print(name, { ok: res.ok });
-        } else if (name === 'uiExtensions') {
-          const ext = takos.extensions.get('com.example.api-test');
-          const api = await takos.activateExtension('com.example.api-test');
-          print(name, { has: !!ext, activated: typeof api?.publish === 'function' });
-        } else if (name === 'uiUrl') {
-          const before = takos.getURL();
-          let changed = false;
-          const off = takos.changeURL(() => { changed = true; });
-          takos.pushURL('tmp', { showBar: false });
-          takos.setURL(before, { showBar: false });
-          off();
-          print(name, { before, changed, after: takos.getURL() });
+        try {
+          if (name === "uiKv") {
+            await takos.kv.write("ui:test", "ok");
+            const value = await takos.kv.read("ui:test");
+            await takos.kv.delete("ui:test");
+            print(name, { value });
+          } else if (name === "uiCdn") {
+            await takos.cdn.write("ui.txt", "hello", { cacheTTL: 0 });
+            const data = await takos.cdn.read("ui.txt");
+            await takos.cdn.delete("ui.txt");
+            print(name, { data });
+          } else if (name === "uiEvents") {
+            let received = false;
+            const u = takos.events.subscribe("uiPing", () => {
+              received = true;
+            });
+            await takos.events.publish("uiPing", {});
+            u();
+            print(name, { received });
+          } else if (name === "uiFetch") {
+            const res = await takos.fetch("https://example.com");
+            print(name, { ok: res.ok });
+          } else if (name === "uiExtensions") {
+            const ext = takos.extensions.get("com.example.api-test");
+            const api = await takos.activateExtension(
+              "com.example.api-test",
+            );
+            print(name, {
+              has: !!ext,
+              activated: typeof api?.publish === "function",
+            });
+          } else if (name === "uiUrl") {
+            const before = takos.getURL();
+            let changed = false;
+            const off = takos.changeURL(() => {
+              changed = true;
+            });
+            takos.pushURL("tmp", { showBar: false });
+            takos.setURL(before, { showBar: false });
+            off();
+            print(name, { before, changed, after: takos.getURL() });
+          }
+        } catch (err) {
+          print(name, String(err), true);
         }
       }
 
-      function print(name, res) {
-        const out = document.getElementById('output');
-        const pre = document.createElement('pre');
-        pre.textContent = name + '\n' + JSON.stringify(res, null, 2);
+      function print(name, res, error = false) {
+        const out = document.getElementById("output");
+        const pre = document.createElement("pre");
+        if (typeof res === "string") {
+          pre.textContent = name + "\n" + res;
+        } else {
+          pre.textContent = name + "\n" + JSON.stringify(res, null, 2);
+        }
+        if (error) pre.classList.add("error");
         out.prepend(pre);
       }
 
-      addButtons(document.getElementById('server'), serverTests, runEvent);
-      addButtons(document.getElementById('client'), clientTests, runEvent);
-      addButtons(document.getElementById('ui'), uiTests, runUi);
+      addButtons(
+        document.getElementById("server"),
+        serverTests,
+        runEvent,
+      );
+      addButtons(
+        document.getElementById("client"),
+        clientTests,
+        runEvent,
+      );
+      addButtons(document.getElementById("ui"), uiTests, runUi);
     </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- expand client `createTakos` with extensions API and URL helpers
- handle local-only events before forwarding to server
- wrap `fetch` to avoid illegal invocation errors

## Testing
- `deno fmt app/client/src/takos.ts`
- `deno fmt examples/api-test-extension/src/ui/index.html`
- `deno lint examples/api-test-extension/src/client/api.ts examples/api-test-extension/src/server/api.ts`
- `deno lint app/client/src/takos.ts`
- `deno test -A` *(fails: JSR package manifest for '@std/assert' failed to load)*

------
https://chatgpt.com/codex/tasks/task_e_684ff8e8e2a08328acde612ebd919cf5