### PR TITLE
Add plugin actor API

### DIFF
--- a/app/api/eventManager.ts
+++ b/app/api/eventManager.ts
@@ -11,6 +11,7 @@ class EventManager {
       schema: z.ZodSchema<any>;
       // deno-lint-ignore no-explicit-any
       handler: (c: Context, payload: any) => Promise<any>;
+      permission?: string;
     }
   >();
 
@@ -20,9 +21,10 @@ class EventManager {
     schema: z.ZodSchema<T>,
     // deno-lint-ignore no-explicit-any
     handler: (c: Context, payload: T) => Promise<any>,
+    permission?: string,
   ) {
     const key = `${identifier}:${eventId}`;
-    this.events.set(key, { schema, handler });
+    this.events.set(key, { schema, handler, permission });
   }
 
   async dispatch(c: Context) {
@@ -40,63 +42,85 @@ class EventManager {
     for (const e of events) {
       const key = `${e.identifier}:${e.eventId}`;
       const eventDef = this.events.get(key);
-      
+
       if (!eventDef) {
         // Check if this is an extension-specific event that should be forwarded to the extension runtime
         if (e.identifier !== "takos") {
           try {
             console.log(`Looking for extension runtime for: ${e.identifier}`);
-            const { callExtension, getExtension } = await import("./utils/extensionsRuntime.ts");
+            const { callExtension, getExtension } = await import(
+              "./utils/extensionsRuntime.ts"
+            );
             const ext = getExtension(e.identifier);
             if (ext) {
-              console.log(`Forwarding event ${e.eventId} to extension ${e.identifier} with payload:`, e.payload);
-              const result = await callExtension(e.identifier, e.eventId, [e.payload]);
+              console.log(
+                `Forwarding event ${e.eventId} to extension ${e.identifier} with payload:`,
+                e.payload,
+              );
+              const result = await callExtension(e.identifier, e.eventId, [
+                e.payload,
+              ]);
               console.log(`Extension ${e.identifier} returned:`, result);
               results.push({ success: true, result });
-              
+
               // WebSocketでイベントを配信
               const wsManager = WebSocketManager.getInstance();
               wsManager.distributeEvent(`${e.identifier}:${e.eventId}`, {
                 identifier: e.identifier,
                 eventId: e.eventId,
                 payload: e.payload,
-                result
+                result,
               });
               continue;
             } else {
               console.log(`Runtime not found for extension: ${e.identifier}`);
             }
           } catch (error) {
-            console.error(`Error forwarding event to extension ${e.identifier}:`, error);
-            results.push({ 
-              success: false, 
-              error: `Extension ${e.identifier} not found or error: ${error instanceof Error ? error.message : String(error)}` 
+            console.error(
+              `Error forwarding event to extension ${e.identifier}:`,
+              error,
+            );
+            results.push({
+              success: false,
+              error: `Extension ${e.identifier} not found or error: ${
+                error instanceof Error ? error.message : String(error)
+              }`,
             });
             continue;
           }
         }
-        
+
         console.log(`No handler found for event: ${key}`);
         results.push({ error: "Invalid event", event: e });
         continue;
       }
-      
+
       const parsed = eventDef.schema.safeParse(e.payload);
       if (!parsed.success) {
         results.push({ error: "Invalid payload", event: e });
         continue;
       }
+      if (eventDef.permission) {
+        const { getManifest } = await import("./utils/extensionsRuntime.ts");
+        const manifest = getManifest(e.identifier) as
+          | { permissions?: string[] }
+          | undefined;
+        if (!manifest?.permissions?.includes(eventDef.permission)) {
+          results.push({ error: "Permission denied", event: e });
+          continue;
+        }
+      }
       try {
         const result = await eventDef.handler(c, parsed.data);
         results.push({ success: true, result });
-        
+
         // WebSocketでイベントを配信
         const wsManager = WebSocketManager.getInstance();
         wsManager.distributeEvent(`${e.identifier}:${e.eventId}`, {
           identifier: e.identifier,
           eventId: e.eventId,
           payload: parsed.data,
-          result
+          result,
         });
       } catch (error) {
         console.error("Event handler error:", error);
@@ -109,6 +133,43 @@ class EventManager {
       }
     }
     return c.json(results);
+  }
+
+  // Programmatically trigger an event
+  async trigger(
+    c: Context,
+    identifier: string,
+    eventId: string,
+    payload: unknown,
+  ): Promise<unknown> {
+    const key = `${identifier}:${eventId}`;
+    const eventDef = this.events.get(key);
+
+    if (!eventDef) {
+      if (identifier !== "takos") {
+        const { callExtension, getExtension } = await import(
+          "./utils/extensionsRuntime.ts"
+        );
+        const ext = getExtension(identifier);
+        if (ext) return await callExtension(identifier, eventId, [payload]);
+      }
+      throw new Error(`Event not found: ${key}`);
+    }
+
+    const parsed = eventDef.schema.safeParse(payload);
+    if (!parsed.success) throw new Error("Invalid payload");
+
+    if (eventDef.permission) {
+      const { getManifest } = await import("./utils/extensionsRuntime.ts");
+      const manifest = getManifest(identifier) as
+        | { permissions?: string[] }
+        | undefined;
+      if (!manifest?.permissions?.includes(eventDef.permission)) {
+        throw new Error("Permission denied");
+      }
+    }
+
+    return await eventDef.handler(c, parsed.data);
   }
 }
 

--- a/app/api/events/extensions.ts
+++ b/app/api/events/extensions.ts
@@ -8,7 +8,11 @@ import {
   searchRegistry,
 } from "../../../packages/registry/mod.ts";
 import { Extension } from "../models/extension.ts";
-import { callExtension, getExtension, loadExtension } from "../utils/extensionsRuntime.ts";
+import {
+  callExtension,
+  getExtension,
+  loadExtension,
+} from "../utils/extensionsRuntime.ts";
 
 function decodeBase64(data: string): Uint8Array {
   const bin = atob(data);
@@ -132,6 +136,7 @@ eventManager.add(
     const result = await callExtension(id, fn, args);
     return result;
   },
+  "extensions:invoke",
 );
 
 eventManager.add(

--- a/app/api/events/kv.ts
+++ b/app/api/events/kv.ts
@@ -16,6 +16,7 @@ eventManager.add(
     const doc = await KVItem.findOne({ identifier: id, side, key });
     return doc ? doc.value : null;
   },
+  "kv:read",
 );
 
 eventManager.add(
@@ -35,6 +36,7 @@ eventManager.add(
     );
     return { success: true };
   },
+  "kv:write",
 );
 
 eventManager.add(
@@ -49,6 +51,7 @@ eventManager.add(
     await KVItem.deleteOne({ identifier: id, side, key });
     return { success: true };
   },
+  "kv:write",
 );
 
 eventManager.add(
@@ -65,4 +68,5 @@ eventManager.add(
     const docs = await KVItem.find(query).select("key");
     return docs.map((d) => d.key);
   },
+  "kv:read",
 );

--- a/app/api/models/pluginActor.ts
+++ b/app/api/models/pluginActor.ts
@@ -1,0 +1,25 @@
+import mongoose from "mongoose";
+
+interface IPluginActor {
+  identifier: string;
+  localName: string;
+  iri: string;
+  actor: Record<string, unknown>;
+  privateKeyPem: string;
+  createdAt?: Date;
+}
+
+const pluginActorSchema = new mongoose.Schema<IPluginActor>({
+  identifier: { type: String, required: true, index: true },
+  localName: { type: String, required: true },
+  iri: { type: String, required: true, unique: true },
+  actor: { type: Object, required: true },
+  privateKeyPem: { type: String, required: true },
+  createdAt: { type: Date, default: Date.now },
+});
+pluginActorSchema.index({ identifier: 1, localName: 1 }, { unique: true });
+
+export const PluginActor = mongoose.model<IPluginActor>(
+  "PluginActor",
+  pluginActorSchema,
+);

--- a/docs/builder/README.md
+++ b/docs/builder/README.md
@@ -1,6 +1,6 @@
 # 🔧 **Takopack Builder API ドキュメント**
 
-> **バージョン**: v2.0 **最終更新**: 2025-06-01
+> **バージョン**: v3.0 **最終更新**: 2025-06-01
 
 ## 📚 **目次**
 
@@ -158,7 +158,7 @@ await extension.build();
   version: "1.0.0",
   identifier: "com.example.ext",
   permissions: ["kv:read", "activitypub:send"],
-  apiVersion: "2.0"  // オプション（デフォルト: "2.0"）
+  apiVersion: "3.0"  // オプション（デフォルト: "3.0"）
 })
 ```
 
@@ -243,7 +243,7 @@ interface ManifestConfig {
   description: string; // 説明
   version: string; // バージョン（SemVer形式）
   identifier: string; // 識別子（逆FQDN形式）
-  apiVersion?: string; // API バージョン（デフォルト: "2.0"）
+  apiVersion?: string; // API バージョン（デフォルト: "3.0"）
   permissions?: Permission[]; // 権限配列
 }
 ```
@@ -345,9 +345,9 @@ await simpleTakos.request("hello", { message: "hi" });
 
 ### 拡張機能 API の呼び出し
 
-他拡張が公開する機能は `takos.extensions.get()` で取得した
-オブジェクトの `request()` メソッドから実行します。
-公開側では `takos.extensions.onRequest()` でハンドラーを登録します。
+他拡張が公開する機能は `takos.extensions.get()` で取得した オブジェクトの
+`request()` メソッドから実行します。 公開側では `takos.extensions.onRequest()`
+でハンドラーを登録します。
 
 ```typescript
 // com.example.lib 側

--- a/packages/builder/deno.json
+++ b/packages/builder/deno.json
@@ -16,7 +16,8 @@
     "@typescript-eslint/typescript-estree": "npm:@typescript-eslint/typescript-estree@8.18.0",
     "@zip-js/zip-js": "jsr:@zip-js/zip-js@^2.7.62",
     "@luca/esbuild-deno-loader": "jsr:@luca/esbuild-deno-loader@^0.11.1",
-    "esbuild": "npm:esbuild@0.20.2"
+    "esbuild": "npm:esbuild@0.20.2",
+    "ajv": "https://esm.sh/ajv@8.12.0"
   },
   "compilerOptions": {
     "lib": ["deno.ns", "dom", "es2022"],


### PR DESCRIPTION
## Summary
- implement plugin-actor events for creating and managing plugin actors
- store plugin actor records in new PluginActor model

## Testing
- `deno fmt app/api/events/activitypub.ts app/api/models/pluginActor.ts app/api/eventManager.ts app/api/events/cdn.ts app/api/events/extensions.ts app/api/events/kv.ts packages/builder/src/builder.ts docs/builder/README.md app/api/activitypub.ts`
- `deno test -A` *(fails: JSR package manifest for '@std/assert' failed to load)*

------
https://chatgpt.com/codex/tasks/task_e_68618a04efe883289a949325decdab8a