### PR TITLE
Introduce request events and remove manifest defs

### DIFF
--- a/docs/class-based-api-guide.md
+++ b/docs/class-based-api-guide.md
@@ -2,7 +2,8 @@
 
 ## 概要
 
-Takopack 3.0では、シンプルで型安全なクラスベースAPIを使用してイベントを定義します。JSDocやデコレータベースの定義は廃止され、クラスインスタンスによる登録のみがサポートされます。
+Takopack
+3.0では、シンプルで型安全なクラスベースAPIを使用してイベントを定義します。JSDocやデコレータベースの定義は廃止され、クラスインスタンスによる登録のみがサポートされます。
 
 ## 基本的な使用方法
 
@@ -24,6 +25,7 @@ takos.client("eventName", (payload: unknown) => {
 ### 2. 各レイヤーでの実装例
 
 #### Client レイヤー (`src/client/events.ts`)
+
 ```typescript
 import { Takos } from "../../../../packages/builder/src/classes.ts";
 
@@ -41,6 +43,7 @@ clientTakos.client("serverToClient", (payload: unknown) => {
 ```
 
 #### Server レイヤー (`src/server/events.ts`)
+
 ```typescript
 import { Takos } from "../../../../packages/builder/src/classes.ts";
 
@@ -60,11 +63,13 @@ serverTakos.server("uiToServer", (payload: unknown) => {
 ## 重要なポイント
 
 ### ✅ 推奨される書き方
+
 - クラスインスタンスを`export`する
 - イベントハンドラーは匿名関数またはアロー関数で直接登録
 - 個別のハンドラー関数は`export`しない
 
 ### ❌ 廃止された書き方
+
 ```typescript
 // ❌ JSDoc方式 (もう使えません)
 /**
@@ -73,7 +78,7 @@ serverTakos.server("uiToServer", (payload: unknown) => {
 export function myHandler() {}
 
 // ❌ デコレータ方式 (もう使えません)
-@event("myEvent")
+
 export function myHandler() {}
 
 // ❌ 個別ハンドラーのexport (推奨しません)
@@ -91,21 +96,7 @@ takos.client("myEvent", myHandler);
 
 ## manifest.json生成
 
-このAPIを使用すると、以下のような`eventDefinitions`が自動生成されます：
-
-```json
-{
-  "eventDefinitions": {
-    "uiToClient": {
-      "source": "client",
-      "handler": "anonymous"
-    },
-    "clientToServer": {
-      "source": "server", 
-      "handler": "anonymous"
-    }
-  }
-}
-```
+v3では `eventDefinitions` フィールドが廃止されました。このAPIを利用すると、
+ビルド時にイベントハンドラーが自動的に公開されます。
 
 クラスベースAPIが見つからない場合、ビルドは失敗し、適切なエラーメッセージが表示されます。

--- a/docs/migration-complete-report.md
+++ b/docs/migration-complete-report.md
@@ -7,7 +7,9 @@
 ## ✅ 移行完了済みプロジェクト
 
 ### 1. `examples/api-test`
+
 **変更前 (JSDoc + 個別関数export)**:
+
 ```typescript
 /**
  * @event serverToClient
@@ -18,6 +20,7 @@ export function onServerToClient(payload: EventPayload) {
 ```
 
 **変更後 (シンプルなクラスベースAPI)**:
+
 ```typescript
 import { Takos } from "../../../../packages/builder/src/classes.ts";
 
@@ -30,11 +33,13 @@ takos.client("serverToClient", (payload: unknown) => {
 ```
 
 ### 2. `examples/layer-communication-test`
+
 同様にJSDocベースからクラスベースAPIに完全移行。
 
 ## 🚀 新しいAPI仕様
 
 ### シンプルな記法
+
 ```typescript
 // 1. Takosクラスをインポート
 import { Takos } from "../../../../packages/builder/src/classes.ts";
@@ -55,6 +60,7 @@ takos.server("serverEvent", (payload: unknown) => {
 ## 🔧 ビルド結果
 
 ### api-test
+
 ```
 ✅ Found Takopack extension instance: serverTakos (Takos)
 ✅ Registered event: clientToServer -> anonymous (server)
@@ -68,6 +74,7 @@ takos.server("serverEvent", (payload: unknown) => {
 ```
 
 ### layer-communication-test
+
 ```
 ✅ Found Takopack extension instance: clientTakos (Takos)
 ✅ Registered event: serverToClient -> anonymous (client)
@@ -79,15 +86,7 @@ takos.server("serverEvent", (payload: unknown) => {
 ## 📊 manifest.json生成結果
 
 ```json
-{
-  "eventDefinitions": {
-    "clientToServer": { "source": "server", "handler": "anonymous" },
-    "uiToServer": { "source": "server", "handler": "anonymous" },
-    "testEvent": { "source": "client", "handler": "anonymous" },
-    "uiToClient": { "source": "client", "handler": "anonymous" },
-    "serverToClient": { "source": "client", "handler": "anonymous" }
-  }
-}
+{}
 ```
 
 ## ❌ 廃止された記法
@@ -101,8 +100,8 @@ takos.server("serverEvent", (payload: unknown) => {
  */
 export function handler() {}
 
-// ❌ デコレータ方式  
-@event("eventName")
+// ❌ デコレータ方式
+
 export function handler() {}
 
 // ❌ 個別ハンドラーexport (推奨しません)
@@ -126,4 +125,5 @@ takos.client("eventName", handler);
 - より高度な型安全性の実装
 - 開発者向けガイドとベストプラクティスの整備
 
-すべてのexampleプロジェクトでJSDoc/デコレータ方式を完全に削除し、シンプルで統一されたクラスベースAPIに移行が完了しました！ 🎉
+すべてのexampleプロジェクトでJSDoc/デコレータ方式を完全に削除し、シンプルで統一されたクラスベースAPIに移行が完了しました！
+🎉

--- a/docs/takopack/manifest.schema.json
+++ b/docs/takopack/manifest.schema.json
@@ -97,10 +97,6 @@
         "hook": { "type": "string" }
       },
       "additionalProperties": false
-    },
-    "eventDefinitions": {
-      "type": "object",
-      "description": "Custom event definitions"
     }
   }
 }

--- a/docs/takopack/v3.md
+++ b/docs/takopack/v3.md
@@ -12,11 +12,10 @@
 6. [APIと権限](#apiと権限)
 7. [globalThis.takos API](#globalthistakos-api)
 8. [ActivityPub フック](#activitypub-フック)
-9. [イベント定義](#イベント定義)
-10. [v2.1からの移行ガイド](#v21からの移行ガイド)
-11. [Sandbox 実行環境](#sandbox-実行環境)
-12. [拡張機能間API連携](#拡張機能間api連携)
-13. [UI URL操作](#ui-url操作)
+9. [v2.1からの移行ガイド](#v21からの移行ガイド)
+10. [Sandbox 実行環境](#sandbox-実行環境)
+11. [拡張機能間API連携](#拡張機能間api連携)
+12. [UI URL操作](#ui-url操作)
 
 ---
 
@@ -115,17 +114,6 @@ awesome-pack.takopack
   "activityPub": {
     "objects": ["Note", "Create", "Like"],
     "hook": "onReceive"
-  },
-
-  "eventDefinitions": {
-    "postMessage": {
-      "source": "client",
-      "handler": "onPostMessage"
-    },
-    "notifyClient": {
-      "source": "server",
-      "handler": "onNotifyClient"
-    }
   }
 }
 ```
@@ -171,10 +159,8 @@ awesome-pack.takopack
 #### アクター操作
 
 - **read**: `takos.ap.actor.read(): Promise<object>`
-- **update**:
-  `takos.ap.actor.update(key: string, value: string): Promise<void>`
-- **delete**:
-  `takos.ap.actor.delete(key: string): Promise<void>`
+- **update**: `takos.ap.actor.update(key: string, value: string): Promise<void>`
+- **delete**: `takos.ap.actor.delete(key: string): Promise<void>`
 - **follow**:
   `takos.ap.follow(followerId: string, followeeId: string): Promise<void>`
 - **unfollow**:
@@ -229,18 +215,19 @@ awesome-pack.takopack
 
 ### events
 
-イベントは manifest.json の `eventDefinitions` で宣言します。各レイヤー (server,
-client, background, ui) からは同じ API で実行できます。
+manifest でのイベント宣言は廃止されました。すべてのレイヤーから次の API
+を利用できます。
 
 - `takos.events.publish(eventName: string, payload: any, options?: { push?: boolean; token?: string }): Promise<[number, object]> | Promise<void>`
-  - 送信先が `server` の場合、ハンドラーが返す `[status, body]`
-    を取得します。その他のレイヤー向けは `void` を返します。
+- `takos.events.request(name: string, payload?: any, opts?: { timeout?: number }): Promise<unknown>`
+- `takos.events.onRequest(name: string, handler: (payload: any) => unknown): () => void`
+  - `request()` は 1 対 1 で呼び出し、`onRequest()`
+    で登録したハンドラーの戻り値を取得します。
   - `options.push` を `true` にすると、クライアントがオフラインでも FCM などの
     Push 通知経由でイベントを配信できます。`options.token`
     にはデバイスのトークンを指定してください。
   - FCM のデータペイロード上限は約 4KB です。これを超えるとエラーになります。
-  - イベントハンドラーは宣言されたファイル上のレイヤーで実行されます。 `client`
-    と `ui` ソースのイベントはブラウザ上で処理され、サーバーへは送信されません。
+  - ハンドラーは登録されたレイヤーで実行されます。
 
 ### 拡張間 API
 
@@ -344,36 +331,13 @@ const afterB = await PackB.onReceive(afterA);
 
 ---
 
-## イベント定義
-
-`eventDefinitions` にイベントを宣言し、`server.js` 等でハンドラーを実装します。
-
-```jsonc
-{
-  "eventDefinitions": {
-    "myEvent": {
-      "source": "client",
-      "handler": "onMyEvent"
-    }
-  }
-}
-```
-
-- 送信元は `client`、`server`、`background`、`ui` のいずれか
-- 対象レイヤーはハンドラーを実装したファイルで決まります
-
-サーバー側ハンドラーは `[200|400|500, body]` を返します。
-
-定義したイベントは、どのレイヤーからも共通の
-`takos.events.publish(eventName, payload, options?)`
-で発行できます。利用可能レイヤーのまとめは[レイヤー別 API 利用可否](#レイヤー別-api-利用可否)を参照してください。
-
 ---
 
 ## v2.1からの移行ガイド
 
 1. 権限宣言を `manifest.permissions` に集約。
-2. イベント定義は `source` のみを指定し、ハンドラー実装側が受信先となります。
+2. manifest から `eventDefinitions` を削除し、`takos.events.onRequest()`
+   でハンドラー登録。
 3. ActivityPub API は `activityPub()` に統合。
 4. `extensionDependencies` と `exports` を利用し、`takos.extensions` API
    で他拡張と連携。

--- a/packages/builder/src/builder.ts
+++ b/packages/builder/src/builder.ts
@@ -350,7 +350,7 @@ export class TakopackBuilder {
       analysis.exports.forEach((exp) => {
         if (exp.type === "class") exportedClassSet.add(exp.name);
       });
-    });    // デバッグ用: AST解析結果を出力
+    }); // デバッグ用: AST解析結果を出力
     console.log("🔍 AST Analysis Debug:");
     [...analyses.server, ...analyses.client].forEach((analysis) => {
       console.log(`  File: ${analysis.filePath}`);
@@ -371,38 +371,26 @@ export class TakopackBuilder {
       console.log(`    Exports: ${analysis.exports.length}`);
       analysis.exports.forEach((exp) => {
         console.log(
-          `      export ${exp.type} ${exp.name} ${exp.instanceOf ? `(instanceOf: ${exp.instanceOf})` : ''}`,
+          `      export ${exp.type} ${exp.name} ${
+            exp.instanceOf ? `(instanceOf: ${exp.instanceOf})` : ""
+          }`,
         );
       });
       console.log(`    Method calls: ${analysis.methodCalls.length}`);
       analysis.methodCalls.forEach((call) => {
         console.log(
-          `      ${call.objectName}.${call.methodName}(${call.args.join(', ')})`,
+          `      ${call.objectName}.${call.methodName}(${
+            call.args.join(", ")
+          })`,
         );
-      });    });
+      });
+    });
 
-    // クラスベースのイベント定義のみをサポート（JSDoc/デコレータは廃止）
-    const hasEventDefinitions = this.extractEventDefinitionsFromClasses(analyses, eventDefinitions);
-    
-    // イベント定義が必須
-    if (!hasEventDefinitions) {
-      throw new Error(
-        `❌ No event definitions found. Event definitions using classes are required.\n\n` +
-        `Please use class-based event definitions in your client/server files:\n\n` +
-        `import { Takos } from "../../../../packages/builder/src/classes.ts";\n\n` +
-        `export const takos = new Takos();\n\n` +
-        `takos\n` +
-        `  .client("eventName", handlerFunction)\n` +
-        `  .server("serverEvent", serverHandler)\n` +
-        `  .ui("uiEvent", uiHandler);\n\n` +
-        `JSDoc-based event definitions (@event) and decorators are no longer supported.`
-      );
-    }
+    // クラスベースのイベント定義を収集（任意）
+    this.extractEventDefinitionsFromClasses(analyses, eventDefinitions);
 
     // マニフェストに追加
-    if (Object.keys(eventDefinitions).length > 0) {
-      manifest.eventDefinitions = eventDefinitions;
-    }
+    // v3 では manifest.eventDefinitions を生成しない
     if (activityPubConfigs.length > 0) {
       manifest.activityPub = {
         objects: activityPubConfigs.map((c) => c.object),
@@ -593,33 +581,44 @@ export class TakopackBuilder {
     }
   } /**
    * JSDocタグからイベント名を抽出
-   */  private extractEventNameFromTag(value: string): string | null {
+   */
+
+  private extractEventNameFromTag(value: string): string | null {
     console.log(`[DEBUG] extractEventNameFromTag - value: "${value}"`);
-    
+
     // まず複雑な形式 "("eventName", { ... })" を試す
     const match = value.match(/^\("([^"']+)"/);
     console.log(`[DEBUG] extractEventNameFromTag - complex match: ${match}`);
-    
+
     if (match) {
       const result = match[1];
-      console.log(`[DEBUG] extractEventNameFromTag - complex result: ${result}`);
+      console.log(
+        `[DEBUG] extractEventNameFromTag - complex result: ${result}`,
+      );
       return result;
     }
-    
+
     // シンプルな形式 " eventName" を試す
     const simpleMatch = value.trim();
-    console.log(`[DEBUG] extractEventNameFromTag - simple match: "${simpleMatch}"`);
-    
-    if (simpleMatch && !simpleMatch.includes("(") && !simpleMatch.includes("{")) {
-      console.log(`[DEBUG] extractEventNameFromTag - simple result: ${simpleMatch}`);
+    console.log(
+      `[DEBUG] extractEventNameFromTag - simple match: "${simpleMatch}"`,
+    );
+
+    if (
+      simpleMatch && !simpleMatch.includes("(") && !simpleMatch.includes("{")
+    ) {
+      console.log(
+        `[DEBUG] extractEventNameFromTag - simple result: ${simpleMatch}`,
+      );
       return simpleMatch;
     }
-    
+
     console.log(`[DEBUG] extractEventNameFromTag - no match found`);
     return null;
-  }/**
+  } /**
    * イベント設定をパース
    */
+
   private parseEventConfig(
     value: string,
     targetFunction: string,
@@ -628,11 +627,11 @@ export class TakopackBuilder {
       console.log(
         `[DEBUG] parseEventConfig - value: "${value}", targetFunction: "${targetFunction}"`,
       );
-      
+
       // まず複雑な形式 "("eventName", { ... })" を試す
       const complexMatch = value.match(/^\("([^"']+)"(?:,\s*({.+}))?/);
       console.log(`[DEBUG] parseEventConfig - complex match: ${complexMatch}`);
-      
+
       if (complexMatch) {
         let options: Record<string, unknown> = {};
         if (complexMatch[2]) {
@@ -655,19 +654,24 @@ export class TakopackBuilder {
         );
 
         const result = {
-          source: (options.source as "client" | "server" | "background" | "ui") ||
+          source:
+            (options.source as "client" | "server" | "background" | "ui") ||
             "client",
           handler: targetFunction,
         };
         console.log(
-          `[DEBUG] parseEventConfig - complex result: ${JSON.stringify(result)}`,
+          `[DEBUG] parseEventConfig - complex result: ${
+            JSON.stringify(result)
+          }`,
         );
         return result;
       }
-      
+
       // シンプルな形式 " eventName" の場合はデフォルト設定を使用
       const simpleValue = value.trim();
-      if (simpleValue && !simpleValue.includes("(") && !simpleValue.includes("{")) {
+      if (
+        simpleValue && !simpleValue.includes("(") && !simpleValue.includes("{")
+      ) {
         const result = {
           source: "client" as const,
           handler: targetFunction,
@@ -677,7 +681,7 @@ export class TakopackBuilder {
         );
         return result;
       }
-        console.log(`[DEBUG] parseEventConfig - no match found`);
+      console.log(`[DEBUG] parseEventConfig - no match found`);
       return null;
     } catch (error) {
       console.log(`[DEBUG] parseEventConfig - error: ${error}`);
@@ -837,44 +841,56 @@ export class TakopackBuilder {
    */
   private extractEventDefinitionsFromClasses(
     analyses: { server: ModuleAnalysis[]; client: ModuleAnalysis[] },
-    eventDefinitions: Record<string, EventDefinition>
+    eventDefinitions: Record<string, EventDefinition>,
   ): boolean {
     let hasDefinitions = false;
-    
+
     [...analyses.server, ...analyses.client].forEach((analysis) => {
       // チェーン形式メソッド呼び出しからイベント定義を抽出
       analysis.methodCalls.forEach((call) => {
         // Takopackのクラス名から直接呼び出されているメソッドを検出
         if (this.isTakopackExtensionClass(call.objectName)) {
-          console.log(`🔗 Processing chained method call: ${call.objectName}.${call.methodName}(${call.args.join(', ')})`);
-          
+          console.log(
+            `🔗 Processing chained method call: ${call.objectName}.${call.methodName}(${
+              call.args.join(", ")
+            })`,
+          );
+
           // server, client, ui, background メソッドかどうかチェック
-          if (['server', 'client', 'ui', 'background'].includes(call.methodName)) {
+          if (
+            ["server", "client", "ui", "background"].includes(call.methodName)
+          ) {
             const eventName = call.args[0] as string;
             const handlerArg = call.args[1];
-            let handlerName = '';
-            
-            if (typeof handlerArg === 'string') {
+            let handlerName = "";
+
+            if (typeof handlerArg === "string") {
               // 関数名が文字列で渡された場合
               handlerName = handlerArg;
             } else {
               // 関数オブジェクトが渡された場合、その関数名を推測
-              handlerName = 'anonymous';
+              handlerName = "anonymous";
             }
-            
+
             if (eventName) {
               eventDefinitions[eventName] = {
-                source: call.methodName as "client" | "server" | "background" | "ui",
+                source: call.methodName as
+                  | "client"
+                  | "server"
+                  | "background"
+                  | "ui",
                 handler: handlerName,
               };
-              console.log(`✅ Registered chained event: ${eventName} -> ${handlerName} (${call.methodName})`);
+              console.log(
+                `✅ Registered chained event: ${eventName} -> ${handlerName} (${call.methodName})`,
+              );
               hasDefinitions = true;
             }
           }
         }
       });
     });
-    
+
     return hasDefinitions;
   }
 }

--- a/packages/builder/src/types.ts
+++ b/packages/builder/src/types.ts
@@ -149,7 +149,6 @@ export interface ExtensionManifest {
   }>;
   /**
    * APIs exported for other extensions.
-   * Array of event names defined in `eventDefinitions`.
    */
   exports?: string[];
   server: {
@@ -159,7 +158,6 @@ export interface ExtensionManifest {
     entryUI: string;
     entryBackground: string;
   };
-  eventDefinitions?: Record<string, EventDefinition>;
   activityPub?: {
     objects: string[];
     hook: string;
@@ -218,11 +216,7 @@ export interface TakopackConfig {
     icon?: string;
     permissions?: Permission[];
     extensionDependencies?: Array<{ identifier: string; version: string }>;
-    /**
-     * APIs exported for other extensions.
-     *
-     * Use event names declared in `eventDefinitions`.
-     */
+    /** APIs exported for other extensions. */
     exports?: string[];
   };
 

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -18,7 +18,7 @@ const runtime = new TakoPack([
   },
 });
 await runtime.init();
-// `call()` runs the handler on the layer specified in `eventDefinitions`
+// `call()` tries the server worker first and falls back to the client worker
 const result = await runtime.call(manifest.identifier, "hello", [
   "world",
 ]);


### PR DESCRIPTION
## Summary
- stop using `manifest.eventDefinitions` across router, client, and builder types
- update runtime docs and class-based guide for new request API
- remove event definition handling from UI router
- add request/onRequest tests for runtime
- start a persistent worker in extension UI for forwarding messages

## Testing
- `deno fmt packages/runtime/mod.test.ts app/api/extensionsRouter.ts app/client/src/takos.ts packages/builder/src/types.ts docs/migration-complete-report.md docs/class-based-api-guide.md packages/runtime/README.md`
- `deno test --unstable-worker-options packages/runtime/mod.test.ts` *(fails: Failed loading https://registry.npmjs.org/@types%2fnode)*

------
https://chatgpt.com/codex/tasks/task_e_685ec113e4f08328ae9d61c222016484