### PR TITLE
Add cross-layer tests for example extension

### DIFF
--- a/examples/api-test-extension/src/client/api.ts
+++ b/examples/api-test-extension/src/client/api.ts
@@ -63,3 +63,22 @@ ApiClient.onClientSource = async (): Promise<
   return [200, { env: "client" }];
 };
 
+/** @event("clientReceiveFromUi", { source: "ui" }) */
+ApiClient.onClientReceiveFromUi = (
+  payload: Record<string, unknown>,
+): [number, Record<string, unknown>] => {
+  console.log("Client received from UI:", payload);
+  return [200, { received: true, payload, timestamp: Date.now() }];
+};
+
+/** @event("clientSendUiEvent", { source: "ui" }) */
+ApiClient.onClientSendUiEvent = async (): Promise<
+  [number, Record<string, unknown>]
+> => {
+  const t = getTakosClientAPI();
+  await t?.events.publish("uiReceiveFromClient", {
+    from: "client",
+    timestamp: Date.now(),
+  });
+  return [200, { ok: true }];
+};

--- a/examples/api-test-extension/src/server/api.ts
+++ b/examples/api-test-extension/src/server/api.ts
@@ -112,3 +112,22 @@ ApiServer.onServerSource = async (): Promise<
   return [200, { env: "server" }];
 };
 
+/** @event("serverReceiveFromUi", { source: "ui" }) */
+ApiServer.onServerReceiveFromUi = (
+  payload: Record<string, unknown>,
+): [number, Record<string, unknown>] => {
+  console.log("Server received from UI:", payload);
+  return [200, { received: true, payload, timestamp: Date.now() }];
+};
+
+/** @event("serverSendUiEvent", { source: "ui" }) */
+ApiServer.onServerSendUiEvent = async (): Promise<
+  [number, Record<string, unknown>]
+> => {
+  const t = getApi();
+  await t?.events.publish("uiReceiveFromServer", {
+    from: "server",
+    timestamp: Date.now(),
+  });
+  return [200, { ok: true }];
+};

--- a/examples/api-test-extension/src/ui/api.ts
+++ b/examples/api-test-extension/src/ui/api.ts
@@ -103,6 +103,7 @@ export async function onUiToClientEvent(): Promise<Record<string, unknown>> {
 }
 
 // Event receivers
+/** @event("uiReceiveFromServer", { source: "server" }) */
 export function onUiReceiveFromServer(payload: Record<string, unknown>): void {
   console.log("UI received from server:", payload);
   const output = document.getElementById("output");
@@ -113,6 +114,7 @@ export function onUiReceiveFromServer(payload: Record<string, unknown>): void {
   }
 }
 
+/** @event("uiReceiveFromClient", { source: "client" }) */
 export function onUiReceiveFromClient(payload: Record<string, unknown>): void {
   console.log("UI received from client:", payload);
   const output = document.getElementById("output");
@@ -123,15 +125,6 @@ export function onUiReceiveFromClient(payload: Record<string, unknown>): void {
   }
 }
 
-export function onServerReceiveFromUi(payload: Record<string, unknown>): [number, Record<string, unknown>] {
-  console.log("Server received from UI:", payload);
-  return [200, { received: true, payload, timestamp: Date.now() }];
-}
-
-export function onClientReceiveFromUi(payload: Record<string, unknown>): [number, Record<string, unknown>] {
-  console.log("Client received from UI:", payload);
-  return [200, { received: true, payload, timestamp: Date.now() }];
-}
 
 // Make functions available globally for HTML to use
 if (typeof globalThis !== "undefined") {
@@ -146,8 +139,6 @@ if (typeof globalThis !== "undefined") {
     onUiToServerEvent,
     onUiToClientEvent,
     onUiReceiveFromServer,
-    onUiReceiveFromClient,
-    onServerReceiveFromUi,
-    onClientReceiveFromUi
+    onUiReceiveFromClient
   });
 }

--- a/examples/api-test-extension/src/ui/index.html
+++ b/examples/api-test-extension/src/ui/index.html
@@ -45,6 +45,10 @@
       <div id="ui"></div>
     </section>
     <section>
+      <h2>Cross Layer</h2>
+      <div id="cross"></div>
+    </section>
+    <section>
       <h2>Results</h2>
       <div id="output"></div>
     </section>
@@ -56,6 +60,7 @@
         "serverActivityPub",
         "serverExtensions",
         "serverFetch",
+        "serverSendUiEvent",
         "serverSource",
       ];
       const clientTests = [
@@ -63,6 +68,7 @@
         "clientEvents",
         "clientExtensions",
         "clientFetch",
+        "clientSendUiEvent",
         "clientSource",
       ];
       const uiTests = [
@@ -71,6 +77,12 @@
         "uiFetch",
         "uiExtensions",
         "uiUrl",
+      ];
+      const crossTests = [
+        "onUiCallServer",
+        "onUiCallClient",
+        "onUiToServerEvent",
+        "onUiToClientEvent",
       ];
 
       function addButtons(container, tests, runner) {
@@ -133,6 +145,18 @@
         }
       }
 
+      async function runCross(name) {
+        try {
+          const fn = globalThis[name];
+          if (typeof fn === "function") {
+            const res = await fn();
+            print(name, res);
+          }
+        } catch (err) {
+          print(name, String(err), true);
+        }
+      }
+
       function print(name, res, error = false) {
         const out = document.getElementById("output");
         const pre = document.createElement("pre");
@@ -156,6 +180,7 @@
         runEvent,
       );
       addButtons(document.getElementById("ui"), uiTests, runUi);
+      addButtons(document.getElementById("cross"), crossTests, runCross);
     </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- expand API test extension with server/client handlers for UI events
- add UI event annotations and cross-layer test buttons

## Testing
- `deno task test --unstable-worker-options` *(fails: invalid peer certificate)*
- `deno task test` in builder *(fails: invalid peer certificate)*
- `deno task test` in registry *(fails: failed to load JSR package)*
- `deno task test` in unpack *(fails: invalid peer certificate)*

------
https://chatgpt.com/codex/tasks/task_e_6857f4e5d8d08328add815867e63e2fe