### PR TITLE
Fix service worker module import

### DIFF
--- a/app/api/sw_extension_template.js
+++ b/app/api/sw_extension_template.js
@@ -1,5 +1,6 @@
 // Takos extension service worker (v2) - Fixed import() issue
 // Static import to avoid ServiceWorker import() restriction
+import * as mod from "__CLIENT_PATH__";
 
 self.addEventListener("install", (e) => e.waitUntil(self.skipWaiting()));
 self.addEventListener("activate", (e) => e.waitUntil(self.clients.claim()));


### PR DESCRIPTION
## Summary
- restore `import * as mod` line in the extension service worker template

## Testing
- `deno test -A --unstable-worker-options` *(fails: Failed loading https://registry.npmjs.org/@types%2fnode)*
- `deno task test --quiet` in `packages/builder` *(fails: invalid peer certificate)*
- `deno task test --quiet` in `packages/unpack` *(fails: invalid peer certificate)*
- `deno task test --quiet` in `packages/registry` *(fails: JSR package manifest failed to load)*

------
https://chatgpt.com/codex/tasks/task_e_685a9d5e5cbc8328b6b4d1920e588f84