### PR TITLE
Update export to use event names

### DIFF
--- a/docs/takopack/manifest.schema.json
+++ b/docs/takopack/manifest.schema.json
@@ -53,26 +53,9 @@
       }
     },
     "exports": {
-      "type": "object",
-      "description": "APIs exported by this extension",
-      "properties": {
-        "server": {
-          "type": "array",
-          "items": { "type": "string" },
-          "description": "Server side exports"
-        },
-        "background": {
-          "type": "array",
-          "items": { "type": "string" },
-          "description": "Background script exports"
-        },
-        "ui": {
-          "type": "array",
-          "items": { "type": "string" },
-          "description": "UI exports"
-        }
-      },
-      "additionalProperties": false
+      "type": "array",
+      "description": "APIs exported by this extension (event names)",
+      "items": { "type": "string" }
     },
     "server": {
       "type": "object",

--- a/docs/takopack/v3.md
+++ b/docs/takopack/v3.md
@@ -74,11 +74,7 @@ awesome-pack.takopack
     { "identifier": "com.example.lib", "version": "^1.0.0" }
   ],
 
-  "exports": {
-    "server": ["calculateHash", "sign"],
-    "background": [],
-    "ui": []
-  },
+  "exports": ["postMessage", "notifyClient"],
 
   "permissions": [
     "fetch:net",
@@ -401,7 +397,7 @@ const afterB = await PackB.onReceive(afterA);
 ### 記述方法
 
 - `extensionDependencies` で依存 Pack を宣言し、未インストール時は UI で通知。
-- `exports` で公開関数をレイヤーごとに列挙します。
+- `exports` には公開するイベント名を列挙します。
 
 ### 権限制御
 

--- a/examples/api-test-extension/takopack.config.ts
+++ b/examples/api-test-extension/takopack.config.ts
@@ -32,11 +32,18 @@ export default defineConfig({
       "deno:sys",
       "deno:ffi",    ],
     icon: "./icon.png",
-    exports: {
-      server: ["onServerKv", "onServerCdn", "onServerEvents", "onServerActivityPub", "onServerExtensions", "onServerFetch"],
-      background: ["onClientKv", "onClientEvents", "onClientExtensions", "onClientFetch"],
-      ui: []
-    },
+    exports: [
+      "serverKv",
+      "serverCdn",
+      "serverEvents",
+      "serverActivityPub",
+      "serverExtensions",
+      "serverFetch",
+      "clientKv",
+      "clientEvents",
+      "clientExtensions",
+      "clientFetch",
+    ],
   },
 
   entries: {

--- a/packages/builder/src/types.ts
+++ b/packages/builder/src/types.ts
@@ -139,12 +139,11 @@ export interface ExtensionManifest {
     identifier: string;
     version: string;
   }>;
-  /** 他拡張へ公開するAPI */
-  exports?: {
-    server?: string[];
-    background?: string[];
-    ui?: string[];
-  };
+  /**
+   * APIs exported for other extensions.
+   * Array of event names defined in `eventDefinitions`.
+   */
+  exports?: string[];
   server: {
     entry: string;
   };
@@ -216,11 +215,12 @@ export interface TakopackConfig {
     icon?: string;
     permissions?: Permission[];
     extensionDependencies?: Array<{ identifier: string; version: string }>;
-    exports?: {
-      server?: string[];
-      background?: string[];
-      ui?: string[];
-    };
+    /**
+     * APIs exported for other extensions.
+     *
+     * Use event names declared in `eventDefinitions`.
+     */
+    exports?: string[];
   };
 
   /** エントリポイント設定 */

--- a/packages/runtime/mod.test.ts
+++ b/packages/runtime/mod.test.ts
@@ -78,7 +78,10 @@ Deno.test("extensions API activation", async () => {
       identifier: "com.example.lib",
       version: "0.1.0",
       icon: "./icon.png",
-      exports: { server: ["add"] },
+      exports: ["add"],
+      eventDefinitions: {
+        add: { source: "server", handler: "add" },
+      },
     }),
     server: `export function add(a,b){return a+b;}`,
   };
@@ -102,7 +105,10 @@ Deno.test("activateExtension from worker", async () => {
       identifier: "com.example.lib2",
       version: "0.1.0",
       icon: "./icon.png",
-      exports: { server: ["mul"] },
+      exports: ["mul"],
+      eventDefinitions: {
+        mul: { source: "server", handler: "mul" },
+      },
     }),
     server: `export function mul(a,b){return a*b;}`,
   };
@@ -210,7 +216,10 @@ Deno.test("extensions API handles methods on exported objects", async () => {
       identifier: "com.example.libobj",
       version: "0.1.0",
       icon: "./icon.png",
-      exports: { server: ["ping"] },
+      exports: ["ping"],
+      eventDefinitions: {
+        ping: { source: "server", handler: "ping" },
+      },
     }),
     server: `export const ApiServer = {}; ApiServer.ping = () => 'pong';`,
   };

--- a/packages/runtime/mod.ts
+++ b/packages/runtime/mod.ts
@@ -622,8 +622,8 @@ class RuntimeExtension implements Extension {
   }> {
     if (this.#pack.activated) return this.#pack.activated;
     const exportsList =
-      Array.isArray((this.#pack.manifest as any)?.exports?.server)
-        ? (this.#pack.manifest as any).exports.server as string[]
+      Array.isArray((this.#pack.manifest as any)?.exports)
+        ? (this.#pack.manifest as any).exports as string[]
         : [];
     if (!this.#pack.serverWorker) {
       const api: {


### PR DESCRIPTION
## Summary
- update manifest schema and builder types so `exports` is an array of event names
- adjust runtime activation to read new manifest format
- update docs and example config for new behaviour
- adapt runtime tests for exported event names

## Testing
- `deno test -A --unstable-worker-options` *(fails: Failed loading https://registry.npmjs.org/@types%2fnode)*

------
https://chatgpt.com/codex/tasks/task_e_6857b64304648328abde7115d46a08d0