### PR TITLE
Introduce request events and remove manifest defs

### DIFF
--- a/docs/class-based-api-guide.md
+++ b/docs/class-based-api-guide.md
@@ -2,7 +2,8 @@
 
 ## 概要
 
-Takopack 3.0では、シンプルで型安全なクラスベースAPIを使用してイベントを定義します。JSDocやデコレータベースの定義は廃止され、クラスインスタンスによる登録のみがサポートされます。
+Takopack
+3.0では、シンプルで型安全なクラスベースAPIを使用してイベントを定義します。JSDocやデコレータベースの定義は廃止され、クラスインスタンスによる登録のみがサポートされます。
 
 ## 基本的な使用方法
 
@@ -24,6 +25,7 @@ takos.client("eventName", (payload: unknown) => {
 ### 2. 各レイヤーでの実装例
 
 #### Client レイヤー (`src/client/events.ts`)
+
 ```typescript
 import { Takos } from "../../../../packages/builder/src/classes.ts";
 
@@ -41,6 +43,7 @@ clientTakos.client("serverToClient", (payload: unknown) => {
 ```
 
 #### Server レイヤー (`src/server/events.ts`)
+
 ```typescript
 import { Takos } from "../../../../packages/builder/src/classes.ts";
 
@@ -60,11 +63,13 @@ serverTakos.server("uiToServer", (payload: unknown) => {
 ## 重要なポイント
 
 ### ✅ 推奨される書き方
+
 - クラスインスタンスを`export`する
 - イベントハンドラーは匿名関数またはアロー関数で直接登録
 - 個別のハンドラー関数は`export`しない
 
 ### ❌ 廃止された書き方
+
 ```typescript
 // ❌ JSDoc方式 (もう使えません)
 /**
@@ -73,7 +78,7 @@ serverTakos.server("uiToServer", (payload: unknown) => {
 export function myHandler() {}
 
 // ❌ デコレータ方式 (もう使えません)
-@event("myEvent")
+
 export function myHandler() {}
 
 // ❌ 個別ハンドラーのexport (推奨しません)
@@ -91,21 +96,7 @@ takos.client("myEvent", myHandler);
 
 ## manifest.json生成
 
-このAPIを使用すると、以下のような`eventDefinitions`が自動生成されます：
-
-```json
-{
-  "eventDefinitions": {
-    "uiToClient": {
-      "source": "client",
-      "handler": "anonymous"
-    },
-    "clientToServer": {
-      "source": "server", 
-      "handler": "anonymous"
-    }
-  }
-}
-```
+v3では `eventDefinitions` フィールドが廃止されました。このAPIを利用すると、
+ビルド時にイベントハンドラーが自動的に公開されます。
 
 クラスベースAPIが見つからない場合、ビルドは失敗し、適切なエラーメッセージが表示されます。

--- a/docs/migration-complete-report.md
+++ b/docs/migration-complete-report.md
@@ -7,7 +7,9 @@
 ## ✅ 移行完了済みプロジェクト
 
 ### 1. `examples/api-test`
+
 **変更前 (JSDoc + 個別関数export)**:
+
 ```typescript
 /**
  * @event serverToClient
@@ -18,6 +20,7 @@ export function onServerToClient(payload: EventPayload) {
 ```
 
 **変更後 (シンプルなクラスベースAPI)**:
+
 ```typescript
 import { Takos } from "../../../../packages/builder/src/classes.ts";
 
@@ -30,11 +33,13 @@ takos.client("serverToClient", (payload: unknown) => {
 ```
 
 ### 2. `examples/layer-communication-test`
+
 同様にJSDocベースからクラスベースAPIに完全移行。
 
 ## 🚀 新しいAPI仕様
 
 ### シンプルな記法
+
 ```typescript
 // 1. Takosクラスをインポート
 import { Takos } from "../../../../packages/builder/src/classes.ts";
@@ -55,6 +60,7 @@ takos.server("serverEvent", (payload: unknown) => {
 ## 🔧 ビルド結果
 
 ### api-test
+
 ```
 ✅ Found Takopack extension instance: serverTakos (Takos)
 ✅ Registered event: clientToServer -> anonymous (server)
@@ -68,6 +74,7 @@ takos.server("serverEvent", (payload: unknown) => {
 ```
 
 ### layer-communication-test
+
 ```
 ✅ Found Takopack extension instance: clientTakos (Takos)
 ✅ Registered event: serverToClient -> anonymous (client)
@@ -79,15 +86,7 @@ takos.server("serverEvent", (payload: unknown) => {
 ## 📊 manifest.json生成結果
 
 ```json
-{
-  "eventDefinitions": {
-    "clientToServer": { "source": "server", "handler": "anonymous" },
-    "uiToServer": { "source": "server", "handler": "anonymous" },
-    "testEvent": { "source": "client", "handler": "anonymous" },
-    "uiToClient": { "source": "client", "handler": "anonymous" },
-    "serverToClient": { "source": "client", "handler": "anonymous" }
-  }
-}
+{}
 ```
 
 ## ❌ 廃止された記法
@@ -101,8 +100,8 @@ takos.server("serverEvent", (payload: unknown) => {
  */
 export function handler() {}
 
-// ❌ デコレータ方式  
-@event("eventName")
+// ❌ デコレータ方式
+
 export function handler() {}
 
 // ❌ 個別ハンドラーexport (推奨しません)
@@ -126,4 +125,5 @@ takos.client("eventName", handler);
 - より高度な型安全性の実装
 - 開発者向けガイドとベストプラクティスの整備
 
-すべてのexampleプロジェクトでJSDoc/デコレータ方式を完全に削除し、シンプルで統一されたクラスベースAPIに移行が完了しました！ 🎉
+すべてのexampleプロジェクトでJSDoc/デコレータ方式を完全に削除し、シンプルで統一されたクラスベースAPIに移行が完了しました！
+🎉

--- a/docs/takopack/manifest.schema.json
+++ b/docs/takopack/manifest.schema.json
@@ -97,10 +97,6 @@
         "hook": { "type": "string" }
       },
       "additionalProperties": false
-    },
-    "eventDefinitions": {
-      "type": "object",
-      "description": "Custom event definitions"
     }
   }
 }

--- a/docs/takopack/v3.md
+++ b/docs/takopack/v3.md
@@ -12,11 +12,10 @@
 6. [APIと権限](#apiと権限)
 7. [globalThis.takos API](#globalthistakos-api)
 8. [ActivityPub フック](#activitypub-フック)
-9. [イベント定義](#イベント定義)
-10. [v2.1からの移行ガイド](#v21からの移行ガイド)
-11. [Sandbox 実行環境](#sandbox-実行環境)
-12. [拡張機能間API連携](#拡張機能間api連携)
-13. [UI URL操作](#ui-url操作)
+9. [v2.1からの移行ガイド](#v21からの移行ガイド)
+10. [Sandbox 実行環境](#sandbox-実行環境)
+11. [拡張機能間API連携](#拡張機能間api連携)
+12. [UI URL操作](#ui-url操作)
 
 ---
 
@@ -115,17 +114,6 @@ awesome-pack.takopack
   "activityPub": {
     "objects": ["Note", "Create", "Like"],
     "hook": "onReceive"
-  },
-
-  "eventDefinitions": {
-    "postMessage": {
-      "source": "client",
-      "handler": "onPostMessage"
-    },
-    "notifyClient": {
-      "source": "server",
-      "handler": "onNotifyClient"
-    }
   }
 }
 ```
@@ -171,10 +159,8 @@ awesome-pack.takopack
 #### アクター操作
 
 - **read**: `takos.ap.actor.read(): Promise<object>`
-- **update**:
-  `takos.ap.actor.update(key: string, value: string): Promise<void>`
-- **delete**:
-  `takos.ap.actor.delete(key: string): Promise<void>`
+- **update**: `takos.ap.actor.update(key: string, value: string): Promise<void>`
+- **delete**: `takos.ap.actor.delete(key: string): Promise<void>`
 - **follow**:
   `takos.ap.follow(followerId: string, followeeId: string): Promise<void>`
 - **unfollow**:
@@ -229,18 +215,19 @@ awesome-pack.takopack
 
 ### events
 
-イベントは manifest.json の `eventDefinitions` で宣言します。各レイヤー (server,
-client, background, ui) からは同じ API で実行できます。
+manifest でのイベント宣言は廃止されました。すべてのレイヤーから次の API
+を利用できます。
 
 - `takos.events.publish(eventName: string, payload: any, options?: { push?: boolean; token?: string }): Promise<[number, object]> | Promise<void>`
-  - 送信先が `server` の場合、ハンドラーが返す `[status, body]`
-    を取得します。その他のレイヤー向けは `void` を返します。
+- `takos.events.request(name: string, payload?: any, opts?: { timeout?: number }): Promise<unknown>`
+- `takos.events.onRequest(name: string, handler: (payload: any) => unknown): () => void`
+  - `request()` は 1 対 1 で呼び出し、`onRequest()`
+    で登録したハンドラーの戻り値を取得します。
   - `options.push` を `true` にすると、クライアントがオフラインでも FCM などの
     Push 通知経由でイベントを配信できます。`options.token`
     にはデバイスのトークンを指定してください。
   - FCM のデータペイロード上限は約 4KB です。これを超えるとエラーになります。
-  - イベントハンドラーは宣言されたファイル上のレイヤーで実行されます。 `client`
-    と `ui` ソースのイベントはブラウザ上で処理され、サーバーへは送信されません。
+  - ハンドラーは登録されたレイヤーで実行されます。
 
 ### 拡張間 API
 
@@ -344,36 +331,13 @@ const afterB = await PackB.onReceive(afterA);
 
 ---
 
-## イベント定義
-
-`eventDefinitions` にイベントを宣言し、`server.js` 等でハンドラーを実装します。
-
-```jsonc
-{
-  "eventDefinitions": {
-    "myEvent": {
-      "source": "client",
-      "handler": "onMyEvent"
-    }
-  }
-}
-```
-
-- 送信元は `client`、`server`、`background`、`ui` のいずれか
-- 対象レイヤーはハンドラーを実装したファイルで決まります
-
-サーバー側ハンドラーは `[200|400|500, body]` を返します。
-
-定義したイベントは、どのレイヤーからも共通の
-`takos.events.publish(eventName, payload, options?)`
-で発行できます。利用可能レイヤーのまとめは[レイヤー別 API 利用可否](#レイヤー別-api-利用可否)を参照してください。
-
 ---
 
 ## v2.1からの移行ガイド
 
 1. 権限宣言を `manifest.permissions` に集約。
-2. イベント定義は `source` のみを指定し、ハンドラー実装側が受信先となります。
+2. manifest から `eventDefinitions` を削除し、`takos.events.onRequest()`
+   でハンドラー登録。
 3. ActivityPub API は `activityPub()` に統合。
 4. `extensionDependencies` と `exports` を利用し、`takos.extensions` API
    で他拡張と連携。

--- a/examples/api-test/README.md
+++ b/examples/api-test/README.md
@@ -1,10 +1,12 @@
 # 🐙 Takos API Test Extension
 
-Takos API Test Extensionは、Takosプラットフォームのすべての主要APIを包括的にテストするための拡張機能です。ActivityPub、KVストレージ、CDN、イベントシステム、拡張機能API、レイヤー間通信など、すべての機能を簡単にテストできます。
+Takos API Test
+Extensionは、Takosプラットフォームのすべての主要APIを包括的にテストするための拡張機能です。ActivityPub、KVストレージ、CDN、イベントシステム、拡張機能API、レイヤー間通信など、すべての機能を簡単にテストできます。
 
 ## 🎯 機能
 
 ### ActivityPub API
+
 - **Note送信**: ActivityPubプロトコルでNoteオブジェクトを作成・送信
 - **アクティビティ一覧**: 送信済みアクティビティの一覧取得
 - **アクター操作**: アクター情報の読み取りと更新
@@ -12,20 +14,24 @@ Takos API Test Extensionは、Takosプラットフォームのすべての主要
 - **受信フック**: ActivityPubオブジェクト受信時の自動処理
 
 ### ストレージAPI
+
 - **サーバーKV**: サーバーサイドキー/値ストレージのテスト
 - **クライアントKV**: クライアントサイド（IndexedDB）ストレージのテスト
 - **CDN**: ファイルアップロード、ダウンロード、リスト取得のテスト
 
 ### ネットワークAPI
+
 - **サーバーFetch**: サーバーサイドHTTP通信のテスト
 - **クライアントFetch**: クライアントサイド（制限付き）HTTP通信のテスト
 
 ### イベントAPI
+
 - **レイヤー間通信**: Server ↔ Client ↔ UI 間のイベント通信
 - **イベントハンドラー**: 各レイヤーでのイベント受信処理
 - **Push通知**: FCM経由のプッシュ通知テスト（オプション）
 
 ### 拡張機能API
+
 - **拡張機能一覧**: インストール済み拡張機能の取得
 - **拡張機能呼び出し**: 他の拡張機能の関数実行
 - **相互運用**: 異なる拡張機能間での連携テスト
@@ -70,31 +76,39 @@ deno task clean
 ### 主なテスト項目
 
 #### 🌐 ActivityPub API
+
 - **Send Note**: テスト用Noteの送信
 - **List Activities**: アクティビティ履歴の確認
 - **Actor Test**: アクター情報の読み取り・更新
 - **Plugin Actor**: 拡張機能アクターの作成
 
 #### 💾 Storage APIs
+
 - **Server KV**: サーバーサイドKVストレージのCRUD操作
 - **Client KV**: クライアントサイドKVストレージのCRUD操作
 - **CDN Test**: ファイルの保存・取得・削除
 
 #### 🌐 Network APIs
+
 - **Fetch API**: HTTP通信のテスト
 - **Client Fetch**: クライアントサイド通信（制限付き）
 
 #### 📡 Events API
+
 - **Events Test**: レイヤー間イベント通信
 - **UI → Server**: UIからサーバーへのイベント送信
 - **UI → Client**: UIからクライアントへのイベント送信
+- **Request/Response**: `takos.events.request()` / `onRequest()`
+  を使用した双方向通信
 
 #### 🔧 Extensions API
+
 - **Extensions List**: 拡張機能の一覧取得
 - **Client Extensions**: クライアントサイド拡張機能操作
 - **Invoke Test**: 拡張機能の関数呼び出し
 
 #### 🔄 Layer Communication
+
 - **UI → Server Call**: UIからサーバー関数の直接呼び出し
 - **UI → Client Call**: UIからクライアント関数の呼び出し
 - **All Layers**: 全レイヤー間通信テスト
@@ -108,75 +122,105 @@ deno task clean
 ### サーバーサイド関数
 
 #### `apiTestServer(testType: string, params?: any)`
+
 汎用サーバーテスト関数
 
 #### `testActivityPubSend()`
+
 ActivityPub Note送信テスト
 
 #### `testActivityPubList()`
+
 ActivityPubアクティビティ一覧取得テスト
 
 #### `testActivityPubActor()`
+
 ActivityPubアクター操作テスト
 
 #### `testPluginActor()`
+
 プラグインアクター作成・操作テスト
 
 #### `testKVOperations()`
+
 サーバーサイドKVストレージテスト
 
 #### `testCDNOperations()`
+
 CDN操作テスト
 
 #### `testFetchAPI()`
+
 サーバーサイドFetch APIテスト
 
 #### `testEventsAPI()`
+
 イベントAPI送信テスト
 
+#### `requestClientEcho(text: string)`
+
+クライアントへのリクエスト/レスポンス例
+
 #### `testExtensionsAPI()`
+
 拡張機能API操作テスト
 
 #### `runAllTests()`
+
 すべてのサーバーサイドテストを実行
 
 ### クライアントサイド関数
 
 #### `apiTestClient(testType: string, params?: any)`
+
 汎用クライアントテスト関数
 
 #### `testClientKV()`
+
 クライアントサイドKVストレージテスト
 
 #### `testClientEvents()`
+
 クライアントサイドイベントテスト
 
 #### `testClientExtensions()`
+
 クライアントサイド拡張機能テスト
 
 #### `testClientFetch()`
+
 クライアントサイドFetch APIテスト
 
+#### `requestServerEcho(text: string)`
+
+サーバーへのリクエスト/レスポンス例
+
 #### `runClientTests()`
+
 すべてのクライアントサイドテストを実行
 
 ### UI関数
 
 #### `apiTestUI(testType: string, params?: any)`
+
 汎用UIテスト関数
 
 ### イベントハンドラー
 
 #### `onActivityPubReceive(activity: any)`
+
 ActivityPubオブジェクト受信時の処理
 
 #### `onTestEvent(payload: any)`
+
 テストイベント受信時の処理
 
 #### `onServerToClient(payload: any)`
+
 サーバーからクライアントへのイベント処理
 
 #### `onUIToServer(payload: any)`
+
 UIからサーバーへのイベント処理
 
 ## 🧪 テスト詳細
@@ -201,11 +245,13 @@ UIからサーバーへのイベント処理
 ## 📊 ログとエクスポート
 
 ### ログレベル
+
 - **All**: すべてのログを表示
 - **Success**: 成功ログのみ表示
 - **Error**: エラーログのみ表示
 
 ### エクスポート機能
+
 テスト結果をJSON形式でエクスポート可能。以下の情報が含まれます：
 
 ```json
@@ -265,6 +311,6 @@ UIからサーバーへのイベント処理
 
 ---
 
-**作成者**: Takos Development Team  
-**バージョン**: 1.0.0  
+**作成者**: Takos Development Team\
+**バージョン**: 1.0.0\
 **最終更新**: 2025年6月23日

--- a/examples/api-test/src/client/api.ts
+++ b/examples/api-test/src/client/api.ts
@@ -6,60 +6,73 @@ export const takos = new Takos();
 
 takos.client("uiToClient", (payload: unknown) => {
   console.log("[Client] Received event from UI (class-based):", payload);
-  
+
   try {
-    return { 
-      received: true, 
+    return {
+      received: true,
       processedBy: "client-class",
       originalPayload: payload,
-      timestamp: new Date().toISOString()
+      timestamp: new Date().toISOString(),
     };
   } catch (error) {
     console.error("[Client] Error handling UI event:", error);
     return {
       received: false,
       error: error instanceof Error ? error.message : String(error),
-      timestamp: new Date().toISOString()
+      timestamp: new Date().toISOString(),
     };
   }
 });
 
 takos.client("serverToClient", (payload: unknown) => {
   console.log("[Client] Received event from server (class-based):", payload);
-  
+
   try {
-    return { 
-      received: true, 
+    return {
+      received: true,
       processedBy: "client-class",
       originalPayload: payload,
-      timestamp: new Date().toISOString()
+      timestamp: new Date().toISOString(),
     };
   } catch (error) {
     console.error("[Client] Error handling server event:", error);
     return {
       received: false,
       error: error instanceof Error ? error.message : String(error),
-      timestamp: new Date().toISOString()
+      timestamp: new Date().toISOString(),
     };
   }
 });
 
 takos.client("testEvent", (payload: unknown) => {
   console.log("[Client] onTestEvent called (class-based):", payload);
-  
+
   try {
-    return { 
-      received: true, 
+    return {
+      received: true,
       processedBy: "client-class",
       originalPayload: payload,
-      timestamp: new Date().toISOString()
+      timestamp: new Date().toISOString(),
     };
   } catch (error) {
     console.error("[Client] Error in onTestEvent:", error);
     return {
       received: false,
       error: error instanceof Error ? error.message : String(error),
-      timestamp: new Date().toISOString()
+      timestamp: new Date().toISOString(),
     };
   }
 });
+
+// Request/response API example
+takos.events.onRequest<{ text: string }, { text: string }>(
+  "echoFromClient",
+  ({ text }) => ({ text: text + " from client" }),
+);
+
+export async function requestServerEcho(text: string) {
+  return await takos.events.request<{ text: string }, { text: string }>(
+    "echoFromServer",
+    { text },
+  );
+}

--- a/examples/api-test/src/server/api.ts
+++ b/examples/api-test/src/server/api.ts
@@ -26,7 +26,7 @@ export function apiTestServer(testType: string, params?: any) {
     testType,
     params,
     timestamp: new Date().toISOString(),
-    result: `Server processed ${testType} test`
+    result: `Server processed ${testType} test`,
   };
 }
 
@@ -38,35 +38,35 @@ export async function testActivityPubSend() {
   try {
     const currentUser = await takos.ap.currentUser();
     console.log(`[Server] Current user: ${currentUser}`);
-    
+
     const note = {
       "@context": "https://www.w3.org/ns/activitystreams",
       "type": "Note",
       "content": "Hello from Takos API Test Extension!",
       "to": ["https://www.w3.org/ns/activitystreams#Public"],
-      "published": new Date().toISOString()
+      "published": new Date().toISOString(),
     };
-    
+
     await takos.ap.send({
       "@context": "https://www.w3.org/ns/activitystreams",
       "type": "Create",
       "actor": currentUser,
       "object": note,
       "to": ["https://www.w3.org/ns/activitystreams#Public"],
-      "published": new Date().toISOString()
+      "published": new Date().toISOString(),
     });
-    
-    return [200, { 
-      success: true, 
+
+    return [200, {
+      success: true,
       message: "ActivityPub note sent successfully",
       currentUser,
-      timestamp: new Date().toISOString()
+      timestamp: new Date().toISOString(),
     }];
   } catch (error) {
     console.error("[Server] ActivityPub send error:", error);
-    return [500, { 
-      success: false, 
-      error: error instanceof Error ? error.message : String(error) 
+    return [500, {
+      success: false,
+      error: error instanceof Error ? error.message : String(error),
     }];
   }
 }
@@ -75,18 +75,18 @@ export async function testActivityPubList() {
   try {
     const activities = await takos.ap.list();
     console.log(`[Server] Found ${activities.length} activities`);
-    
-    return [200, { 
-      success: true, 
+
+    return [200, {
+      success: true,
       count: activities.length,
       activities: activities.slice(0, 5), // 最初の5件のみ返す
-      timestamp: new Date().toISOString()
+      timestamp: new Date().toISOString(),
     }];
   } catch (error) {
     console.error("[Server] ActivityPub list error:", error);
-    return [500, { 
-      success: false, 
-      error: error instanceof Error ? error.message : String(error) 
+    return [500, {
+      success: false,
+      error: error instanceof Error ? error.message : String(error),
     }];
   }
 }
@@ -95,21 +95,21 @@ export async function testActivityPubActor() {
   try {
     const actor = await takos.ap.actor.read();
     console.log("[Server] Current actor:", actor);
-    
+
     // アクターの一部情報を更新してテスト
     await takos.ap.actor.update("summary", "Updated from API Test Extension");
-    
-    return [200, { 
-      success: true, 
+
+    return [200, {
+      success: true,
       actor,
       message: "Actor read and updated successfully",
-      timestamp: new Date().toISOString()
+      timestamp: new Date().toISOString(),
     }];
   } catch (error) {
     console.error("[Server] ActivityPub actor error:", error);
-    return [500, { 
-      success: false, 
-      error: error instanceof Error ? error.message : String(error) 
+    return [500, {
+      success: false,
+      error: error instanceof Error ? error.message : String(error),
     }];
   }
 }
@@ -117,25 +117,28 @@ export async function testActivityPubActor() {
 // ActivityPub受信フック
 export async function onActivityPubReceive(activity: any) {
   console.log("[Server] Received ActivityPub activity:", activity);
-  
+
   try {
     // 受信したアクティビティをKVに保存
     await takos.kv.write(`received_activity_${Date.now()}`, {
       activity,
-      processedAt: new Date().toISOString()
+      processedAt: new Date().toISOString(),
     });
-    
+
     // UIにイベントを送信
     await takos.events.publish("activityReceived", {
       type: activity.type,
       actor: activity.actor,
-      timestamp: new Date().toISOString()
+      timestamp: new Date().toISOString(),
     });
-    
+
     return { processed: true };
   } catch (error) {
     console.error("[Server] Error processing ActivityPub receive:", error);
-    return { processed: false, error: error instanceof Error ? error.message : String(error) };
+    return {
+      processed: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
   }
 }
 
@@ -149,29 +152,29 @@ export async function testPluginActor() {
     const actorId = await takos.ap.pluginActor.create("test-bot", {
       name: "Test Bot",
       summary: "A test bot created by API Test Extension",
-      type: "Service"
+      type: "Service",
     });
-    
+
     console.log(`[Server] Created plugin actor: ${actorId}`);
-    
+
     // 作成したアクターを読み取り
     const actor = await takos.ap.pluginActor.read(actorId);
-    
+
     // アクターのリストを取得
     const actors = await takos.ap.pluginActor.list();
-    
+
     return [200, {
       success: true,
       createdActor: actorId,
       actorData: actor,
       totalActors: actors.length,
-      timestamp: new Date().toISOString()
+      timestamp: new Date().toISOString(),
     }];
   } catch (error) {
     console.error("[Server] Plugin actor error:", error);
-    return [500, { 
-      success: false, 
-      error: error instanceof Error ? error.message : String(error) 
+    return [500, {
+      success: false,
+      error: error instanceof Error ? error.message : String(error),
     }];
   }
 }
@@ -186,34 +189,34 @@ export async function testKVOperations() {
     const testValue = {
       message: "Hello from KV!",
       timestamp: new Date().toISOString(),
-      data: { test: true, number: 42 }
+      data: { test: true, number: 42 },
     };
-    
+
     // 書き込み
     await takos.kv.write(testKey, testValue);
     console.log(`[Server] Wrote to KV: ${testKey}`);
-    
+
     // 読み込み
     const readValue = await takos.kv.read(testKey);
     console.log(`[Server] Read from KV:`, readValue);
-    
+
     // リスト取得
     const keys = await takos.kv.list();
     console.log(`[Server] KV keys count: ${keys.length}`);
-    
+
     return [200, {
       success: true,
       written: testValue,
       read: readValue,
       keysCount: keys.length,
       testKey,
-      timestamp: new Date().toISOString()
+      timestamp: new Date().toISOString(),
     }];
   } catch (error) {
     console.error("[Server] KV operations error:", error);
-    return [500, { 
-      success: false, 
-      error: error instanceof Error ? error.message : String(error) 
+    return [500, {
+      success: false,
+      error: error instanceof Error ? error.message : String(error),
     }];
   }
 }
@@ -228,34 +231,34 @@ export async function testCDNOperations() {
     const testData = JSON.stringify({
       message: "Hello from CDN!",
       timestamp: new Date().toISOString(),
-      extension: "jp.takos.api-test"
+      extension: "jp.takos.api-test",
     });
-    
+
     // ファイルを書き込み
     const url = await takos.cdn.write(testPath, testData, { cacheTTL: 3600 });
     console.log(`[Server] Wrote to CDN: ${url}`);
-    
+
     // ファイルを読み込み
     const readData = await takos.cdn.read(testPath);
     console.log(`[Server] Read from CDN:`, readData);
-    
+
     // ファイルリストを取得
     const files = await takos.cdn.list("test/");
     console.log(`[Server] CDN files in test/: ${files.length}`);
-    
+
     return [200, {
       success: true,
       url,
       written: testData,
       read: readData,
       filesCount: files.length,
-      timestamp: new Date().toISOString()
+      timestamp: new Date().toISOString(),
     }];
   } catch (error) {
     console.error("[Server] CDN operations error:", error);
-    return [500, { 
-      success: false, 
-      error: error instanceof Error ? error.message : String(error) 
+    return [500, {
+      success: false,
+      error: error instanceof Error ? error.message : String(error),
     }];
   }
 }
@@ -267,22 +270,24 @@ export async function testCDNOperations() {
 export async function testFetchAPI() {
   try {
     // JSONPlaceholderで簡単なHTTPテスト
-    const response = await takos.fetch("https://jsonplaceholder.typicode.com/posts/1");
+    const response = await takos.fetch(
+      "https://jsonplaceholder.typicode.com/posts/1",
+    );
     const data = await response.json();
-    
+
     console.log("[Server] Fetch test successful:", data.title);
-    
+
     return [200, {
       success: true,
       status: response.status,
       data,
-      timestamp: new Date().toISOString()
+      timestamp: new Date().toISOString(),
     }];
   } catch (error) {
     console.error("[Server] Fetch API error:", error);
-    return [500, { 
-      success: false, 
-      error: error instanceof Error ? error.message : String(error) 
+    return [500, {
+      success: false,
+      error: error instanceof Error ? error.message : String(error),
     }];
   }
 }
@@ -296,33 +301,33 @@ export async function testEventsAPI() {
     // 各レイヤーにイベントを送信
     await takos.events.publish("serverToClient", {
       message: "Hello from server to client!",
-      timestamp: new Date().toISOString()
+      timestamp: new Date().toISOString(),
     });
-    
+
     await takos.events.publish("serverToUI", {
       message: "Hello from server to UI!",
-      timestamp: new Date().toISOString()
+      timestamp: new Date().toISOString(),
     });
-    
+
     // テストイベントを発火
     await takos.events.publish("testEvent", {
       source: "server",
       message: "Test event from server",
-      timestamp: new Date().toISOString()
+      timestamp: new Date().toISOString(),
     });
-    
+
     console.log("[Server] Events sent successfully");
-    
+
     return [200, {
       success: true,
       message: "Events sent to client, UI, and test event fired",
-      timestamp: new Date().toISOString()
+      timestamp: new Date().toISOString(),
     }];
   } catch (error) {
     console.error("[Server] Events API error:", error);
-    return [500, { 
-      success: false, 
-      error: error instanceof Error ? error.message : String(error) 
+    return [500, {
+      success: false,
+      error: error instanceof Error ? error.message : String(error),
     }];
   }
 }
@@ -336,32 +341,34 @@ export function testExtensionsAPI() {
     // 利用可能な拡張機能を取得
     const allExtensions = takos.extensions.all;
     console.log(`[Server] Found ${allExtensions.length} extensions`);
-    
+
     // 自分自身の拡張機能を取得
     const selfExtension = takos.extensions.get("jp.takos.api-test");
-    
+
     const result = {
       success: true,
       totalExtensions: allExtensions.length,
       extensions: allExtensions.map((ext: any) => ({
         identifier: ext.identifier,
         version: ext.version,
-        isActive: ext.isActive
+        isActive: ext.isActive,
       })),
-      selfExtension: selfExtension ? {
-        identifier: selfExtension.identifier,
-        version: selfExtension.version,
-        isActive: selfExtension.isActive
-      } : null,
-      timestamp: new Date().toISOString()
+      selfExtension: selfExtension
+        ? {
+          identifier: selfExtension.identifier,
+          version: selfExtension.version,
+          isActive: selfExtension.isActive,
+        }
+        : null,
+      timestamp: new Date().toISOString(),
     };
-    
+
     return [200, result];
   } catch (error) {
     console.error("[Server] Extensions API error:", error);
-    return [500, { 
-      success: false, 
-      error: error instanceof Error ? error.message : String(error) 
+    return [500, {
+      success: false,
+      error: error instanceof Error ? error.message : String(error),
     }];
   }
 }
@@ -372,23 +379,25 @@ export function testExtensionsAPI() {
 
 export async function onTestEvent(payload: EventPayload) {
   console.log("[Server] onTestEvent called with payload:", payload);
-  
+
   try {
     await takos.kv.write("lastTestEvent", {
       source: "server",
       payload,
-      processedAt: new Date().toISOString()
+      processedAt: new Date().toISOString(),
     });
-    
-    return [200, { 
-      received: true, 
+
+    return [200, {
+      received: true,
       processedBy: "server",
       originalPayload: payload,
-      timestamp: new Date().toISOString()
+      timestamp: new Date().toISOString(),
     }];
   } catch (error) {
     console.error("[Server] Error in onTestEvent:", error);
-    return [500, { error: error instanceof Error ? error.message : String(error) }];
+    return [500, {
+      error: error instanceof Error ? error.message : String(error),
+    }];
   }
 }
 
@@ -398,111 +407,117 @@ export async function onTestEvent(payload: EventPayload) {
 
 export async function runAllTests() {
   console.log("[Server] Running comprehensive API tests...");
-  
+
   const results: Record<string, TestResult> = {};
-  
+
   // ActivityPub tests
   try {
     const [status, data] = await testActivityPubList();
     results.activityPubList = {
       success: status === 200,
       data,
-      timestamp: new Date().toISOString()
+      timestamp: new Date().toISOString(),
     };
-  } catch (error) {    results.activityPubList = {
+  } catch (error) {
+    results.activityPubList = {
       success: false,
       error: error instanceof Error ? error.message : String(error),
-      timestamp: new Date().toISOString()
+      timestamp: new Date().toISOString(),
     };
   }
-  
+
   // KV tests
   try {
     const [status, data] = await testKVOperations();
     results.kvOperations = {
       success: status === 200,
       data,
-      timestamp: new Date().toISOString()
-    };  } catch (error) {
+      timestamp: new Date().toISOString(),
+    };
+  } catch (error) {
     results.kvOperations = {
       success: false,
       error: error instanceof Error ? error.message : String(error),
-      timestamp: new Date().toISOString()
+      timestamp: new Date().toISOString(),
     };
   }
-  
+
   // CDN tests
   try {
     const [status, data] = await testCDNOperations();
     results.cdnOperations = {
       success: status === 200,
       data,
-      timestamp: new Date().toISOString()
-    };  } catch (error) {
+      timestamp: new Date().toISOString(),
+    };
+  } catch (error) {
     results.cdnOperations = {
       success: false,
       error: error instanceof Error ? error.message : String(error),
-      timestamp: new Date().toISOString()
+      timestamp: new Date().toISOString(),
     };
   }
-  
+
   // Fetch tests
   try {
     const [status, data] = await testFetchAPI();
     results.fetchAPI = {
       success: status === 200,
       data,
-      timestamp: new Date().toISOString()
-    };  } catch (error) {
+      timestamp: new Date().toISOString(),
+    };
+  } catch (error) {
     results.fetchAPI = {
       success: false,
       error: error instanceof Error ? error.message : String(error),
-      timestamp: new Date().toISOString()
+      timestamp: new Date().toISOString(),
     };
   }
-  
+
   // Events tests
   try {
     const [status, data] = await testEventsAPI();
     results.eventsAPI = {
       success: status === 200,
       data,
-      timestamp: new Date().toISOString()
-    };  } catch (error) {
+      timestamp: new Date().toISOString(),
+    };
+  } catch (error) {
     results.eventsAPI = {
       success: false,
       error: error instanceof Error ? error.message : String(error),
-      timestamp: new Date().toISOString()
+      timestamp: new Date().toISOString(),
     };
   }
-  
+
   // Extensions tests
   try {
     const [status, data] = await testExtensionsAPI();
     results.extensionsAPI = {
       success: status === 200,
       data,
-      timestamp: new Date().toISOString()
-    };  } catch (error) {
+      timestamp: new Date().toISOString(),
+    };
+  } catch (error) {
     results.extensionsAPI = {
       success: false,
       error: error instanceof Error ? error.message : String(error),
-      timestamp: new Date().toISOString()
+      timestamp: new Date().toISOString(),
     };
   }
-  
+
   const summary = {
     total: Object.keys(results).length,
-    passed: Object.values(results).filter(r => r.success).length,
-    failed: Object.values(results).filter(r => !r.success).length,
-    timestamp: new Date().toISOString()
+    passed: Object.values(results).filter((r) => r.success).length,
+    failed: Object.values(results).filter((r) => !r.success).length,
+    timestamp: new Date().toISOString(),
   };
-  
+
   return [200, {
     success: true,
     summary,
     results,
-    message: `API tests completed: ${summary.passed}/${summary.total} passed`
+    message: `API tests completed: ${summary.passed}/${summary.total} passed`,
   }];
 }
 
@@ -511,12 +526,12 @@ export const serverTakos = new Takos();
 
 serverTakos.server("clientToServer", (payload: unknown) => {
   console.log("[Server] onClientToServer called:", payload);
-  
+
   try {
-    return { 
-      received: true, 
+    return {
+      received: true,
       processedBy: "server",
-      timestamp: new Date().toISOString()
+      timestamp: new Date().toISOString(),
     };
   } catch (error) {
     return { error: error instanceof Error ? error.message : String(error) };
@@ -525,12 +540,12 @@ serverTakos.server("clientToServer", (payload: unknown) => {
 
 serverTakos.server("uiToServer", (payload: unknown) => {
   console.log("[Server] onUIToServer called:", payload);
-  
+
   try {
-    return { 
-      received: true, 
+    return {
+      received: true,
       processedBy: "server",
-      timestamp: new Date().toISOString()
+      timestamp: new Date().toISOString(),
     };
   } catch (error) {
     return { error: error instanceof Error ? error.message : String(error) };
@@ -539,16 +554,29 @@ serverTakos.server("uiToServer", (payload: unknown) => {
 
 serverTakos.server("testEvent", (payload: unknown) => {
   console.log("[Server] onTestEvent called with payload:", payload);
-  
+
   try {
-    return { 
-      received: true, 
+    return {
+      received: true,
       processedBy: "server",
       originalPayload: payload,
-      timestamp: new Date().toISOString()
+      timestamp: new Date().toISOString(),
     };
   } catch (error) {
     console.error("[Server] Error in onTestEvent:", error);
     return { error: error instanceof Error ? error.message : String(error) };
   }
 });
+
+// Request/response API examples
+takos.events.onRequest<{ text: string }, { text: string }>(
+  "echoFromServer",
+  ({ text }) => ({ text: text + " from server" }),
+);
+
+export async function requestClientEcho(text: string) {
+  return await takos.events.request<{ text: string }, { text: string }>(
+    "echoFromClient",
+    { text },
+  );
+}

--- a/packages/builder/src/builder.ts
+++ b/packages/builder/src/builder.ts
@@ -350,7 +350,7 @@ export class TakopackBuilder {
       analysis.exports.forEach((exp) => {
         if (exp.type === "class") exportedClassSet.add(exp.name);
       });
-    });    // デバッグ用: AST解析結果を出力
+    }); // デバッグ用: AST解析結果を出力
     console.log("🔍 AST Analysis Debug:");
     [...analyses.server, ...analyses.client].forEach((analysis) => {
       console.log(`  File: ${analysis.filePath}`);
@@ -371,38 +371,26 @@ export class TakopackBuilder {
       console.log(`    Exports: ${analysis.exports.length}`);
       analysis.exports.forEach((exp) => {
         console.log(
-          `      export ${exp.type} ${exp.name} ${exp.instanceOf ? `(instanceOf: ${exp.instanceOf})` : ''}`,
+          `      export ${exp.type} ${exp.name} ${
+            exp.instanceOf ? `(instanceOf: ${exp.instanceOf})` : ""
+          }`,
         );
       });
       console.log(`    Method calls: ${analysis.methodCalls.length}`);
       analysis.methodCalls.forEach((call) => {
         console.log(
-          `      ${call.objectName}.${call.methodName}(${call.args.join(', ')})`,
+          `      ${call.objectName}.${call.methodName}(${
+            call.args.join(", ")
+          })`,
         );
-      });    });
+      });
+    });
 
-    // クラスベースのイベント定義のみをサポート（JSDoc/デコレータは廃止）
-    const hasEventDefinitions = this.extractEventDefinitionsFromClasses(analyses, eventDefinitions);
-    
-    // イベント定義が必須
-    if (!hasEventDefinitions) {
-      throw new Error(
-        `❌ No event definitions found. Event definitions using classes are required.\n\n` +
-        `Please use class-based event definitions in your client/server files:\n\n` +
-        `import { Takos } from "../../../../packages/builder/src/classes.ts";\n\n` +
-        `export const takos = new Takos();\n\n` +
-        `takos\n` +
-        `  .client("eventName", handlerFunction)\n` +
-        `  .server("serverEvent", serverHandler)\n` +
-        `  .ui("uiEvent", uiHandler);\n\n` +
-        `JSDoc-based event definitions (@event) and decorators are no longer supported.`
-      );
-    }
+    // クラスベースのイベント定義を収集（任意）
+    this.extractEventDefinitionsFromClasses(analyses, eventDefinitions);
 
     // マニフェストに追加
-    if (Object.keys(eventDefinitions).length > 0) {
-      manifest.eventDefinitions = eventDefinitions;
-    }
+    // v3 では manifest.eventDefinitions を生成しない
     if (activityPubConfigs.length > 0) {
       manifest.activityPub = {
         objects: activityPubConfigs.map((c) => c.object),
@@ -593,33 +581,44 @@ export class TakopackBuilder {
     }
   } /**
    * JSDocタグからイベント名を抽出
-   */  private extractEventNameFromTag(value: string): string | null {
+   */
+
+  private extractEventNameFromTag(value: string): string | null {
     console.log(`[DEBUG] extractEventNameFromTag - value: "${value}"`);
-    
+
     // まず複雑な形式 "("eventName", { ... })" を試す
     const match = value.match(/^\("([^"']+)"/);
     console.log(`[DEBUG] extractEventNameFromTag - complex match: ${match}`);
-    
+
     if (match) {
       const result = match[1];
-      console.log(`[DEBUG] extractEventNameFromTag - complex result: ${result}`);
+      console.log(
+        `[DEBUG] extractEventNameFromTag - complex result: ${result}`,
+      );
       return result;
     }
-    
+
     // シンプルな形式 " eventName" を試す
     const simpleMatch = value.trim();
-    console.log(`[DEBUG] extractEventNameFromTag - simple match: "${simpleMatch}"`);
-    
-    if (simpleMatch && !simpleMatch.includes("(") && !simpleMatch.includes("{")) {
-      console.log(`[DEBUG] extractEventNameFromTag - simple result: ${simpleMatch}`);
+    console.log(
+      `[DEBUG] extractEventNameFromTag - simple match: "${simpleMatch}"`,
+    );
+
+    if (
+      simpleMatch && !simpleMatch.includes("(") && !simpleMatch.includes("{")
+    ) {
+      console.log(
+        `[DEBUG] extractEventNameFromTag - simple result: ${simpleMatch}`,
+      );
       return simpleMatch;
     }
-    
+
     console.log(`[DEBUG] extractEventNameFromTag - no match found`);
     return null;
-  }/**
+  } /**
    * イベント設定をパース
    */
+
   private parseEventConfig(
     value: string,
     targetFunction: string,
@@ -628,11 +627,11 @@ export class TakopackBuilder {
       console.log(
         `[DEBUG] parseEventConfig - value: "${value}", targetFunction: "${targetFunction}"`,
       );
-      
+
       // まず複雑な形式 "("eventName", { ... })" を試す
       const complexMatch = value.match(/^\("([^"']+)"(?:,\s*({.+}))?/);
       console.log(`[DEBUG] parseEventConfig - complex match: ${complexMatch}`);
-      
+
       if (complexMatch) {
         let options: Record<string, unknown> = {};
         if (complexMatch[2]) {
@@ -655,19 +654,24 @@ export class TakopackBuilder {
         );
 
         const result = {
-          source: (options.source as "client" | "server" | "background" | "ui") ||
+          source:
+            (options.source as "client" | "server" | "background" | "ui") ||
             "client",
           handler: targetFunction,
         };
         console.log(
-          `[DEBUG] parseEventConfig - complex result: ${JSON.stringify(result)}`,
+          `[DEBUG] parseEventConfig - complex result: ${
+            JSON.stringify(result)
+          }`,
         );
         return result;
       }
-      
+
       // シンプルな形式 " eventName" の場合はデフォルト設定を使用
       const simpleValue = value.trim();
-      if (simpleValue && !simpleValue.includes("(") && !simpleValue.includes("{")) {
+      if (
+        simpleValue && !simpleValue.includes("(") && !simpleValue.includes("{")
+      ) {
         const result = {
           source: "client" as const,
           handler: targetFunction,
@@ -677,7 +681,7 @@ export class TakopackBuilder {
         );
         return result;
       }
-        console.log(`[DEBUG] parseEventConfig - no match found`);
+      console.log(`[DEBUG] parseEventConfig - no match found`);
       return null;
     } catch (error) {
       console.log(`[DEBUG] parseEventConfig - error: ${error}`);
@@ -837,44 +841,56 @@ export class TakopackBuilder {
    */
   private extractEventDefinitionsFromClasses(
     analyses: { server: ModuleAnalysis[]; client: ModuleAnalysis[] },
-    eventDefinitions: Record<string, EventDefinition>
+    eventDefinitions: Record<string, EventDefinition>,
   ): boolean {
     let hasDefinitions = false;
-    
+
     [...analyses.server, ...analyses.client].forEach((analysis) => {
       // チェーン形式メソッド呼び出しからイベント定義を抽出
       analysis.methodCalls.forEach((call) => {
         // Takopackのクラス名から直接呼び出されているメソッドを検出
         if (this.isTakopackExtensionClass(call.objectName)) {
-          console.log(`🔗 Processing chained method call: ${call.objectName}.${call.methodName}(${call.args.join(', ')})`);
-          
+          console.log(
+            `🔗 Processing chained method call: ${call.objectName}.${call.methodName}(${
+              call.args.join(", ")
+            })`,
+          );
+
           // server, client, ui, background メソッドかどうかチェック
-          if (['server', 'client', 'ui', 'background'].includes(call.methodName)) {
+          if (
+            ["server", "client", "ui", "background"].includes(call.methodName)
+          ) {
             const eventName = call.args[0] as string;
             const handlerArg = call.args[1];
-            let handlerName = '';
-            
-            if (typeof handlerArg === 'string') {
+            let handlerName = "";
+
+            if (typeof handlerArg === "string") {
               // 関数名が文字列で渡された場合
               handlerName = handlerArg;
             } else {
               // 関数オブジェクトが渡された場合、その関数名を推測
-              handlerName = 'anonymous';
+              handlerName = "anonymous";
             }
-            
+
             if (eventName) {
               eventDefinitions[eventName] = {
-                source: call.methodName as "client" | "server" | "background" | "ui",
+                source: call.methodName as
+                  | "client"
+                  | "server"
+                  | "background"
+                  | "ui",
                 handler: handlerName,
               };
-              console.log(`✅ Registered chained event: ${eventName} -> ${handlerName} (${call.methodName})`);
+              console.log(
+                `✅ Registered chained event: ${eventName} -> ${handlerName} (${call.methodName})`,
+              );
               hasDefinitions = true;
             }
           }
         }
       });
     });
-    
+
     return hasDefinitions;
   }
 }

--- a/packages/builder/src/types.ts
+++ b/packages/builder/src/types.ts
@@ -149,7 +149,6 @@ export interface ExtensionManifest {
   }>;
   /**
    * APIs exported for other extensions.
-   * Array of event names defined in `eventDefinitions`.
    */
   exports?: string[];
   server: {
@@ -159,7 +158,6 @@ export interface ExtensionManifest {
     entryUI: string;
     entryBackground: string;
   };
-  eventDefinitions?: Record<string, EventDefinition>;
   activityPub?: {
     objects: string[];
     hook: string;
@@ -218,11 +216,7 @@ export interface TakopackConfig {
     icon?: string;
     permissions?: Permission[];
     extensionDependencies?: Array<{ identifier: string; version: string }>;
-    /**
-     * APIs exported for other extensions.
-     *
-     * Use event names declared in `eventDefinitions`.
-     */
+    /** APIs exported for other extensions. */
     exports?: string[];
   };
 

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -18,7 +18,7 @@ const runtime = new TakoPack([
   },
 });
 await runtime.init();
-// `call()` runs the handler on the layer specified in `eventDefinitions`
+// `call()` tries the server worker first and falls back to the client worker
 const result = await runtime.call(manifest.identifier, "hello", [
   "world",
 ]);


### PR DESCRIPTION
## Summary
- stop using `manifest.eventDefinitions` across router, client, and builder types
- update runtime docs and class-based guide for new request API
- remove event definition handling from UI router
- add request/onRequest tests for runtime
- start a persistent worker in extension UI for forwarding messages

## Testing
- `deno fmt packages/runtime/mod.test.ts app/api/extensionsRouter.ts app/client/src/takos.ts packages/builder/src/types.ts docs/migration-complete-report.md docs/class-based-api-guide.md packages/runtime/README.md`
- `deno test --unstable-worker-options packages/runtime/mod.test.ts` *(fails: Failed loading https://registry.npmjs.org/@types%2fnode)*

------
https://chatgpt.com/codex/tasks/task_e_685ec113e4f08328ae9d61c222016484