### PR TITLE
Remove example extension icon

### DIFF
--- a/examples/api-test-example/README.md
+++ b/examples/api-test-example/README.md
@@ -1,0 +1,20 @@
+# API Test Example Extension
+
+This example demonstrates basic usage of the Takos v3 APIs.
+
+## Build
+
+```bash
+cd examples/api-test-example
+deno task build
+```
+
+After building, install the generated `.takopack` file in Takos and open the UI page.
+
+The UI allows you to:
+
+- Call a server function (`ping`)
+- Write and read values via the KV API
+- Send a simple ActivityPub Note
+
+Results appear in the output panel.

--- a/examples/api-test-example/deno.json
+++ b/examples/api-test-example/deno.json
@@ -1,0 +1,9 @@
+{
+  "tasks": {
+    "build": "deno run -A ../../packages/cli/cli.ts build",
+    "dev": "deno run -A ../../packages/cli/cli.ts build --dev"
+  },
+  "imports": {
+    "@std/assert": "jsr:@std/assert@^1.0.0"
+  }
+}

--- a/examples/api-test-example/src/client/api.ts
+++ b/examples/api-test-example/src/client/api.ts
@@ -1,0 +1,16 @@
+// deno-lint-ignore-file no-explicit-any
+const { takos } = globalThis as any;
+
+export function clientPing(message: string) {
+  return {
+    layer: "client",
+    message: `client pong: ${message}`,
+    timestamp: new Date().toISOString(),
+  };
+}
+
+export function onServerToClient(payload: any) {
+  console.log("[Client] Received event from server", payload);
+  takos.kv.write("lastServerEvent", payload);
+  return { received: true };
+}

--- a/examples/api-test-example/src/server/api.ts
+++ b/examples/api-test-example/src/server/api.ts
@@ -1,0 +1,32 @@
+// deno-lint-ignore-file no-explicit-any
+const { takos } = globalThis as any;
+
+export function ping(message: string) {
+  return {
+    layer: "server",
+    message: `pong: ${message}`,
+    timestamp: new Date().toISOString(),
+  };
+}
+
+export async function saveKV(key: string, value: unknown) {
+  await takos.kv.write(key, value);
+  return { saved: true };
+}
+
+export async function readKV(key: string) {
+  return await takos.kv.read(key);
+}
+
+export async function sendActivity(note: string) {
+  await takos.activitypub.send({
+    type: "Note",
+    content: note,
+  });
+  return { sent: true };
+}
+
+export async function publishToClient(message: string) {
+  await takos.events.publish("serverToClient", { message, timestamp: new Date().toISOString() });
+  return { status: "sent" };
+}

--- a/examples/api-test-example/src/ui/index.html
+++ b/examples/api-test-example/src/ui/index.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>API Test Example</title>
+    <style>
+        body { font-family: sans-serif; padding: 20px; }
+        button { margin-right: 8px; }
+        pre { background: #eee; padding: 10px; }
+    </style>
+</head>
+<body>
+    <h1>Takos API Test Example</h1>
+    <div>
+        <button onclick="callPing()">Ping Server</button>
+        <button onclick="writeKV()">Write KV</button>
+        <button onclick="readKV()">Read KV</button>
+        <button onclick="sendActivity()">Send Activity</button>
+    </div>
+    <pre id="output">Ready...</pre>
+    <script>
+        // deno-lint-ignore-file no-explicit-any
+        const { takos } = globalThis;
+        const output = document.getElementById('output');
+
+        function log(msg) {
+            output.textContent += "\n" + msg;
+        }
+
+        async function callPing() {
+            const res = await takos.extensions.invoke('jp.takos.api-test-example', 'ping', ['hello']);
+            log(JSON.stringify(res));
+        }
+
+        async function writeKV() {
+            await takos.extensions.invoke('jp.takos.api-test-example', 'saveKV', ['demo', { time: Date.now() }]);
+            log('KV written');
+        }
+
+        async function readKV() {
+            const val = await takos.extensions.invoke('jp.takos.api-test-example', 'readKV', ['demo']);
+            log('KV value: ' + JSON.stringify(val));
+        }
+
+        async function sendActivity() {
+            await takos.extensions.invoke('jp.takos.api-test-example', 'sendActivity', ['Hello ActivityPub']);
+            log('Activity sent');
+        }
+    </script>
+</body>
+</html>

--- a/examples/api-test-example/takopack.config.ts
+++ b/examples/api-test-example/takopack.config.ts
@@ -1,0 +1,32 @@
+import { defineConfig } from "../../packages/builder/mod.ts";
+
+export default defineConfig({
+  manifest: {
+    name: "API Test Example",
+    identifier: "jp.takos.api-test-example",
+    version: "1.0.0",
+    description: "Demonstrates usage of Takos v3 APIs",
+    permissions: [
+      "kv:read",
+      "kv:write",
+      "events:publish",
+      "extensions:invoke",
+      "activitypub:send",
+      "activitypub:read",
+      "cdn:read",
+      "cdn:write",
+    ],
+    exports: ["ping", "saveKV", "readKV"],
+  },
+  entries: {
+    server: ["src/server/api.ts"],
+    client: ["src/client/api.ts"],
+    ui: ["src/ui/index.html"],
+  },
+  build: {
+    target: "es2022",
+    dev: false,
+    analysis: true,
+    outDir: "dist",
+  },
+});


### PR DESCRIPTION
## Summary
- remove `icon.png` from the API Test Example extension
- update `takopack.config.ts` accordingly

## Testing
- `deno task build` in `examples/api-test-example` *(fails: JSR package manifest failed to load)*
- `deno task test` in `packages/unpack` *(fails: invalid peer certificate when fetching npm packages)*
- `deno task test` in `packages/runtime` *(fails: requires --unstable-worker-options flag)*

------
https://chatgpt.com/codex/tasks/task_e_68586baf8c888328a73083147fc3c0a7