### PR TITLE
Introduce selected user API for ActivityPub

### DIFF
--- a/app/client/builder/types/takos-api.ts
+++ b/app/client/builder/types/takos-api.ts
@@ -70,16 +70,17 @@ export interface PluginActorManager {
 
 export interface ActivityPubManager {
   // Object operations
-  send(userId: string, activity: ActivityPubObject): Promise<void>;
+  currentUser(): Promise<string>;
+  send(activity: ActivityPubObject): Promise<void>;
   read(id: string): Promise<ActivityPubObject>;
   delete(id: string): Promise<void>;
-  list(userId?: string): Promise<string[]>;
+  list(): Promise<string[]>;
 
   // Actor operations
   actor: {
-    read(userId: string): Promise<ActivityPubActor>;
-    update(userId: string, key: string, value: string): Promise<void>;
-    delete(userId: string, key: string): Promise<void>;
+    read(): Promise<ActivityPubActor>;
+    update(key: string, value: string): Promise<void>;
+    delete(key: string): Promise<void>;
   };
 
   // Follow operations

--- a/docs/takopack/v3.md
+++ b/docs/takopack/v3.md
@@ -149,15 +149,17 @@ awesome-pack.takopack
 
 ### ActivityPub
 
-#### オブジェクト操作
+-#### オブジェクト操作
 
-- **send**: `takos.ap.send(userId: string, activity: object): Promise<void>`
+- **currentUser**: `takos.ap.currentUser(): Promise<string>`
+  - **必要権限**: なし
+- **send**: `takos.ap.send(activity: object): Promise<void>`
   - **必要権限**: `activitypub:send`
 - **read**: `takos.ap.read(id: string): Promise<object>`
   - **必要権限**: `activitypub:read`
 - **delete**: `takos.ap.delete(id: string): Promise<void>`
   - **必要権限**: `activitypub:send`
-- **list**: `takos.ap.list(userId?: string): Promise<string[]>`
+- **list**: `takos.ap.list(): Promise<string[]>`
   - **必要権限**: `activitypub:read`
   - **利用可能レイヤー**: `server` のみ
 
@@ -168,11 +170,11 @@ awesome-pack.takopack
 
 #### アクター操作
 
-- **read**: `takos.ap.actor.read(userId: string): Promise<object>`
+- **read**: `takos.ap.actor.read(): Promise<object>`
 - **update**:
-  `takos.ap.actor.update(userId: string, key: string, value: string): Promise<void>`
+  `takos.ap.actor.update(key: string, value: string): Promise<void>`
 - **delete**:
-  `takos.ap.actor.delete(userId: string, key: string): Promise<void>`
+  `takos.ap.actor.delete(key: string): Promise<void>`
 - **follow**:
   `takos.ap.follow(followerId: string, followeeId: string): Promise<void>`
 - **unfollow**:

--- a/docs/takos-web/user.md
+++ b/docs/takos-web/user.md
@@ -11,3 +11,11 @@ req: { userId: string, }
 
 req: { userId: string, icon: string, description: string, type: "public" or
 "private" }
+
+### /_takos/users/selected (GET)
+
+res: { userId: string }
+
+### /_takos/users/selected (POST)
+
+req: { userId: string }

--- a/examples/api-test-extension/src/server/api.ts
+++ b/examples/api-test-extension/src/server/api.ts
@@ -33,13 +33,13 @@ async function testEvents() {
 
 async function testActivityPub() {
   const t = getApi();
-  await t?.activitypub.send("srv", { type: "Note" });
+  await t?.activitypub.send({ type: "Note" });
   await t?.activitypub.read("id:srv");
   await t?.activitypub.delete("id:srv");
-  await t?.activitypub.list("srv");
-  await t?.activitypub.actor.read("srv");
-  await t?.activitypub.actor.update("srv", "k", "v");
-  await t?.activitypub.actor.delete("srv", "k");
+  await t?.activitypub.list();
+  await t?.activitypub.actor.read();
+  await t?.activitypub.actor.update("k", "v");
+  await t?.activitypub.actor.delete("k");
   await t?.activitypub.follow("srv", "you");
   await t?.activitypub.unfollow("srv", "you");
   await t?.activitypub.listFollowers("srv");

--- a/packages/builder/src/api-helpers.ts
+++ b/packages/builder/src/api-helpers.ts
@@ -39,18 +39,19 @@ export interface TakosCdnAPI {
 }
 
 export interface TakosActivityPubAPI {
-  send(userId: string, activity: Record<string, unknown>): Promise<void>;
+  currentUser(): Promise<string>;
+  send(activity: Record<string, unknown>): Promise<void>;
   read(id: string): Promise<Record<string, unknown>>;
   delete(id: string): Promise<void>;
-  list(userId?: string): Promise<string[]>;
+  list(): Promise<string[]>;
   follow(followerId: string, followeeId: string): Promise<void>;
   unfollow(followerId: string, followeeId: string): Promise<void>;
   listFollowers(actorId: string): Promise<string[]>;
   listFollowing(actorId: string): Promise<string[]>;
   actor: {
-    read(userId: string): Promise<Record<string, unknown>>;
-    update(userId: string, key: string, value: string): Promise<void>;
-    delete(userId: string, key: string): Promise<void>;
+    read(): Promise<Record<string, unknown>>;
+    update(key: string, value: string): Promise<void>;
+    delete(key: string): Promise<void>;
   };
   pluginActor: {
     create(
@@ -213,7 +214,6 @@ export async function kvWrite(key: string, value: unknown): Promise<void> {
  * ActivityPubアクションを安全に実行する
  */
 export async function sendActivityPub(
-  userId: string,
   activity: Record<string, unknown>,
 ): Promise<void> {
   const api = getTakosServerAPI();
@@ -222,7 +222,7 @@ export async function sendActivityPub(
     return;
   }
 
-  await api.activitypub.send(userId, activity);
+  await api.activitypub.send(activity);
 }
 
 // 型ガード関数

--- a/packages/builder/src/generator.ts
+++ b/packages/builder/src/generator.ts
@@ -665,14 +665,15 @@ declare global {
     var takos: {
       kv: TakosKVAPI;
       activityPub: {
-        send(userId: string, activity: SerializableObject): Promise<void>;
+        currentUser(): Promise<string>;
+        send(activity: SerializableObject): Promise<void>;
         read(id: string): Promise<SerializableObject>;
         delete(id: string): Promise<void>;
-        list(userId?: string): Promise<string[]>;
+        list(): Promise<string[]>;
         actor: {
-          read(userId: string): Promise<SerializableObject>;
-          update(userId: string, key: string, value: string): Promise<void>;
-          delete(userId: string, key: string): Promise<void>;
+          read(): Promise<SerializableObject>;
+          update(key: string, value: string): Promise<void>;
+          delete(key: string): Promise<void>;
         };
         pluginActor: {
           create(localName: string, profile: SerializableObject): Promise<string>;

--- a/packages/builder/src/types.ts
+++ b/packages/builder/src/types.ts
@@ -335,9 +335,9 @@ export interface TakosKVAPI {
 }
 
 export interface TakosActivityPubActorAPI {
-  read(userId: string): Promise<ActivityPubActor>;
-  update(userId: string, key: string, value: string): Promise<void>;
-  delete(userId: string, key: string): Promise<void>;
+  read(): Promise<ActivityPubActor>;
+  update(key: string, value: string): Promise<void>;
+  delete(key: string): Promise<void>;
 }
 
 export interface TakosActivityPubPluginActorAPI {
@@ -349,10 +349,11 @@ export interface TakosActivityPubPluginActorAPI {
 }
 
 export interface TakosActivityPubAPI {
-  send(userId: string, activity: ActivityPubActivity): Promise<void>;
+  currentUser(): Promise<string>;
+  send(activity: ActivityPubActivity): Promise<void>;
   read(id: string): Promise<ActivityPubActivity>;
   delete(id: string): Promise<void>;
-  list(userId?: string): Promise<string[]>;
+  list(): Promise<string[]>;
   follow(followerId: string, followeeId: string): Promise<void>;
   unfollow(followerId: string, followeeId: string): Promise<void>;
   listFollowers(actorId: string): Promise<string[]>;

--- a/packages/runtime/mod.ts
+++ b/packages/runtime/mod.ts
@@ -32,14 +32,18 @@ export interface TakosCdn {
 }
 
 export interface TakosActivityPub {
-  send(userId: string, activity: Record<string, unknown>): Promise<void>;
+  /** 現在選択中のユーザーIDを取得する */
+  currentUser(): Promise<string>;
+  /** 選択ユーザーとして Activity を送信 */
+  send(activity: Record<string, unknown>): Promise<void>;
   read(id: string): Promise<Record<string, unknown>>;
   delete(id: string): Promise<void>;
-  list(userId?: string): Promise<string[]>;
+  /** 選択ユーザーの送信履歴を取得 */
+  list(): Promise<string[]>;
   actor: {
-    read(userId: string): Promise<Record<string, unknown>>;
-    update(userId: string, key: string, value: string): Promise<void>;
-    delete(userId: string, key: string): Promise<void>;
+    read(): Promise<Record<string, unknown>>;
+    update(key: string, value: string): Promise<void>;
+    delete(key: string): Promise<void>;
   };
   follow(followerId: string, followeeId: string): Promise<void>;
   unfollow(followerId: string, followeeId: string): Promise<void>;
@@ -343,14 +347,15 @@ export class Takos {
     list: async (_prefix?: string) => [] as string[],
   };
   activitypub = {
-    send: async (_userId: string, _activity: Record<string, unknown>) => {},
+    currentUser: async () => "",
+    send: async (_activity: Record<string, unknown>) => {},
     read: async (_id: string) => ({} as Record<string, unknown>),
     delete: async (_id: string) => {},
-    list: async (_userId?: string) => [] as string[],
+    list: async () => [] as string[],
     actor: {
-      read: async (_userId: string) => ({} as Record<string, unknown>),
-      update: async (_userId: string, _key: string, _value: string) => {},
-      delete: async (_userId: string, _key: string) => {},
+      read: async () => ({} as Record<string, unknown>),
+      update: async (_key: string, _value: string) => {},
+      delete: async (_key: string) => {},
     },
     follow: async (_followerId: string, _followeeId: string) => {},
     unfollow: async (_followerId: string, _followeeId: string) => {},
@@ -381,6 +386,7 @@ const TAKOS_PATHS: string[][] = [
   ["cdn", "write"],
   ["cdn", "delete"],
   ["cdn", "list"],
+  ["activitypub", "currentUser"],
   ["activitypub", "send"],
   ["activitypub", "read"],
   ["activitypub", "delete"],
@@ -401,6 +407,7 @@ const TAKOS_PATHS: string[][] = [
   ["ap", "read"],
   ["ap", "delete"],
   ["ap", "list"],
+  ["ap", "currentUser"],
   ["ap", "actor", "read"],
   ["ap", "actor", "update"],
   ["ap", "actor", "delete"],


### PR DESCRIPTION
## Summary
- add `currentUser()` and restrict ActivityPub operations to the selected user
- update runtime and builder API definitions
- document new endpoints and API usage
- adapt example extension to new API

## Testing
- `deno test -A` *(fails: JSR package manifest failed to load)*

------
https://chatgpt.com/codex/tasks/task_e_685864d2cfd48328a1f50f71b4489271