### PR TITLE
Fix client example for server-only features

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -1,0 +1,132 @@
+# Takos AI Agent ガイド
+
+このドキュメントは、Takosプロジェクトの開発において、AIエージェントが効率的に作業するためのガイドラインです。
+
+## 📋 プロジェクト概要
+
+**Takos**は、ActivityPubプロトコルをベースとした分散型ソーシャルネットワークソフトウェアです。独自の拡張機能システム「Takopack」により、VSCodeのような安全で柔軟な機能拡張が可能です。
+
+### 🏗️ アーキテクチャ
+
+```
+takos/
+├── app/
+│   ├── api/           # バックエンドAPI (Hono + Deno)
+│   ├── client/        # フロントエンド (Solid.js + Tauri)
+│   ├── registry/      # 拡張機能レジストリ
+│   └── registry_ui/   # レジストリUI
+├── packages/          # 共通パッケージ
+├── examples/          # サンプル拡張機能
+└── docs/             # ドキュメント
+```
+
+### 🔧 技術スタック
+
+- **ランタイム**: Deno (TypeScript)
+- **バックエンド**: Hono
+- **フロントエンド**: Solid.js + Tauri
+- **データベース**: MongoDB (Mongoose)
+- **プロトコル**: ActivityPub + 独自拡張
+
+## 🎯 重要なコンポーネント
+
+### 1. Takopack Extension System
+- **場所**: `packages/builder/`, `packages/runtime/`, `packages/unpack/`
+- **目的**: 安全な権限ベースの拡張機能システム
+- **特徴**: VSCode風のAPIデザイン、サンドボックス実行
+
+### 2. ActivityPub Implementation
+- **場所**: `app/api/types/activitypub.ts`, `app/api/utils/activitypub.ts`
+- **目的**: 標準ActivityPubとカスタムオブジェクトの実装
+- **拡張**: Community、Group、Message等の独自オブジェクト
+
+### 3. Event System
+- **場所**: `app/api/events/`, `app/api/eventManager.ts`
+- **目的**: リアルタイムイベント配信とWebSocket通信
+
+## 🛠️ 開発ワークフロー
+
+### 環境セットアップ
+
+```bash
+# バックエンド開発
+cd app/api
+deno task dev
+
+# フロントエンド開発
+cd app/client
+deno task dev
+
+# 拡張機能ビルド
+deno run --allow-all build.ts build
+```
+
+### ファイル編集時の注意点
+
+1. **Import Paths**: 相対パスまたは`deno.json`のimportマップを使用
+2. **権限**: Denoの権限システムを考慮（`-A`フラグは開発時のみ）
+3. **Type Safety**: TypeScript型定義を活用
+
+### 主要なファイルパターン
+
+#### API Routes (`app/api/`)
+- `index.ts`: メインサーバーエントリーポイント
+- `hono.ts`: Honoアプリケーション設定
+- `events/*.ts`: イベントハンドラー
+- `models/*.ts`: データモデル定義
+
+#### Extensions (`examples/*/`)
+- `takopack.config.ts`: 拡張機能設定
+- `src/server.ts`: サーバーサイドロジック
+- `src/client.ts`: クライアントサイドロジック
+- `src/index.html`: UI定義
+
+## 🔍 デバッグとトラブルシューティング
+
+### よくある問題
+
+1. **Import Error**: `deno.json`のimportマップを確認
+2. **Permission Denied**: 必要な権限フラグを追加
+3. **Type Error**: 型定義ファイルの整合性を確認
+
+### ログの確認方法
+
+```bash
+# APIサーバーログ
+cd app/api && deno task dev
+
+# 拡張機能ログ
+# コンソールまたはWebSocketイベントで確認
+```
+
+## 📚 参考ドキュメント
+
+- **[Takopack仕様](./docs/takopack/)**: 拡張機能開発ガイド
+- **[takos-web API](./docs/takos-web/)**: Web API仕様
+- **[ActivityPub拡張](./docs/activityPub/)**: カスタムオブジェクト仕様
+
+## 🤖 AI Agent 向けのヒント
+
+### コード理解のポイント
+
+1. **イベントドリブン設計**: `eventManager.ts`を中心とした非同期処理
+2. **型安全性**: ZodスキーマとTypeScript型の活用
+3. **モジュラー設計**: 各機能が独立したモジュールとして実装
+
+### 編集時の推奨事項
+
+1. **既存パターンに従う**: 既存のコードスタイルとアーキテクチャを維持
+2. **型安全性を保つ**: 新しいコードでも型定義を適切に追加
+3. **テストを考慮**: 変更時はテスト可能性を念頭に置く
+
+### 新機能追加の流れ
+
+1. **型定義**: `types/`または`models/`で型を定義
+2. **イベント**: 必要に応じて`events/`にイベントハンドラーを追加
+3. **API**: `api/`にエンドポイントを実装
+4. **フロントエンド**: `client/`でUI実装
+5. **ドキュメント**: `docs/`で仕様を記述
+
+---
+
+**最終更新**: 2025年6月18日

--- a/app/api/events/extensions.ts
+++ b/app/api/events/extensions.ts
@@ -121,7 +121,7 @@ eventManager.add(
     if (!runtime) {
       throw new Error("extension not found");
     }
-    const result = await runtime.callServer(id, fn, args);
+    const result = await runtime.call(id, fn, args);
     return result;
   },
 );

--- a/app/api/extensionsRouter.ts
+++ b/app/api/extensionsRouter.ts
@@ -10,11 +10,20 @@ app.get("/api/extensions/:id/ui", async (c) => {
   if (!ext || !ext.ui) return c.notFound();
   c.header("Content-Type", "text/html; charset=utf-8");
   const script =
-    "<script>try{if(!window.takos&&window.parent)window.takos=window.parent.takos;}catch(e){}</script>";
+    `<script>try{if(!window.takos&&window.parent)window.takos=window.parent.takos;}catch(e){}</script>` +
+    `<script type="module" src="/api/extensions/${id}/client.js"></script>`;
   const html = ext.ui.includes("</head>")
     ? ext.ui.replace("</head>", script + "</head>")
     : script + ext.ui;
   return c.html(html);
+});
+
+app.get("/api/extensions/:id/client.js", async (c) => {
+  const id = c.req.param("id");
+  const ext = await Extension.findOne({ identifier: id });
+  if (!ext || !ext.client) return c.notFound();
+  c.header("Content-Type", "application/javascript; charset=utf-8");
+  return c.body(ext.client);
 });
 
 export default app;

--- a/app/api/extensionsRouter.ts
+++ b/app/api/extensionsRouter.ts
@@ -9,8 +9,11 @@ app.get("/api/extensions/:id/ui", async (c) => {
   const ext = await Extension.findOne({ identifier: id });
   if (!ext || !ext.ui) return c.notFound();
   c.header("Content-Type", "text/html; charset=utf-8");
+  const eventDefs = JSON.stringify(ext.manifest?.eventDefinitions || {});
   const script =
-    `<script>try{if(!window.takos&&window.parent)window.takos=window.parent.takos;}catch(e){}</script>` +
+    `<script>try{if(!window.takos&&window.parent)window.takos=window.parent.takos;}catch(e){};` +
+    `window.__takosEventDefs=window.__takosEventDefs||{};` +
+    `window.__takosEventDefs["${id}"]=${eventDefs};</script>` +
     `<script type="module" src="/api/extensions/${id}/client.js"></script>`;
   const html = ext.ui.includes("</head>")
     ? ext.ui.replace("</head>", script + "</head>")

--- a/app/api/utils/extensionsRuntime.ts
+++ b/app/api/utils/extensionsRuntime.ts
@@ -81,14 +81,15 @@ export async function loadExtension(
 
     await pack.init();
 
-    // Forward client events to the server runtime
+    // Forward client events to connected clients only
     pack.setClientPublish(
       (
         name: string,
         payload: unknown,
-        options?: { push?: boolean },
+        _options?: { push?: boolean },
       ) => {
-        return pack.callServer(doc.identifier, name, [payload, options]);
+        wsManager.distributeEvent(name, payload);
+        return Promise.resolve(undefined);
       },
     );
     runtimes.set(doc.identifier, pack);

--- a/app/client/builder/examples/example-new.ts
+++ b/app/client/builder/examples/example-new.ts
@@ -399,10 +399,7 @@ const modernUI = `<!DOCTYPE html>
 
         // イベントリスナー設定
         if (typeof takos !== 'undefined' && takos.events) {
-            takos.events.subscribe('metricsUpdated', function(data) {
-                addLog('メトリクスが更新されました', 'info');
-                refreshMetrics();
-            });
+            // events.subscribe has been removed
         }
     </script>
 </body>
@@ -433,7 +430,6 @@ const extension = new FunctionBasedTakopack()
       "activitypub:send",
       "activitypub:receive:hook",
       "events:publish",
-      "events:subscribe",
     ],
   })
   // === サーバー関数（権限引数なし） ===

--- a/app/client/builder/examples/example.ts
+++ b/app/client/builder/examples/example.ts
@@ -399,10 +399,7 @@ const modernUI = `<!DOCTYPE html>
 
         // イベントリスナー設定
         if (typeof takos !== 'undefined' && takos.events) {
-            takos.events.subscribe('metricsUpdated', function(data) {
-                addLog('メトリクスが更新されました', 'info');
-                refreshMetrics();
-            });
+            // events.subscribe is removed; metricsUpdated will invoke handlers directly
         }
     </script>
 </body>
@@ -433,7 +430,6 @@ const extension = new FunctionBasedTakopack()
       "activitypub:send",
       "activitypub:receive:hook",
       "events:publish",
-      "events:subscribe",
     ],
   })
   // === サーバー関数（権限引数なし） ===

--- a/app/client/builder/main.ts
+++ b/app/client/builder/main.ts
@@ -35,7 +35,6 @@ export type Permission =
   | "cdn:read"
   | "cdn:write"
   | "events:publish"
-  | "events:subscribe"
   | "deno:read"
   | "deno:write"
   | "deno:net"

--- a/app/client/builder/types/takos-api.ts
+++ b/app/client/builder/types/takos-api.ts
@@ -93,10 +93,7 @@ export interface ActivityPubManager {
 }
 
 export interface TakosAPI {
-  activitypub: ActivityPubManager;
-  ap: ActivityPubManager;
   kv: KVStore;
-  cdn: CdnManager;
   events: EventManager;
   fetch(url: string, options?: RequestInit): Promise<Response>;
 }

--- a/app/client/src/takos.ts
+++ b/app/client/src/takos.ts
@@ -193,6 +193,15 @@ export function createTakos(identifier: string) {
           /* ignore */
         }
       });
+      const local = (globalThis as Record<string, any>).__takosClientEvents?.[identifier]?.[name];
+      if (typeof local === "function") {
+        try {
+          return await local(payload);
+        } catch (err) {
+          console.error("local event handler error", err);
+          throw err;
+        }
+      }
       try {
         const raw = await call("extensions:invoke", {
           id: identifier,

--- a/app/registry/deno.json
+++ b/app/registry/deno.json
@@ -7,7 +7,7 @@
   },
   "tasks": {
     "start": "deno run -A --watch index.ts",
-    "dev": "deno run -A npm:vite --config ui/vite.config.ts",
+    "dev": "deno run -A --watch index.ts",
     "ui-build": "deno run -A npm:vite build --config ui/vite.config.ts"
   }
 }

--- a/app/registry/deno.json
+++ b/app/registry/deno.json
@@ -7,7 +7,7 @@
   },
   "tasks": {
     "start": "deno run -A --watch index.ts",
-    "ui-dev": "deno run -A npm:vite --config ui/vite.config.ts",
+    "dev": "deno run -A npm:vite --config ui/vite.config.ts",
     "ui-build": "deno run -A npm:vite build --config ui/vite.config.ts"
   }
 }

--- a/app/registry/deno.lock
+++ b/app/registry/deno.lock
@@ -10,7 +10,8 @@
     "npm:hono@^4.7.11": "4.7.11",
     "npm:mongoose@8": "8.15.1",
     "npm:nodemailer@*": "6.10.0",
-    "npm:nodemailer@^7.0.3": "7.0.3"
+    "npm:nodemailer@^7.0.3": "7.0.3",
+    "npm:vite@*": "6.3.5_@types+node@22.15.15_picomatch@4.0.2"
   },
   "jsr": {
     "@std/dotenv@0.225.5": {
@@ -30,11 +31,239 @@
     }
   },
   "npm": {
+    "@esbuild/aix-ppc64@0.25.5": {
+      "integrity": "sha512-9o3TMmpmftaCMepOdA5k/yDw8SfInyzWWTjYTFCX3kPSDJMROQTb8jg+h9Cnwnmm1vOzvxN7gIfB5V2ewpjtGA==",
+      "os": ["aix"],
+      "cpu": ["ppc64"]
+    },
+    "@esbuild/android-arm64@0.25.5": {
+      "integrity": "sha512-VGzGhj4lJO+TVGV1v8ntCZWJktV7SGCs3Pn1GRWI1SBFtRALoomm8k5E9Pmwg3HOAal2VDc2F9+PM/rEY6oIDg==",
+      "os": ["android"],
+      "cpu": ["arm64"]
+    },
+    "@esbuild/android-arm@0.25.5": {
+      "integrity": "sha512-AdJKSPeEHgi7/ZhuIPtcQKr5RQdo6OO2IL87JkianiMYMPbCtot9fxPbrMiBADOWWm3T2si9stAiVsGbTQFkbA==",
+      "os": ["android"],
+      "cpu": ["arm"]
+    },
+    "@esbuild/android-x64@0.25.5": {
+      "integrity": "sha512-D2GyJT1kjvO//drbRT3Hib9XPwQeWd9vZoBJn+bu/lVsOZ13cqNdDeqIF/xQ5/VmWvMduP6AmXvylO/PIc2isw==",
+      "os": ["android"],
+      "cpu": ["x64"]
+    },
+    "@esbuild/darwin-arm64@0.25.5": {
+      "integrity": "sha512-GtaBgammVvdF7aPIgH2jxMDdivezgFu6iKpmT+48+F8Hhg5J/sfnDieg0aeG/jfSvkYQU2/pceFPDKlqZzwnfQ==",
+      "os": ["darwin"],
+      "cpu": ["arm64"]
+    },
+    "@esbuild/darwin-x64@0.25.5": {
+      "integrity": "sha512-1iT4FVL0dJ76/q1wd7XDsXrSW+oLoquptvh4CLR4kITDtqi2e/xwXwdCVH8hVHU43wgJdsq7Gxuzcs6Iq/7bxQ==",
+      "os": ["darwin"],
+      "cpu": ["x64"]
+    },
+    "@esbuild/freebsd-arm64@0.25.5": {
+      "integrity": "sha512-nk4tGP3JThz4La38Uy/gzyXtpkPW8zSAmoUhK9xKKXdBCzKODMc2adkB2+8om9BDYugz+uGV7sLmpTYzvmz6Sw==",
+      "os": ["freebsd"],
+      "cpu": ["arm64"]
+    },
+    "@esbuild/freebsd-x64@0.25.5": {
+      "integrity": "sha512-PrikaNjiXdR2laW6OIjlbeuCPrPaAl0IwPIaRv+SMV8CiM8i2LqVUHFC1+8eORgWyY7yhQY+2U2fA55mBzReaw==",
+      "os": ["freebsd"],
+      "cpu": ["x64"]
+    },
+    "@esbuild/linux-arm64@0.25.5": {
+      "integrity": "sha512-Z9kfb1v6ZlGbWj8EJk9T6czVEjjq2ntSYLY2cw6pAZl4oKtfgQuS4HOq41M/BcoLPzrUbNd+R4BXFyH//nHxVg==",
+      "os": ["linux"],
+      "cpu": ["arm64"]
+    },
+    "@esbuild/linux-arm@0.25.5": {
+      "integrity": "sha512-cPzojwW2okgh7ZlRpcBEtsX7WBuqbLrNXqLU89GxWbNt6uIg78ET82qifUy3W6OVww6ZWobWub5oqZOVtwolfw==",
+      "os": ["linux"],
+      "cpu": ["arm"]
+    },
+    "@esbuild/linux-ia32@0.25.5": {
+      "integrity": "sha512-sQ7l00M8bSv36GLV95BVAdhJ2QsIbCuCjh/uYrWiMQSUuV+LpXwIqhgJDcvMTj+VsQmqAHL2yYaasENvJ7CDKA==",
+      "os": ["linux"],
+      "cpu": ["ia32"]
+    },
+    "@esbuild/linux-loong64@0.25.5": {
+      "integrity": "sha512-0ur7ae16hDUC4OL5iEnDb0tZHDxYmuQyhKhsPBV8f99f6Z9KQM02g33f93rNH5A30agMS46u2HP6qTdEt6Q1kg==",
+      "os": ["linux"],
+      "cpu": ["loong64"]
+    },
+    "@esbuild/linux-mips64el@0.25.5": {
+      "integrity": "sha512-kB/66P1OsHO5zLz0i6X0RxlQ+3cu0mkxS3TKFvkb5lin6uwZ/ttOkP3Z8lfR9mJOBk14ZwZ9182SIIWFGNmqmg==",
+      "os": ["linux"],
+      "cpu": ["mips64el"]
+    },
+    "@esbuild/linux-ppc64@0.25.5": {
+      "integrity": "sha512-UZCmJ7r9X2fe2D6jBmkLBMQetXPXIsZjQJCjgwpVDz+YMcS6oFR27alkgGv3Oqkv07bxdvw7fyB71/olceJhkQ==",
+      "os": ["linux"],
+      "cpu": ["ppc64"]
+    },
+    "@esbuild/linux-riscv64@0.25.5": {
+      "integrity": "sha512-kTxwu4mLyeOlsVIFPfQo+fQJAV9mh24xL+y+Bm6ej067sYANjyEw1dNHmvoqxJUCMnkBdKpvOn0Ahql6+4VyeA==",
+      "os": ["linux"],
+      "cpu": ["riscv64"]
+    },
+    "@esbuild/linux-s390x@0.25.5": {
+      "integrity": "sha512-K2dSKTKfmdh78uJ3NcWFiqyRrimfdinS5ErLSn3vluHNeHVnBAFWC8a4X5N+7FgVE1EjXS1QDZbpqZBjfrqMTQ==",
+      "os": ["linux"],
+      "cpu": ["s390x"]
+    },
+    "@esbuild/linux-x64@0.25.5": {
+      "integrity": "sha512-uhj8N2obKTE6pSZ+aMUbqq+1nXxNjZIIjCjGLfsWvVpy7gKCOL6rsY1MhRh9zLtUtAI7vpgLMK6DxjO8Qm9lJw==",
+      "os": ["linux"],
+      "cpu": ["x64"]
+    },
+    "@esbuild/netbsd-arm64@0.25.5": {
+      "integrity": "sha512-pwHtMP9viAy1oHPvgxtOv+OkduK5ugofNTVDilIzBLpoWAM16r7b/mxBvfpuQDpRQFMfuVr5aLcn4yveGvBZvw==",
+      "os": ["netbsd"],
+      "cpu": ["arm64"]
+    },
+    "@esbuild/netbsd-x64@0.25.5": {
+      "integrity": "sha512-WOb5fKrvVTRMfWFNCroYWWklbnXH0Q5rZppjq0vQIdlsQKuw6mdSihwSo4RV/YdQ5UCKKvBy7/0ZZYLBZKIbwQ==",
+      "os": ["netbsd"],
+      "cpu": ["x64"]
+    },
+    "@esbuild/openbsd-arm64@0.25.5": {
+      "integrity": "sha512-7A208+uQKgTxHd0G0uqZO8UjK2R0DDb4fDmERtARjSHWxqMTye4Erz4zZafx7Di9Cv+lNHYuncAkiGFySoD+Mw==",
+      "os": ["openbsd"],
+      "cpu": ["arm64"]
+    },
+    "@esbuild/openbsd-x64@0.25.5": {
+      "integrity": "sha512-G4hE405ErTWraiZ8UiSoesH8DaCsMm0Cay4fsFWOOUcz8b8rC6uCvnagr+gnioEjWn0wC+o1/TAHt+It+MpIMg==",
+      "os": ["openbsd"],
+      "cpu": ["x64"]
+    },
+    "@esbuild/sunos-x64@0.25.5": {
+      "integrity": "sha512-l+azKShMy7FxzY0Rj4RCt5VD/q8mG/e+mDivgspo+yL8zW7qEwctQ6YqKX34DTEleFAvCIUviCFX1SDZRSyMQA==",
+      "os": ["sunos"],
+      "cpu": ["x64"]
+    },
+    "@esbuild/win32-arm64@0.25.5": {
+      "integrity": "sha512-O2S7SNZzdcFG7eFKgvwUEZ2VG9D/sn/eIiz8XRZ1Q/DO5a3s76Xv0mdBzVM5j5R639lXQmPmSo0iRpHqUUrsxw==",
+      "os": ["win32"],
+      "cpu": ["arm64"]
+    },
+    "@esbuild/win32-ia32@0.25.5": {
+      "integrity": "sha512-onOJ02pqs9h1iMJ1PQphR+VZv8qBMQ77Klcsqv9CNW2w6yLqoURLcgERAIurY6QE63bbLuqgP9ATqajFLK5AMQ==",
+      "os": ["win32"],
+      "cpu": ["ia32"]
+    },
+    "@esbuild/win32-x64@0.25.5": {
+      "integrity": "sha512-TXv6YnJ8ZMVdX+SXWVBo/0p8LTcrUYngpWjvm91TMjjBQii7Oz11Lw5lbDV5Y0TzuhSJHwiH4hEtC1I42mMS0g==",
+      "os": ["win32"],
+      "cpu": ["x64"]
+    },
     "@mongodb-js/saslprep@1.2.2": {
       "integrity": "sha512-EB0O3SCSNRUFk66iRCpI+cXzIjdswfCs7F6nOC3RAGJ7xr5YhaicvsRwJ9eyzYvYRlCSDUO/c7g4yNulxKC1WA==",
       "dependencies": [
         "sparse-bitfield"
       ]
+    },
+    "@rollup/rollup-android-arm-eabi@4.43.0": {
+      "integrity": "sha512-Krjy9awJl6rKbruhQDgivNbD1WuLb8xAclM4IR4cN5pHGAs2oIMMQJEiC3IC/9TZJ+QZkmZhlMO/6MBGxPidpw==",
+      "os": ["android"],
+      "cpu": ["arm"]
+    },
+    "@rollup/rollup-android-arm64@4.43.0": {
+      "integrity": "sha512-ss4YJwRt5I63454Rpj+mXCXicakdFmKnUNxr1dLK+5rv5FJgAxnN7s31a5VchRYxCFWdmnDWKd0wbAdTr0J5EA==",
+      "os": ["android"],
+      "cpu": ["arm64"]
+    },
+    "@rollup/rollup-darwin-arm64@4.43.0": {
+      "integrity": "sha512-eKoL8ykZ7zz8MjgBenEF2OoTNFAPFz1/lyJ5UmmFSz5jW+7XbH1+MAgCVHy72aG59rbuQLcJeiMrP8qP5d/N0A==",
+      "os": ["darwin"],
+      "cpu": ["arm64"]
+    },
+    "@rollup/rollup-darwin-x64@4.43.0": {
+      "integrity": "sha512-SYwXJgaBYW33Wi/q4ubN+ldWC4DzQY62S4Ll2dgfr/dbPoF50dlQwEaEHSKrQdSjC6oIe1WgzosoaNoHCdNuMg==",
+      "os": ["darwin"],
+      "cpu": ["x64"]
+    },
+    "@rollup/rollup-freebsd-arm64@4.43.0": {
+      "integrity": "sha512-SV+U5sSo0yujrjzBF7/YidieK2iF6E7MdF6EbYxNz94lA+R0wKl3SiixGyG/9Klab6uNBIqsN7j4Y/Fya7wAjQ==",
+      "os": ["freebsd"],
+      "cpu": ["arm64"]
+    },
+    "@rollup/rollup-freebsd-x64@4.43.0": {
+      "integrity": "sha512-J7uCsiV13L/VOeHJBo5SjasKiGxJ0g+nQTrBkAsmQBIdil3KhPnSE9GnRon4ejX1XDdsmK/l30IYLiAaQEO0Cg==",
+      "os": ["freebsd"],
+      "cpu": ["x64"]
+    },
+    "@rollup/rollup-linux-arm-gnueabihf@4.43.0": {
+      "integrity": "sha512-gTJ/JnnjCMc15uwB10TTATBEhK9meBIY+gXP4s0sHD1zHOaIh4Dmy1X9wup18IiY9tTNk5gJc4yx9ctj/fjrIw==",
+      "os": ["linux"],
+      "cpu": ["arm"]
+    },
+    "@rollup/rollup-linux-arm-musleabihf@4.43.0": {
+      "integrity": "sha512-ZJ3gZynL1LDSIvRfz0qXtTNs56n5DI2Mq+WACWZ7yGHFUEirHBRt7fyIk0NsCKhmRhn7WAcjgSkSVVxKlPNFFw==",
+      "os": ["linux"],
+      "cpu": ["arm"]
+    },
+    "@rollup/rollup-linux-arm64-gnu@4.43.0": {
+      "integrity": "sha512-8FnkipasmOOSSlfucGYEu58U8cxEdhziKjPD2FIa0ONVMxvl/hmONtX/7y4vGjdUhjcTHlKlDhw3H9t98fPvyA==",
+      "os": ["linux"],
+      "cpu": ["arm64"]
+    },
+    "@rollup/rollup-linux-arm64-musl@4.43.0": {
+      "integrity": "sha512-KPPyAdlcIZ6S9C3S2cndXDkV0Bb1OSMsX0Eelr2Bay4EsF9yi9u9uzc9RniK3mcUGCLhWY9oLr6er80P5DE6XA==",
+      "os": ["linux"],
+      "cpu": ["arm64"]
+    },
+    "@rollup/rollup-linux-loongarch64-gnu@4.43.0": {
+      "integrity": "sha512-HPGDIH0/ZzAZjvtlXj6g+KDQ9ZMHfSP553za7o2Odegb/BEfwJcR0Sw0RLNpQ9nC6Gy8s+3mSS9xjZ0n3rhcYg==",
+      "os": ["linux"],
+      "cpu": ["loong64"]
+    },
+    "@rollup/rollup-linux-powerpc64le-gnu@4.43.0": {
+      "integrity": "sha512-gEmwbOws4U4GLAJDhhtSPWPXUzDfMRedT3hFMyRAvM9Mrnj+dJIFIeL7otsv2WF3D7GrV0GIewW0y28dOYWkmw==",
+      "os": ["linux"],
+      "cpu": ["ppc64"]
+    },
+    "@rollup/rollup-linux-riscv64-gnu@4.43.0": {
+      "integrity": "sha512-XXKvo2e+wFtXZF/9xoWohHg+MuRnvO29TI5Hqe9xwN5uN8NKUYy7tXUG3EZAlfchufNCTHNGjEx7uN78KsBo0g==",
+      "os": ["linux"],
+      "cpu": ["riscv64"]
+    },
+    "@rollup/rollup-linux-riscv64-musl@4.43.0": {
+      "integrity": "sha512-ruf3hPWhjw6uDFsOAzmbNIvlXFXlBQ4nk57Sec8E8rUxs/AI4HD6xmiiasOOx/3QxS2f5eQMKTAwk7KHwpzr/Q==",
+      "os": ["linux"],
+      "cpu": ["riscv64"]
+    },
+    "@rollup/rollup-linux-s390x-gnu@4.43.0": {
+      "integrity": "sha512-QmNIAqDiEMEvFV15rsSnjoSmO0+eJLoKRD9EAa9rrYNwO/XRCtOGM3A5A0X+wmG+XRrw9Fxdsw+LnyYiZWWcVw==",
+      "os": ["linux"],
+      "cpu": ["s390x"]
+    },
+    "@rollup/rollup-linux-x64-gnu@4.43.0": {
+      "integrity": "sha512-jAHr/S0iiBtFyzjhOkAics/2SrXE092qyqEg96e90L3t9Op8OTzS6+IX0Fy5wCt2+KqeHAkti+eitV0wvblEoQ==",
+      "os": ["linux"],
+      "cpu": ["x64"]
+    },
+    "@rollup/rollup-linux-x64-musl@4.43.0": {
+      "integrity": "sha512-3yATWgdeXyuHtBhrLt98w+5fKurdqvs8B53LaoKD7P7H7FKOONLsBVMNl9ghPQZQuYcceV5CDyPfyfGpMWD9mQ==",
+      "os": ["linux"],
+      "cpu": ["x64"]
+    },
+    "@rollup/rollup-win32-arm64-msvc@4.43.0": {
+      "integrity": "sha512-wVzXp2qDSCOpcBCT5WRWLmpJRIzv23valvcTwMHEobkjippNf+C3ys/+wf07poPkeNix0paTNemB2XrHr2TnGw==",
+      "os": ["win32"],
+      "cpu": ["arm64"]
+    },
+    "@rollup/rollup-win32-ia32-msvc@4.43.0": {
+      "integrity": "sha512-fYCTEyzf8d+7diCw8b+asvWDCLMjsCEA8alvtAutqJOJp/wL5hs1rWSqJ1vkjgW0L2NB4bsYJrpKkiIPRR9dvw==",
+      "os": ["win32"],
+      "cpu": ["ia32"]
+    },
+    "@rollup/rollup-win32-x64-msvc@4.43.0": {
+      "integrity": "sha512-SnGhLiE5rlK0ofq8kzuDkM0g7FN1s5VYY+YSMTibP7CqShxCQvqtNxTARS4xX4PFJfHjG0ZQYX9iGzI3FQh5Aw==",
+      "os": ["win32"],
+      "cpu": ["x64"]
+    },
+    "@types/estree@1.0.7": {
+      "integrity": "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ=="
     },
     "@types/node@22.15.15": {
       "integrity": "sha512-R5muMcZob3/Jjchn5LcO8jdKwSCbzqmPB6ruBxMcf9kbxtniZHP327s6C37iOfuw8mbKK3cAQa7sEl7afLrQ8A==",
@@ -68,6 +297,52 @@
       "dependencies": [
         "ms"
       ]
+    },
+    "esbuild@0.25.5": {
+      "integrity": "sha512-P8OtKZRv/5J5hhz0cUAdu/cLuPIKXpQl1R9pZtvmHWQvrAUVd0UNIPT4IB4W3rNOqVO0rlqHmCIbSwxh/c9yUQ==",
+      "optionalDependencies": [
+        "@esbuild/aix-ppc64",
+        "@esbuild/android-arm",
+        "@esbuild/android-arm64",
+        "@esbuild/android-x64",
+        "@esbuild/darwin-arm64",
+        "@esbuild/darwin-x64",
+        "@esbuild/freebsd-arm64",
+        "@esbuild/freebsd-x64",
+        "@esbuild/linux-arm",
+        "@esbuild/linux-arm64",
+        "@esbuild/linux-ia32",
+        "@esbuild/linux-loong64",
+        "@esbuild/linux-mips64el",
+        "@esbuild/linux-ppc64",
+        "@esbuild/linux-riscv64",
+        "@esbuild/linux-s390x",
+        "@esbuild/linux-x64",
+        "@esbuild/netbsd-arm64",
+        "@esbuild/netbsd-x64",
+        "@esbuild/openbsd-arm64",
+        "@esbuild/openbsd-x64",
+        "@esbuild/sunos-x64",
+        "@esbuild/win32-arm64",
+        "@esbuild/win32-ia32",
+        "@esbuild/win32-x64"
+      ],
+      "scripts": true,
+      "bin": true
+    },
+    "fdir@6.4.6_picomatch@4.0.2": {
+      "integrity": "sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==",
+      "dependencies": [
+        "picomatch"
+      ],
+      "optionalPeers": [
+        "picomatch"
+      ]
+    },
+    "fsevents@2.3.3": {
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "os": ["darwin"],
+      "scripts": true
     },
     "hono@4.7.11": {
       "integrity": "sha512-rv0JMwC0KALbbmwJDEnxvQCeJh+xbS3KEWW5PC9cMJ08Ur9xgatI0HmtgYZfOdOSOeYsp5LO2cOhdI8cLEbDEQ=="
@@ -126,11 +401,29 @@
     "ms@2.1.3": {
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
+    "nanoid@3.3.11": {
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "bin": true
+    },
     "nodemailer@6.10.0": {
       "integrity": "sha512-SQ3wZCExjeSatLE/HBaXS5vqUOQk6GtBdIIKxiFdmm01mOQZX/POJkO3SUX1wDiYcwUOJwT23scFSC9fY2H8IA=="
     },
     "nodemailer@7.0.3": {
       "integrity": "sha512-Ajq6Sz1x7cIK3pN6KesGTah+1gnwMnx5gKl3piQlQQE/PwyJ4Mbc8is2psWYxK3RJTVeqsDaCv8ZzXLCDHMTZw=="
+    },
+    "picocolors@1.1.1": {
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
+    },
+    "picomatch@4.0.2": {
+      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg=="
+    },
+    "postcss@8.5.5": {
+      "integrity": "sha512-d/jtm+rdNT8tpXuHY5MMtcbJFBkhXE6593XVR9UoGCH8jSFGci7jGvMGH5RYd5PBJW+00NZQt6gf7CbagJCrhg==",
+      "dependencies": [
+        "nanoid",
+        "picocolors",
+        "source-map-js"
+      ]
     },
     "prompts@2.4.2": {
       "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
@@ -142,16 +435,56 @@
     "punycode@2.3.1": {
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="
     },
+    "rollup@4.43.0": {
+      "integrity": "sha512-wdN2Kd3Twh8MAEOEJZsuxuLKCsBEo4PVNLK6tQWAn10VhsVewQLzcucMgLolRlhFybGxfclbPeEYBaP6RvUFGg==",
+      "dependencies": [
+        "@types/estree"
+      ],
+      "optionalDependencies": [
+        "@rollup/rollup-android-arm-eabi",
+        "@rollup/rollup-android-arm64",
+        "@rollup/rollup-darwin-arm64",
+        "@rollup/rollup-darwin-x64",
+        "@rollup/rollup-freebsd-arm64",
+        "@rollup/rollup-freebsd-x64",
+        "@rollup/rollup-linux-arm-gnueabihf",
+        "@rollup/rollup-linux-arm-musleabihf",
+        "@rollup/rollup-linux-arm64-gnu",
+        "@rollup/rollup-linux-arm64-musl",
+        "@rollup/rollup-linux-loongarch64-gnu",
+        "@rollup/rollup-linux-powerpc64le-gnu",
+        "@rollup/rollup-linux-riscv64-gnu",
+        "@rollup/rollup-linux-riscv64-musl",
+        "@rollup/rollup-linux-s390x-gnu",
+        "@rollup/rollup-linux-x64-gnu",
+        "@rollup/rollup-linux-x64-musl",
+        "@rollup/rollup-win32-arm64-msvc",
+        "@rollup/rollup-win32-ia32-msvc",
+        "@rollup/rollup-win32-x64-msvc",
+        "fsevents"
+      ],
+      "bin": true
+    },
     "sift@17.1.3": {
       "integrity": "sha512-Rtlj66/b0ICeFzYTuNvX/EF1igRbbnGSvEyT79McoZa/DeGhMyC5pWKOEsZKnpkqtSeovd5FL/bjHWC3CIIvCQ=="
     },
     "sisteransi@1.0.5": {
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="
     },
+    "source-map-js@1.2.1": {
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="
+    },
     "sparse-bitfield@3.0.3": {
       "integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
       "dependencies": [
         "memory-pager"
+      ]
+    },
+    "tinyglobby@0.2.14_picomatch@4.0.2": {
+      "integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
+      "dependencies": [
+        "fdir",
+        "picomatch"
       ]
     },
     "tr46@5.1.1": {
@@ -162,6 +495,25 @@
     },
     "undici-types@6.21.0": {
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="
+    },
+    "vite@6.3.5_@types+node@22.15.15_picomatch@4.0.2": {
+      "integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
+      "dependencies": [
+        "@types/node",
+        "esbuild",
+        "fdir",
+        "picomatch",
+        "postcss",
+        "rollup",
+        "tinyglobby"
+      ],
+      "optionalDependencies": [
+        "fsevents"
+      ],
+      "optionalPeers": [
+        "@types/node"
+      ],
+      "bin": true
     },
     "webidl-conversions@7.0.0": {
       "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g=="

--- a/deno.json
+++ b/deno.json
@@ -1,0 +1,5 @@
+{
+    "tasks": {
+        "dev": "deno run -A --watch dev.ts"
+    }
+}

--- a/deno.json
+++ b/deno.json
@@ -1,5 +1,8 @@
 {
     "tasks": {
         "dev": "deno run -A --watch dev.ts"
+    },
+    "imports": {
+        "@std/streams": "jsr:@std/streams@^1.0.10"
     }
 }

--- a/deno.lock
+++ b/deno.lock
@@ -1,0 +1,6 @@
+{
+  "version": "5",
+  "remote": {
+    "https://deno.land/std@0.224.0/streams/text_line_stream.ts": "21f33d3922e019ec1a1676474beb543929cb564ec99b69cd2654e029e0f45bd5"
+  }
+}

--- a/deno.lock
+++ b/deno.lock
@@ -1,6 +1,26 @@
 {
   "version": "5",
+  "specifiers": {
+    "jsr:@std/bytes@^1.0.6": "1.0.6",
+    "jsr:@std/streams@^1.0.10": "1.0.10"
+  },
+  "jsr": {
+    "@std/bytes@1.0.6": {
+      "integrity": "f6ac6adbd8ccd99314045f5703e23af0a68d7f7e58364b47d2c7f408aeb5820a"
+    },
+    "@std/streams@1.0.10": {
+      "integrity": "75c0b1431873cd0d8b3d679015220204d36d3c7420d93b60acfc379eb0dc30af",
+      "dependencies": [
+        "jsr:@std/bytes"
+      ]
+    }
+  },
   "remote": {
     "https://deno.land/std@0.224.0/streams/text_line_stream.ts": "21f33d3922e019ec1a1676474beb543929cb564ec99b69cd2654e029e0f45bd5"
+  },
+  "workspace": {
+    "dependencies": [
+      "jsr:@std/streams@^1.0.10"
+    ]
   }
 }

--- a/dev.ts
+++ b/dev.ts
@@ -1,0 +1,92 @@
+import { TextLineStream } from "https://deno.land/std@0.224.0/streams/text_line_stream.ts";
+import { TextDecoderStream } from "https://deno.land/std@0.224.0/streams/text_decoder_stream.ts";
+
+const targetDirectories = [
+    "app/api",
+    "app/client",
+    "app/registry",
+    "app/registry_ui",
+];
+
+async function runDevCommandInDir(dir: string): Promise<Deno.CommandStatus> {
+    console.log(`[INFO] Starting 'deno task dev' in ./${dir}`);
+    try {
+        const command = new Deno.Command("deno", {
+            args: ["task", "dev"],
+            cwd: `./${dir}`, // Ensure it's treated as a relative path from current script's CWD
+            stdout: "piped",
+            stderr: "piped",
+        });
+
+        const process = command.spawn();
+
+        // Pipe stdout
+        process.stdout
+            .pipeThrough(new TextDecoderStream())
+            .pipeThrough(new TextLineStream())
+            .pipeTo(
+                new WritableStream({
+                    write(line: string) {
+                        console.log(`[${dir}] ${line}`);
+                    },
+                })
+            ).catch(error => {
+                console.error(`[${dir} STDOUT_PIPE_ERROR] ${error.message}`);
+            });
+
+        // Pipe stderr
+        process.stderr
+            .pipeThrough(new TextDecoderStream())
+            .pipeThrough(new TextLineStream())
+            .pipeTo(
+                new WritableStream({
+                    write(line: string) {
+                        console.error(`[${dir} ERROR] ${line}`);
+                    },
+                })
+            ).catch(error => {
+                console.error(`[${dir} STDERR_PIPE_ERROR] ${error.message}`);
+            });
+
+        const status = await process.status;
+        if (status.success) {
+            console.log(`[INFO] 'deno task dev' in ./${dir} finished successfully.`);
+        } else {
+            console.error(`[INFO] 'deno task dev' in ./${dir} exited with code ${status.code}.`);
+        }
+        return status;
+
+    } catch (error) {
+        console.error(`[INFO] Failed to start 'deno task dev' in ./${dir}: ${error.message}`);
+        // Re-throw or return a custom error status if needed for Promise.all handling
+        throw error; 
+    }
+}
+
+async function main() {
+    const processPromises: Promise<Deno.CommandStatus>[] = [];
+
+    for (const dir of targetDirectories) {
+        processPromises.push(runDevCommandInDir(dir));
+    }
+
+    try {
+        const results = await Promise.all(processPromises);
+        console.log("[INFO] All 'deno task dev' processes have completed.");
+        results.forEach((status, index) => {
+            if (!status.success) {
+                console.warn(`[INFO] Process for ./${targetDirectories[index]} exited with error code: ${status.code}`);
+            }
+        });
+    } catch (error) {
+        console.error("[INFO] An error occurred while managing dev tasks:", error.message);
+        // This block is reached if any `runDevCommandInDir` throws an unhandled error (e.g., command not found, cwd invalid before spawn)
+        // Child processes that were successfully spawned might still be running.
+        // Deno's default behavior on script termination (e.g. due to unhandled rejection)
+        // should typically terminate spawned child processes.
+    }
+}
+
+if (import.meta.main) {
+    main();
+}

--- a/dev.ts
+++ b/dev.ts
@@ -1,5 +1,4 @@
-import { TextLineStream } from "https://deno.land/std@0.224.0/streams/text_line_stream.ts";
-import { TextDecoderStream } from "https://deno.land/std@0.224.0/streams/text_decoder_stream.ts";
+import { TextLineStream } from "@std/streams/text-line-stream";
 
 const targetDirectories = [
     "app/api",
@@ -57,7 +56,11 @@ async function runDevCommandInDir(dir: string): Promise<Deno.CommandStatus> {
         return status;
 
     } catch (error) {
-        console.error(`[INFO] Failed to start 'deno task dev' in ./${dir}: ${error.message}`);
+        if (error instanceof Error) {
+            console.error(`[INFO] Failed to start 'deno task dev' in ./${dir}: ${error.message}`);
+        } else {
+            console.error(`[INFO] Failed to start 'deno task dev' in ./${dir}: ${String(error)}`);
+        }
         // Re-throw or return a custom error status if needed for Promise.all handling
         throw error; 
     }
@@ -79,7 +82,11 @@ async function main() {
             }
         });
     } catch (error) {
-        console.error("[INFO] An error occurred while managing dev tasks:", error.message);
+        if (error instanceof Error) {
+            console.error("[INFO] An error occurred while managing dev tasks:", error.message);
+        } else {
+            console.error("[INFO] An error occurred while managing dev tasks:", String(error));
+        }
         // This block is reached if any `runDevCommandInDir` throws an unhandled error (e.g., command not found, cwd invalid before spawn)
         // Child processes that were successfully spawned might still be running.
         // Deno's default behavior on script termination (e.g. due to unhandled rejection)

--- a/docs/builder/README.md
+++ b/docs/builder/README.md
@@ -319,7 +319,6 @@ type Permission =
   | "cdn:read"
   | "cdn:write"
   | "events:publish"
-  | "events:subscribe"
   | "deno:read" // 特権権限
   | "deno:write" // 特権権限
   | "deno:net" // 特権権限
@@ -576,7 +575,7 @@ const memoExtension = new FunctionBasedTakopack()
     description: "A simple memo-taking extension",
     version: "1.0.0",
     identifier: "com.example.simplememo",
-    permissions: ["kv:read", "kv:write", "events:publish", "events:subscribe"],
+    permissions: ["kv:read", "kv:write", "events:publish"],
   });
 
 await memoExtension.build();

--- a/docs/takopack/v2.md
+++ b/docs/takopack/v2.md
@@ -113,7 +113,6 @@ manifest.json は [manifest.schema.json](./manifest.schema.json)
     "cdn:read",
     "cdn:write",
     "events:publish",
-    "events:subscribe",
     "extensions:invoke", // 他拡張API呼び出し権限
     "extensions:export", // 自身のAPI公開権限
     // 以下の特権権限は高度な権限を持ちます。使用に関して警告が表示されます。
@@ -284,11 +283,7 @@ manifest.json は [manifest.schema.json](./manifest.schema.json)
 サーバー側ハンドラーが存在する場合は `[status, body]` が返ります。それ以外は
 `void` です。
 
-**共通API**:
-
-- `takos.events.subscribe(eventName: string, handler: (payload: any) => void): () => void`
-
-**必要権限**: `events:publish` / `events:subscribe`
+**必要権限**: `events:publish`
 
 - **レート制限**: 10件/秒
 

--- a/docs/takopack/v3.md
+++ b/docs/takopack/v3.md
@@ -214,7 +214,7 @@ awesome-pack.takopack
 - **list**: `takos.kv.list(): Promise<string[]>`
   - **必要権限**: `kv:read` / `kv:write`
   - `server.js` と `client.js` / `index.html` のストレージは独立
-  - クライアント側では LocalStorage を利用したストアが使われ、サーバーとは同期されません
+  - クライアント側では IndexedDB を利用したストアが使われ、サーバーとは同期されません
 
 ### fetch
 

--- a/docs/takopack/v3.md
+++ b/docs/takopack/v3.md
@@ -52,7 +52,7 @@ awesome-pack.takopack
 ```
 
 `server.js` と `client.js` は依存のない単一ファイルです。`index.html` は UI
-を提供します。
+を提供します。`/api/extensions/<id>/ui` で読み込むと `client.js` も自動でロードされます。
 
 ---
 
@@ -246,6 +246,7 @@ client, background, ui) からは同じ API で実行できます。
   - `options.push` を `true` にすると、クライアントがオフラインでも FCM などの
     Push 通知経由でイベントを配信できます。
   - イベントハンドラーは宣言されたファイル上のレイヤーで実行されます。
+    `client` と `ui` ソースのイベントはブラウザ上で処理され、サーバーへは送信されません。
 
 ### 拡張間 API
 

--- a/docs/takopack/v3.md
+++ b/docs/takopack/v3.md
@@ -171,6 +171,7 @@ awesome-pack.takopack
   - **必要権限**: `activitypub:send`
 - **list**: `takos.ap.list(userId?: string): Promise<string[]>`
   - **必要権限**: `activitypub:read`
+  - **利用可能レイヤー**: `server` のみ
 
 #### フック処理
 
@@ -232,6 +233,7 @@ awesome-pack.takopack
 - **list**: `takos.cdn.list(prefix?: string): Promise<string[]>`
   - **必要権限**: `cdn:read` / `cdn:write`
   - **制限**: 合計 20MB まで。エンドポイント `/cdn/<identifier>/<path>`
+  - **利用可能レイヤー**: `server` のみ
 
 ### events
 
@@ -243,6 +245,7 @@ client, background, ui) からは同じ API で実行できます。
     を取得します。その他のレイヤー向けは `void` を返します。
   - `options.push` を `true` にすると、クライアントがオフラインでも FCM などの
     Push 通知経由でイベントを配信できます。
+  - イベントハンドラーは宣言されたファイル上のレイヤーで実行されます。
 
 ### 拡張間 API
 
@@ -325,7 +328,7 @@ if (api2) {
 | ----------------------------------------------------------- | --------- | ---------------------- | --------------- |
 | `fetch`                                                     | ✓         | ✓                      | ✓               |
 | `kv`                                                        | ✓         | ✓                      | ✓               |
-| `cdn`                                                       | ✓         | ✓                      | ✓               |
+| `cdn`                                                       | ✓         | ―                      | ―               |
 | `events`                                                    | ✓         | ✓                      | ✓               |
 | `activitypub`                                               | ✓         | ―                      | ―               |
 | `extensions` / `activateExtension`                          | ✓         | ✓                      | ✓               |

--- a/docs/takopack/v3.md
+++ b/docs/takopack/v3.md
@@ -214,7 +214,7 @@ awesome-pack.takopack
 - **list**: `takos.kv.list(): Promise<string[]>`
   - **必要権限**: `kv:read` / `kv:write`
   - `server.js` と `client.js` / `index.html` のストレージは独立
-  - クライアント側ではメモリ上の簡易ストアが利用され、サーバーとは同期されません
+  - クライアント側では LocalStorage を利用したストアが使われ、サーバーとは同期されません
 
 ### fetch
 

--- a/docs/takopack/v3.md
+++ b/docs/takopack/v3.md
@@ -215,6 +215,7 @@ awesome-pack.takopack
 - **list**: `takos.kv.list(): Promise<string[]>`
   - **必要権限**: `kv:read` / `kv:write`
   - `server.js` と `client.js` / `index.html` のストレージは独立
+  - クライアント側ではメモリ上の簡易ストアが利用され、サーバーとは同期されません
 
 ### fetch
 

--- a/docs/takopack/v3.md
+++ b/docs/takopack/v3.md
@@ -96,7 +96,6 @@ awesome-pack.takopack
     "cdn:read",
     "cdn:write",
     "events:publish",
-    "events:subscribe",
     "extensions:invoke",
     "extensions:export",
     // denoの権限は特権的な操作を制限するために必要です

--- a/examples/api-test-extension/README.md
+++ b/examples/api-test-extension/README.md
@@ -4,7 +4,8 @@ This example extension provides a quick way to verify each Takopack runtime API.
 The UI page lists buttons for the APIs exposed to the server, client and UI
 layers individually. Click a button to run that API call and see the returned
 value in the output panel. ActivityPub and CDN features are server-only, so
-tests for those APIs run only on the server layer.
+tests for those APIs run only on the server layer. The client KV store uses
+an in-memory map separate from the server's storage.
 
 Use the provided build task to generate a `.takopack` archive:
 

--- a/examples/api-test-extension/README.md
+++ b/examples/api-test-extension/README.md
@@ -5,7 +5,7 @@ The UI page lists buttons for the APIs exposed to the server, client and UI
 layers individually. Click a button to run that API call and see the returned
 value in the output panel. ActivityPub and CDN features are server-only, so
 tests for those APIs run only on the server layer. The client KV store
-stores values using `localStorage` in the browser, separate from the
+stores values using IndexedDB in the browser, separate from the
 server's storage.
 
 Use the provided build task to generate a `.takopack` archive:

--- a/examples/api-test-extension/README.md
+++ b/examples/api-test-extension/README.md
@@ -3,7 +3,8 @@
 This example extension provides a quick way to verify each Takopack runtime API.
 The UI page lists buttons for the APIs exposed to the server, client and UI
 layers individually. Click a button to run that API call and see the returned
-value in the output panel.
+value in the output panel. ActivityPub and CDN features are server-only, so
+tests for those APIs run only on the server layer.
 
 Use the provided build task to generate a `.takopack` archive:
 

--- a/examples/api-test-extension/README.md
+++ b/examples/api-test-extension/README.md
@@ -4,8 +4,9 @@ This example extension provides a quick way to verify each Takopack runtime API.
 The UI page lists buttons for the APIs exposed to the server, client and UI
 layers individually. Click a button to run that API call and see the returned
 value in the output panel. ActivityPub and CDN features are server-only, so
-tests for those APIs run only on the server layer. The client KV store uses
-an in-memory map separate from the server's storage.
+tests for those APIs run only on the server layer. The client KV store
+stores values using `localStorage` in the browser, separate from the
+server's storage.
 
 Use the provided build task to generate a `.takopack` archive:
 

--- a/examples/api-test-extension/src/client/api.ts
+++ b/examples/api-test-extension/src/client/api.ts
@@ -11,14 +11,6 @@ async function testKv() {
   return { value };
 }
 
-async function testCdn() {
-  const t = getTakosClientAPI();
-  await t?.cdn.write("client.txt", "hello", { cacheTTL: 0 });
-  const data = await t?.cdn.read("client.txt");
-  await t?.cdn.delete("client.txt");
-  return { data };
-}
-
 async function testEvents() {
   const t = getTakosClientAPI();
   let flag = false;
@@ -48,13 +40,6 @@ ApiClient.onClientKv = async (): Promise<[number, Record<string, unknown>]> => {
   return [200, await testKv()];
 };
 
-/** @event("clientCdn", { source: "ui" }) */
-ApiClient.onClientCdn = async (): Promise<
-  [number, Record<string, unknown>]
-> => {
-  return [200, await testCdn()];
-};
-
 /** @event("clientEvents", { source: "ui" }) */
 ApiClient.onClientEvents = async (): Promise<
   [number, Record<string, unknown>]
@@ -79,9 +64,6 @@ ApiClient.onClientFetch = async (): Promise<
 // Direct wrappers for event names when not using builder-generated wrappers
 export function clientKv(): Promise<[number, Record<string, unknown>]> {
   return ApiClient.onClientKv();
-}
-export function clientCdn(): Promise<[number, Record<string, unknown>]> {
-  return ApiClient.onClientCdn();
 }
 export function clientEvents(): Promise<[number, Record<string, unknown>]> {
   return ApiClient.onClientEvents();

--- a/examples/api-test-extension/src/client/api.ts
+++ b/examples/api-test-extension/src/client/api.ts
@@ -13,13 +13,8 @@ async function testKv() {
 
 async function testEvents() {
   const t = getTakosClientAPI();
-  let flag = false;
-  const unsub = t?.events.subscribe("clientPing", () => {
-    flag = true;
-  });
   await t?.events.publish("clientPing", {});
-  unsub?.();
-  return { received: flag };
+  return { ok: true };
 }
 
 async function testExtensions() {

--- a/examples/api-test-extension/src/server/api.ts
+++ b/examples/api-test-extension/src/server/api.ts
@@ -27,13 +27,8 @@ async function testCdn() {
 
 async function testEvents() {
   const t = getApi();
-  let flag = false;
-  const unsub = t?.events.subscribe("srvPing", () => {
-    flag = true;
-  });
   await t?.events.publish("srvPing", {});
-  unsub?.();
-  return { received: flag };
+  return { ok: true };
 }
 
 async function testActivityPub() {

--- a/examples/api-test-extension/src/ui/index.html
+++ b/examples/api-test-extension/src/ui/index.html
@@ -59,14 +59,12 @@
       ];
       const clientTests = [
         "clientKv",
-        "clientCdn",
         "clientEvents",
         "clientExtensions",
         "clientFetch",
       ];
       const uiTests = [
         "uiKv",
-        "uiCdn",
         "uiEvents",
         "uiFetch",
         "uiExtensions",
@@ -102,11 +100,6 @@
             const value = await takos.kv.read("ui:test");
             await takos.kv.delete("ui:test");
             print(name, { value });
-          } else if (name === "uiCdn") {
-            await takos.cdn.write("ui.txt", "hello", { cacheTTL: 0 });
-            const data = await takos.cdn.read("ui.txt");
-            await takos.cdn.delete("ui.txt");
-            print(name, { data });
           } else if (name === "uiEvents") {
             let received = false;
             const u = takos.events.subscribe("uiPing", () => {

--- a/examples/api-test-extension/src/ui/index.html
+++ b/examples/api-test-extension/src/ui/index.html
@@ -101,13 +101,8 @@
             await takos.kv.delete("ui:test");
             print(name, { value });
           } else if (name === "uiEvents") {
-            let received = false;
-            const u = takos.events.subscribe("uiPing", () => {
-              received = true;
-            });
             await takos.events.publish("uiPing", {});
-            u();
-            print(name, { received });
+            print(name, { ok: true });
           } else if (name === "uiFetch") {
             const res = await takos.fetch("https://example.com");
             print(name, { ok: res.ok });

--- a/examples/api-test-extension/takopack.config.ts
+++ b/examples/api-test-extension/takopack.config.ts
@@ -22,7 +22,6 @@ export default defineConfig({
       "cdn:read",
       "cdn:write",
       "events:publish",
-      "events:subscribe",
       "extensions:invoke",
       "extensions:export",
       "deno:read",

--- a/examples/microblog-extension/takopack.config.ts
+++ b/examples/microblog-extension/takopack.config.ts
@@ -10,7 +10,6 @@ export default defineConfig({
       "kv:read",
       "kv:write",
       "events:publish",
-      "events:subscribe",
     ],
   },
 

--- a/packages/builder/src/api-helpers.ts
+++ b/packages/builder/src/api-helpers.ts
@@ -18,10 +18,6 @@ export interface TakosEventsAPI {
     payload: T,
     options?: { push?: boolean },
   ): Promise<[number, unknown] | void>;
-  subscribe<T = unknown>(
-    eventName: string,
-    handler: (payload: T) => void,
-  ): () => void;
 }
 
 export interface TakosKVAPI {

--- a/packages/builder/src/api-helpers.ts
+++ b/packages/builder/src/api-helpers.ts
@@ -98,8 +98,6 @@ export interface TakosServerAPI {
 
 export interface TakosClientAPI {
   kv: TakosKVAPI;
-  activitypub: TakosActivityPubAPI;
-  cdn: TakosCdnAPI;
   events: TakosEventsAPI;
   extensions: TakosExtensionsAPI;
   activateExtension(
@@ -110,7 +108,6 @@ export interface TakosClientAPI {
 
 export interface TakosUIAPI {
   events: TakosEventsAPI;
-  activitypub: TakosActivityPubAPI;
   extensions: TakosExtensionsAPI;
   activateExtension(
     identifier: string,
@@ -247,7 +244,6 @@ export function isClientContext(api: unknown): api is TakosClientAPI {
   return api !== null &&
     typeof api === "object" &&
     "kv" in api &&
-    "cdn" in api &&
     "events" in api &&
     "fetch" in api;
 }
@@ -256,5 +252,6 @@ export function isUIContext(api: unknown): api is TakosUIAPI {
   return api !== null &&
     typeof api === "object" &&
     "events" in api &&
-    !("kv" in api);
+    !("kv" in api) &&
+    !("activitypub" in api);
 }

--- a/packages/builder/src/generator.ts
+++ b/packages/builder/src/generator.ts
@@ -635,7 +635,6 @@ export interface TakosEvent<T = SerializableValue> {
 }
 
 export type EventHandler<T = SerializableValue> = (payload: T) => void | Promise<void>;
-export type EventUnsubscribe = () => void;
 
 // KV API
 export interface TakosKVAPI {
@@ -686,8 +685,6 @@ declare global {
       cdn: TakosCdnAPI;
       events: {
         publish<T = SerializableValue>(name: string, payload: T): Promise<void>;
-        subscribe<T = SerializableValue>(name: string, handler: EventHandler<T>): EventUnsubscribe;
-        unsubscribe(name: string, handler: EventHandler): void;
       };
     } | undefined;
   }
@@ -701,8 +698,6 @@ export interface GlobalThisWithClientTakos {
     cdn: TakosCdnAPI;
     events: {
       publish<T = SerializableValue>(name: string, payload: T): Promise<void>;
-      subscribe<T = SerializableValue>(name: string, handler: EventHandler<T>): EventUnsubscribe;
-      unsubscribe(name: string, handler: EventHandler): void;
     };
   } | undefined;
 }
@@ -715,8 +710,6 @@ export interface GlobalThisWithUITakos {
   takos: {
     events: {
       publish<T = SerializableValue>(name: string, payload: T): Promise<void>;
-      subscribe<T = SerializableValue>(name: string, handler: EventHandler<T>): EventUnsubscribe;
-      unsubscribe(name: string, handler: EventHandler): void;
     };
   } | undefined;
 }

--- a/packages/builder/src/generator.ts
+++ b/packages/builder/src/generator.ts
@@ -160,6 +160,7 @@ export class VirtualEntryGenerator {
     const wrappers: string[] = [];
     const classMap = new Map<string, Set<string>>();
     const exportInfoMap = new Map<string, ExportInfo>();
+    const eventWrappers = new Map<string, { className?: string; handler: string }>();
 
     analyses.forEach((analysis) => {
       // import文を収集
@@ -213,14 +214,14 @@ export class VirtualEntryGenerator {
         {},
         [],
         classMap,
-        new Map(),
+        eventWrappers,
       );
       this.processDecorators(
         analysis,
         {},
         [],
         classMap,
-        new Map(),
+        eventWrappers,
       );
     });
 
@@ -246,6 +247,20 @@ export class VirtualEntryGenerator {
           exports.push(wrapperName);
         });
       }
+    });
+
+    eventWrappers.forEach((info, eventName) => {
+      const wrapperName = eventName;
+      if (info.className) {
+        wrappers.push(
+          `export const ${wrapperName} = (...args: any[]) => ${info.className}.${info.handler}(...args);`,
+        );
+      } else {
+        wrappers.push(
+          `export const ${wrapperName} = (...args: any[]) => ${info.handler}(...args);`,
+        );
+      }
+      exports.push(wrapperName);
     });
 
     const content = this.buildEntryContent([...imports, ...wrappers], exports);

--- a/packages/builder/src/types.ts
+++ b/packages/builder/src/types.ts
@@ -409,20 +409,20 @@ export interface TakosEventsAPI {
 // Main Takos API Interface
 export interface TakosAPI {
   kv: TakosKVAPI;
-  activitypub: TakosActivityPubAPI;
-  ap: TakosActivityPubAPI;
-  cdn: TakosCdnAPI;
   fetch(url: string, options?: RequestInit): Promise<Response>;
 }
 
 export interface TakosServerAPI extends TakosAPI {
+  activitypub: TakosActivityPubAPI;
+  ap: TakosActivityPubAPI;
+  cdn: TakosCdnAPI;
   events: TakosEventsAPI;
   extensions: TakosExtensionsAPI;
   activateExtension(
     identifier: string,
-  ): Promise<
-    { publish(name: string, payload?: SerializableValue): Promise<SerializableValue> } | undefined
-  >;
+    ): Promise<
+      { publish(name: string, payload?: SerializableValue): Promise<SerializableValue> } | undefined
+    >;
 }
 
 export interface TakosClientAPI extends TakosAPI {

--- a/packages/builder/src/types.ts
+++ b/packages/builder/src/types.ts
@@ -15,7 +15,6 @@ export type Permission =
   | "cdn:read"
   | "cdn:write"
   | "events:publish"
-  | "events:subscribe"
   | "deno:read"
   | "deno:write"
   | "deno:net"
@@ -326,7 +325,6 @@ export interface TakosEvent<T = SerializableValue> {
 export type EventHandler<T = SerializableValue> = (
   payload: T,
 ) => void | Promise<void>;
-export type EventUnsubscribe = () => void;
 
 // Assets 関連型
 export interface AssetWriteOptions {
@@ -400,10 +398,6 @@ export interface TakosEventsAPI {
     payload: SerializableValue,
     options?: { push?: boolean },
   ): Promise<[200 | 400 | 500, SerializableObject] | void>;
-  subscribe<T = SerializableValue>(
-    eventName: string,
-    handler: EventHandler<T>,
-  ): EventUnsubscribe;
 }
 
 // Main Takos API Interface

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -18,7 +18,8 @@ const runtime = new TakoPack([
   },
 });
 await runtime.init();
-const result = await runtime.callServer(manifest.identifier, "hello", [
+// Automatically runs the handler in the appropriate layer
+const result = await runtime.call(manifest.identifier, "hello", [
   "world",
 ]);
 ```

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -18,7 +18,7 @@ const runtime = new TakoPack([
   },
 });
 await runtime.init();
-// Automatically runs the handler in the appropriate layer
+// `call()` runs the handler on the layer specified in `eventDefinitions`
 const result = await runtime.call(manifest.identifier, "hello", [
   "world",
 ]);

--- a/packages/runtime/mod.ts
+++ b/packages/runtime/mod.ts
@@ -419,6 +419,20 @@ const TAKOS_PATHS: string[][] = [
   ["activateExtension"],
 ];
 
+const CLIENT_TAKOS_PATHS: string[][] = [
+  ["fetch"],
+  ["kv", "read"],
+  ["kv", "write"],
+  ["kv", "delete"],
+  ["kv", "list"],
+  ["events", "publish"],
+  ["events", "subscribe"],
+  ["extensions", "get"],
+  ["extensions", "activate"],
+  ["extensions", "invoke"],
+  ["activateExtension"],
+];
+
 class PackWorker {
   #worker: Worker;
   #ready: Promise<void>;
@@ -430,6 +444,7 @@ class PackWorker {
     takos: Takos,
     perms: Record<string, boolean>,
     useDeno = false,
+    paths: string[][] = TAKOS_PATHS,
   ) {
     const url = URL.createObjectURL(
       new Blob([WORKER_SOURCE], { type: "application/javascript" }),
@@ -471,7 +486,7 @@ class PackWorker {
     this.#worker.postMessage({
       type: "init",
       code: wrapped,
-      takosPaths: TAKOS_PATHS,
+      takosPaths: paths,
       allowedPermissions: perms,
       extensions: Array.from(takos.extensions.all, (e) => ({
         identifier: e.identifier,
@@ -724,6 +739,7 @@ export class TakoPack {
           this.serverTakos,
           perms,
           true,
+          TAKOS_PATHS,
         );
       }
       if (pack.clientCode) {
@@ -742,6 +758,7 @@ export class TakoPack {
           this.clientTakos,
           perms,
           false,
+          CLIENT_TAKOS_PATHS,
         );
       }
     }

--- a/packages/runtime/mod.ts
+++ b/packages/runtime/mod.ts
@@ -274,6 +274,7 @@ export class Takos {
     get(id: string): Extension | undefined;
     all: Extension[];
   };
+  private localKv = new Map<string, unknown>();
   extensions: TakosExtensions;
   constructor(opts: TakosOptions = {}) {
     this.opts = opts;
@@ -311,10 +312,17 @@ export class Takos {
     return fn(url, options);
   };
   kv = {
-    read: async (_key: string) => undefined as unknown,
-    write: async (_key: string, _value: unknown) => {},
-    delete: async (_key: string) => {},
-    list: async () => [] as string[],
+    read: async (key: string) => this.localKv.get(key),
+    write: async (key: string, value: unknown) => {
+      this.localKv.set(key, value);
+    },
+    delete: async (key: string) => {
+      this.localKv.delete(key);
+    },
+    list: async (prefix?: string) => {
+      const keys = Array.from(this.localKv.keys());
+      return prefix ? keys.filter((k) => k.startsWith(prefix)) : keys;
+    },
   };
   events: TakosEvents = {
     publish: async (

--- a/packages/runtime/mod.ts
+++ b/packages/runtime/mod.ts
@@ -18,7 +18,6 @@ export interface TakosEvents {
     payload: unknown,
     options?: { push?: boolean },
   ): Promise<unknown>;
-  subscribe(name: string, handler: (payload: unknown) => void): () => void;
 }
 
 export interface TakosCdn {
@@ -332,12 +331,6 @@ export class Takos {
     ): Promise<unknown> => {
       return undefined;
     },
-    subscribe: (
-      _name: string,
-      _handler: (payload: unknown) => void,
-    ): () => void => {
-      return () => {};
-    },
   };
   cdn = {
     read: async (_path: string) => "",
@@ -384,7 +377,6 @@ const TAKOS_PATHS: string[][] = [
   ["kv", "delete"],
   ["kv", "list"],
   ["events", "publish"],
-  ["events", "subscribe"],
   ["cdn", "read"],
   ["cdn", "write"],
   ["cdn", "delete"],
@@ -434,7 +426,6 @@ const CLIENT_TAKOS_PATHS: string[][] = [
   ["kv", "delete"],
   ["kv", "list"],
   ["events", "publish"],
-  ["events", "subscribe"],
   ["extensions", "get"],
   ["extensions", "activate"],
   ["extensions", "invoke"],


### PR DESCRIPTION
## Summary
- update API test example to remove client-side CDN usage
- clarify in README that ActivityPub and CDN tests run only on server layer
- adjust UI script to skip CDN tests in client and UI

## Testing
- `deno test -A` *(fails: JSR package manifest for '@std/assert' failed to load)*

------
https://chatgpt.com/codex/tasks/task_e_68513baed08883289bfd89356fe90f43