### PR TITLE
Switch ActivityPub hooks to event API

### DIFF
--- a/app/api/initExtension.js
+++ b/app/api/initExtension.js
@@ -1,12 +1,14 @@
-(function() {
+(function () {
   try {
-    const extensionId = '__EXTENSION_ID__';
+    const extensionId = "__EXTENSION_ID__";
 
     const pending = new Map();
     let seq = 0;
     const requestHandlers = new Map();
 
-    const worker = new Worker('/api/extensions/' + extensionId + '/client.js', { type: 'module' });
+    const worker = new Worker("/api/extensions/" + extensionId + "/client.js", {
+      type: "module",
+    });
 
     function callWorker(type, name, payload) {
       return new Promise((resolve) => {
@@ -21,7 +23,7 @@
       if (id && pending.has(id)) {
         pending.get(id)(result);
         pending.delete(id);
-      } else if (type === 'request' && name) {
+      } else if (type === "request" && name) {
         const handler = requestHandlers.get(name);
         Promise.resolve(handler?.(payload)).then((res) => {
           if (id) worker.postMessage({ id, result: res });
@@ -29,8 +31,8 @@
       }
     };
 
-    window.addEventListener('message', (ev) => {
-      if (ev.data && ev.data.target === 'takos-worker') {
+    window.addEventListener("message", (ev) => {
+      if (ev.data && ev.data.target === "takos-worker") {
         worker.postMessage(ev.data.payload);
       }
     });
@@ -39,42 +41,51 @@
       extensions: {
         all: [{
           identifier: extensionId,
-          version: '1.0.0',
+          version: "1.0.0",
           isActive: true,
-          request: (name, payload) => callWorker('extension', name, payload),
+          request: (name, payload) => callWorker("extension", name, payload),
         }],
-        get: (extId) => extId === extensionId ? window.takos.extensions.all[0] : undefined,
-        request: (name, payload) => callWorker('extension', name, payload),
-        onRequest: (name, handler) => { requestHandlers.set(name, handler); },
+        get: (extId) =>
+          extId === extensionId ? window.takos.extensions.all[0] : undefined,
+        request: (name, payload) => callWorker("extension", name, payload),
+        onRequest: (name, handler) => {
+          requestHandlers.set(name, handler);
+          return () => requestHandlers.delete(name);
+        },
       },
       events: {
-        request: (name, payload) => callWorker('event', name, payload),
-        onRequest: (name, handler) => { requestHandlers.set(name, handler); },
+        request: (name, payload) => callWorker("event", name, payload),
+        onRequest: (name, handler) => {
+          requestHandlers.set(name, handler);
+          return () => requestHandlers.delete(name);
+        },
       },
-      request: (name, payload) => callWorker('extension', name, payload),
-      onRequest: (name, handler) => { requestHandlers.set(name, handler); },
+      request: (name, payload) => callWorker("extension", name, payload),
+      onRequest: (name, handler) => {
+        requestHandlers.set(name, handler);
+      },
     };
 
-    console.log('Takos object initialized for extension:', extensionId);
-
-  } catch(e) {
-    console.error('Failed to initialize takos object:', e);
+    console.log("Takos object initialized for extension:", extensionId);
+  } catch (e) {
+    console.error("Failed to initialize takos object:", e);
     // Fallback basic takos object
     window.takos = {
       extensions: {
         all: [],
         get: () => {
-          console.error('Extension system not available');
+          console.error("Extension system not available");
           return undefined;
         },
-        invoke: () => Promise.reject(new Error('Extension system not available'))
+        invoke: () =>
+          Promise.reject(new Error("Extension system not available")),
       },
       events: {
         request: () => {
-          console.error('Event system not available');
+          console.error("Event system not available");
           return Promise.resolve();
-        }
-      }
+        },
+      },
     };
   }
 })();

--- a/app/api/initExtension.js
+++ b/app/api/initExtension.js
@@ -39,15 +39,11 @@
 
     window.takos = {
       extensions: {
-        all: [{
-          identifier: extensionId,
-          version: "1.0.0",
-          isActive: true,
-          request: (name, payload) => callWorker("extension", name, payload),
-        }],
-        get: (extId) =>
-          extId === extensionId ? window.takos.extensions.all[0] : undefined,
-        request: (name, payload) => callWorker("extension", name, payload),
+        get: (extId) => ({
+          identifier: extId,
+          request: (name, payload) =>
+            callWorker("extension", `${extId}:${name}`, payload),
+        }),
         onRequest: (name, handler) => {
           requestHandlers.set(name, handler);
           return () => requestHandlers.delete(name);
@@ -60,10 +56,6 @@
           return () => requestHandlers.delete(name);
         },
       },
-      request: (name, payload) => callWorker("extension", name, payload),
-      onRequest: (name, handler) => {
-        requestHandlers.set(name, handler);
-      },
     };
 
     console.log("Takos object initialized for extension:", extensionId);
@@ -72,13 +64,15 @@
     // Fallback basic takos object
     window.takos = {
       extensions: {
-        all: [],
         get: () => {
           console.error("Extension system not available");
-          return undefined;
+          return {
+            identifier: "",
+            request: () =>
+              Promise.reject(new Error("Extension system not available")),
+          };
         },
-        invoke: () =>
-          Promise.reject(new Error("Extension system not available")),
+        onRequest: () => () => {},
       },
       events: {
         request: () => {

--- a/docs/builder/README.md
+++ b/docs/builder/README.md
@@ -345,7 +345,8 @@ await simpleTakos.request("hello", { message: "hi" });
 
 ### 拡張機能 API の呼び出し
 
-他拡張が公開する機能は `takos.extensions.request()` から実行します。
+他拡張が公開する機能は `takos.extensions.get()` で取得した
+オブジェクトの `request()` メソッドから実行します。
 公開側では `takos.extensions.onRequest()` でハンドラーを登録します。
 
 ```typescript
@@ -355,7 +356,10 @@ takos.extensions.onRequest("com.example.lib:hello", () => {
 });
 
 // 呼び出し側
-await takos.extensions.request("com.example.lib:hello");
+const lib = takos.extensions.get("com.example.lib");
+if (lib) {
+  await lib.request("hello");
+}
 ```
 
 ---

--- a/docs/takopack/api.md
+++ b/docs/takopack/api.md
@@ -94,17 +94,11 @@ manifest でのイベント宣言は廃止されました。すべてのレイ�
   - FCM のデータペイロード上限は約 4KB です。これを超えるとエラーになります。
   - ハンドラーは登録されたレイヤーで実行されます。
 
-### 拡張間 API
+-### 拡張間 API
 
 - `takos.extensions.get(identifier: string): Extension | undefined`
 - `Extension.request(name: string, payload?: unknown, opts?: { timeout?: number }): Promise<unknown>`
-- `takos.extensions.request(name: string, payload?: unknown, opts?: { timeout?: number }): Promise<unknown>`
-  (ショートカット)
 - `takos.extensions.onRequest(name: string, handler: (payload: unknown) => unknown): () => void`
-- `takos.request(name: string, payload?: unknown): Promise<unknown>`
-  (グローバル)
-- `takos.onRequest(name: string, handler: (payload: unknown) => unknown): void`
-  (グローバル)
   - **必要権限**: `extensions:invoke`
 
 権限はすべて `manifest.permissions` に列挙し、必要最低限を宣言してください。
@@ -121,8 +115,6 @@ let hash: string | undefined;
 if (ext) {
   hash = await ext.request("calculateHash", "hello");
 }
-// 直接呼び出す場合
-// const hash = await takos.request("com.example.lib:calculateHash", "hello");
 ```
 
 ---
@@ -219,9 +211,8 @@ takos.events.onRequest("activitypub:object", async ({ context, object }) => {
 
 - `extensionDependencies` で依存 Pack を宣言し、未インストール時は UI で通知。
 
-公開したい処理は `takos.extensions.onRequest()` で登録し、 呼び出し側は
-`extensions.get()` で取得したオブジェクトや `takos.request()`
-を利用して実行します。
+公開したい処理は `takos.extensions.onRequest()` で登録し、呼び出し側は
+`extensions.get()` で取得したオブジェクトの `request()` を利用して実行します。
 
 ### 権限制御
 
@@ -236,8 +227,6 @@ takos.extensions.onRequest("com.example.lib:doSomething", async () => "ok");
 // 呼び出し側
 const api = takos.extensions.get("com.example.lib");
 if (api) await api.request("doSomething");
-// または
-// await takos.request("com.example.lib:doSomething");
 ```
 
 TypeScript で型安全に連携でき、npm-semver 準拠で依存解決されます。

--- a/docs/takopack/api.md
+++ b/docs/takopack/api.md
@@ -22,11 +22,6 @@
   - **必要権限**: `activitypub:read`
   - **利用可能レイヤー**: `server` のみ
 
-#### フック処理
-
-- ActivityPub オブジェクト受信時のフック (`hook`)
-  - **必要権限**: `activitypub:receive:hook`
-
 #### アクター操作
 
 - **read**: `takos.ap.actor.read(): Promise<object>`
@@ -183,15 +178,17 @@ const { takos } = globalThis;
 
 ---
 
-## ActivityPub フック
+## ActivityPub イベント
 
-`ap.objects` に指定したオブジェクトを受信すると、`hook` に
-登録した関数が呼び出されます。これらの API はサーバーレイヤー専用です。
-利用可能なレイヤーについては[レイヤー別 API 利用可否](#レイヤー別-api-利用可否)を参照してください。
+ActivityPub オブジェクトを受信すると `activitypub:object` イベントが発火します。
+拡張機能は `takos.events.onRequest()` でハンドラーを登録し、
+`{ context, object }` を受け取って処理結果を返せます。
 
 ```javascript
-const afterA = await PackA.onReceive(obj);
-const afterB = await PackB.onReceive(afterA);
+takos.events.onRequest("activitypub:object", async ({ context, object }) => {
+  console.log("Activity received", object);
+  return object;
+});
 ```
 
 ---

--- a/docs/takopack/manifest.schema.json
+++ b/docs/takopack/manifest.schema.json
@@ -80,18 +80,6 @@
       },
       "additionalProperties": false
     },
-    "activityPub": {
-      "type": "object",
-      "description": "ActivityPub hooks configuration",
-      "required": ["objects", "hook"],
-      "properties": {
-        "objects": {
-          "type": "array",
-          "items": { "type": "string" }
-        },
-        "hook": { "type": "string" }
-      },
-      "additionalProperties": false
-    }
+    
   }
 }

--- a/docs/takopack/v3.md
+++ b/docs/takopack/v3.md
@@ -113,8 +113,7 @@ awesome-pack.takopack
   - KV: `${identifier}:${key}`
   - CDN: `${identifier}/${path}`
   - 公開処理は `takos.extensions.onRequest()` で登録し、
-    `takos.extensions.get(id)?.request(name)` または
-    `takos.extensions.request("id:name")` で呼び出します。
+    `takos.extensions.get(id)?.request(name)` で呼び出します。
 - 依存解決は npm-semver 準拠で最新版優先、警告あり。
 
 ---

--- a/docs/takopack/v3.md
+++ b/docs/takopack/v3.md
@@ -73,7 +73,6 @@ awesome-pack.takopack
     "fetch:net",
     "activitypub:send",
     "activitypub:read",
-    "activitypub:receive:hook",
     "activitypub:actor:read",
     "activitypub:actor:write",
     "plugin-actor:create",
@@ -102,10 +101,6 @@ awesome-pack.takopack
     "entryBackground": "./client.js"
   },
 
-  "activityPub": {
-    "objects": ["Note", "Create", "Like"],
-    "hook": "onReceive"
-  }
 }
 ```
 

--- a/examples/api-test/README.md
+++ b/examples/api-test/README.md
@@ -264,7 +264,6 @@ CDN操作テスト
   "permissions": [
     "activitypub:send",
     "activitypub:read",
-    "activitypub:receive:hook",
     "activitypub:actor:read",
     "activitypub:actor:write",
     "plugin-actor:create",

--- a/examples/api-test/takopack.config.ts
+++ b/examples/api-test/takopack.config.ts
@@ -11,7 +11,6 @@ export default defineConfig({
       // ActivityPub permissions
       "activitypub:send",
       "activitypub:read",
-      "activitypub:receive:hook",
       "activitypub:actor:read",
       "activitypub:actor:write",
       "plugin-actor:create",

--- a/packages/builder/src/api-helpers.ts
+++ b/packages/builder/src/api-helpers.ts
@@ -67,15 +67,11 @@ export interface TakosActivityPubAPI {
 
 export interface Extension {
   identifier: string;
-  version: string;
-  isActive: boolean;
   request(name: string, payload?: unknown): Promise<unknown>;
 }
 
 export interface TakosExtensionsAPI {
   get(identifier: string): Extension | undefined;
-  readonly all: Extension[];
-  request(name: string, payload?: unknown): Promise<unknown>;
   onRequest(
     name: string,
     handler: (payload: unknown) => unknown | Promise<unknown>,
@@ -89,11 +85,6 @@ export interface TakosServerAPI {
   cdn: TakosCdnAPI;
   events: TakosEventsAPI;
   extensions: TakosExtensionsAPI;
-  request(name: string, payload: unknown): Promise<unknown>;
-  onRequest(
-    name: string,
-    handler: (payload: unknown) => unknown | Promise<unknown>,
-  ): void;
   fetch(url: string, options?: RequestInit): Promise<Response>;
 }
 
@@ -101,22 +92,12 @@ export interface TakosClientAPI {
   kv: TakosKVAPI;
   events: TakosEventsAPI;
   extensions: TakosExtensionsAPI;
-  request(name: string, payload: unknown): Promise<unknown>;
-  onRequest(
-    name: string,
-    handler: (payload: unknown) => unknown | Promise<unknown>,
-  ): void;
   fetch(url: string, options?: RequestInit): Promise<Response>;
 }
 
 export interface TakosUIAPI {
   events: TakosEventsAPI;
   extensions: TakosExtensionsAPI;
-  request(name: string, payload: unknown): Promise<unknown>;
-  onRequest(
-    name: string,
-    handler: (payload: unknown) => unknown | Promise<unknown>,
-  ): void;
 }
 
 // 型安全なTakos APIアクセス関数群

--- a/packages/builder/src/api-helpers.ts
+++ b/packages/builder/src/api-helpers.ts
@@ -17,7 +17,7 @@ export interface TakosEventsAPI {
   onRequest(
     name: string,
     handler: (payload: unknown) => unknown | Promise<unknown>,
-  ): void;
+  ): () => void;
 }
 
 export interface TakosKVAPI {
@@ -79,7 +79,7 @@ export interface TakosExtensionsAPI {
   onRequest(
     name: string,
     handler: (payload: unknown) => unknown | Promise<unknown>,
-  ): void;
+  ): () => void;
 }
 
 // コンテキスト別API定義

--- a/packages/builder/src/simple-api.ts
+++ b/packages/builder/src/simple-api.ts
@@ -61,19 +61,10 @@ export interface SimpleTakosAPI {
     list: (prefix?: string) => Promise<string[]>;
   };
   extensions?: {
-    all: Array<{
-      identifier: string;
-      version: string;
-      isActive: boolean;
-      request: (name: string, payload?: unknown) => Promise<unknown>;
-    }>;
     get?: (id: string) => {
       identifier: string;
-      version: string;
-      isActive: boolean;
       request: (name: string, payload?: unknown) => Promise<unknown>;
     } | undefined;
-    request?: (name: string, payload?: unknown) => Promise<unknown>;
     onRequest?: (
       name: string,
       handler: (payload: unknown) => unknown | Promise<unknown>,
@@ -97,7 +88,7 @@ function request(
   payload: unknown,
 ): Promise<unknown> | void {
   return api.request?.(name, payload) ??
-    api.extensions?.request?.(name, payload);
+    api.events?.request?.(name, payload);
 }
 
 function onRequest(
@@ -108,7 +99,7 @@ function onRequest(
     api.onRequest(name, handler);
     return;
   }
-  return api.extensions?.onRequest?.(name, handler);
+  return api.events?.onRequest?.(name, handler);
 }
 
 function kvRead(key: string): Promise<unknown> | void {

--- a/packages/builder/src/simple-api.ts
+++ b/packages/builder/src/simple-api.ts
@@ -12,7 +12,7 @@ export interface SimpleTakosAPI {
     onRequest: (
       name: string,
       handler: (payload: unknown) => unknown | Promise<unknown>,
-    ) => void;
+    ) => () => void;
   };
   kv?: {
     read: (key: string) => Promise<unknown> | void;
@@ -73,17 +73,11 @@ export interface SimpleTakosAPI {
       isActive: boolean;
       request: (name: string, payload?: unknown) => Promise<unknown>;
     } | undefined;
-    /**
-     * Directly call another extension's exported API function.
-     */
     request?: (name: string, payload?: unknown) => Promise<unknown>;
-    /**
-     * Register a handler that other extensions can invoke via `request()`.
-     */
     onRequest?: (
       name: string,
       handler: (payload: unknown) => unknown | Promise<unknown>,
-    ) => void;
+    ) => () => void;
   };
 
   request: (name: string, payload: unknown) => Promise<unknown> | void;
@@ -102,15 +96,19 @@ function request(
   name: string,
   payload: unknown,
 ): Promise<unknown> | void {
-  return api.request?.(name, payload) ?? api.extensions?.request?.(name, payload);
+  return api.request?.(name, payload) ??
+    api.extensions?.request?.(name, payload);
 }
 
 function onRequest(
   name: string,
   handler: (payload: unknown) => unknown | Promise<unknown>,
-): void {
-  if (api.onRequest) api.onRequest(name, handler);
-  else api.extensions?.onRequest?.(name, handler);
+): (() => void) | void {
+  if (api.onRequest) {
+    api.onRequest(name, handler);
+    return;
+  }
+  return api.extensions?.onRequest?.(name, handler);
 }
 
 function kvRead(key: string): Promise<unknown> | void {


### PR DESCRIPTION
## Summary
- expose takos.extensions API and remove temporary singular alias
- update docs and example to use takos.extensions.request/onRequest
- adapt simple API and runtime interfaces for plural API
- return disposer from extensions.onRequest/events.onRequest handlers
- remove outdated references to ActivityPub hooks in docs and examples

## Testing
- `deno test -A` *(fails: JSR package manifest failed to load)*

------
https://chatgpt.com/codex/tasks/task_e_6861735da8d08328ace8544fafa687f0