### PR TITLE
Improve registry version handling

### DIFF
--- a/app/registry/README.md
+++ b/app/registry/README.md
@@ -23,6 +23,7 @@
     レコードとして追加してから実行します
 - `GET /api/domains` - 登録済みドメイン一覧を取得
 - `POST /api/packages` - パッケージ登録（ドメイン確認済みが必要）
+  - 既存の identifier と version の組み合わせは登録できません
 - `GET /api/<file>` - `.takopack` アーカイブのダウンロード
 
 ## サーバーの起動方法

--- a/docs/takopack/registry.md
+++ b/docs/takopack/registry.md
@@ -16,6 +16,7 @@ HTTP API を提供します。
   特定の識別子の最新パッケージ情報を取得します。
 - `GET <downloadUrl>` – `index.json` で参照されている `.takopack`
   アーカイブをダウンロードします。
+- パッケージ登録時は同じ identifier と version の組み合わせを再登録できません。
 
 `index.json` のフォーマットは以下の通りです。
 


### PR DESCRIPTION
## Summary
- enforce unique identifier/version in registry DB
- reject uploads of existing package version
- document new registry behavior

## Testing
- `deno task test` *(fails: JSR package manifest failed to load)*
- `deno task test` *(fails: Unstable API 'Worker.deno.permissions')*
- `deno task test` *(fails: invalid peer certificate)*

------
https://chatgpt.com/codex/tasks/task_e_68519a68c45c8328a640a6b7219f4e5b