### PR TITLE
Implement Takos API type generation

### DIFF
--- a/packages/builder/src/generator.ts
+++ b/packages/builder/src/generator.ts
@@ -1,9 +1,9 @@
 import type {
   ActivityPubConfig,
   ModuleAnalysis,
-  VirtualEntry,
   TypeGenerationOptions,
   TypeGenerationResult,
+  VirtualEntry,
 } from "./types.ts";
 
 export class VirtualEntryGenerator {
@@ -18,7 +18,9 @@ export class VirtualEntryGenerator {
         if (tag.tag === "event") {
           const name = this.extractEventName(tag.value);
           if (name) {
-            lines.push(`export const ${name} = (...args: any[]) => ${modVar}.${tag.targetFunction}(...args);`);
+            lines.push(
+              `export const ${name} = (...args: any[]) => ${modVar}.${tag.targetFunction}(...args);`,
+            );
             exports.push(name);
           }
         }
@@ -38,7 +40,9 @@ export class VirtualEntryGenerator {
         if (tag.tag === "event") {
           const name = this.extractEventName(tag.value);
           if (name) {
-            lines.push(`export const ${name} = (...args: any[]) => ${modVar}.${tag.targetFunction}(...args);`);
+            lines.push(
+              `export const ${name} = (...args: any[]) => ${modVar}.${tag.targetFunction}(...args);`,
+            );
             exports.push(name);
           }
         }
@@ -48,7 +52,142 @@ export class VirtualEntryGenerator {
   }
 
   generateTypeDefinitions(options: TypeGenerationOptions): TypeGenerationResult {
-    return { filePath: options.outputPath, content: "", typeCount: 0 };
+    const lines: string[] = [];
+
+    lines.push("// Auto-generated TypeScript definitions for Takos Extension");
+    lines.push("// DO NOT EDIT MANUALLY");
+    lines.push("// Generated at: " + new Date().toISOString());
+    lines.push("");
+
+    // Core API types
+    lines.push("export interface TakosEvent<T = unknown> {");
+    lines.push("  name: string;");
+    lines.push("  payload: T;");
+    lines.push("  timestamp: number;");
+    lines.push("  source: 'server' | 'client' | 'ui' | 'background';");
+    lines.push("}");
+    lines.push("");
+
+    lines.push("export interface TakosEventsAPI {");
+    lines.push("  request(name: string, payload: unknown): Promise<unknown>;");
+    lines.push(
+      "  onRequest(name: string, handler: (payload: unknown) => unknown | Promise<unknown>): () => void;",
+    );
+    lines.push("}");
+    lines.push("");
+
+    lines.push("export interface TakosKVAPI {");
+    lines.push("  read(key: string): Promise<unknown>;");
+    lines.push("  write(key: string, value: unknown): Promise<void>;");
+    lines.push("  delete(key: string): Promise<void>;");
+    lines.push("  list(prefix?: string): Promise<string[]>;");
+    lines.push("}");
+    lines.push("");
+
+    lines.push("export interface TakosCdnAPI {");
+    lines.push("  read(path: string): Promise<string>;");
+    lines.push(
+      "  write(path: string, data: string | Uint8Array, options?: { cacheTTL?: number }): Promise<string>;",
+    );
+    lines.push("  delete(path: string): Promise<void>;");
+    lines.push("  list(prefix?: string): Promise<string[]>;");
+    lines.push("}");
+    lines.push("");
+
+    lines.push("export interface TakosActivityPubAPI {");
+    lines.push("  currentUser(): Promise<string>;");
+    lines.push("  send(activity: Record<string, unknown>): Promise<void>;");
+    lines.push("  read(id: string): Promise<Record<string, unknown>>;");
+    lines.push("  delete(id: string): Promise<void>;");
+    lines.push("  list(): Promise<string[]>;");
+    lines.push(
+      "  follow(followerId: string, followeeId: string): Promise<void>;",
+    );
+    lines.push(
+      "  unfollow(followerId: string, followeeId: string): Promise<void>;",
+    );
+    lines.push(
+      "  listFollowers(actorId: string): Promise<string[]>;",
+    );
+    lines.push(
+      "  listFollowing(actorId: string): Promise<string[]>;",
+    );
+    lines.push("  actor: {");
+    lines.push("    read(): Promise<Record<string, unknown>>;");
+    lines.push("    update(key: string, value: string): Promise<void>;");
+    lines.push("    delete(key: string): Promise<void>;");
+    lines.push("  };\n  pluginActor: {");
+    lines.push(
+      "    create(localName: string, profile: Record<string, unknown>): Promise<string>;",
+    );
+    lines.push("    read(iri: string): Promise<Record<string, unknown>>;");
+    lines.push(
+      "    update(iri: string, partial: Record<string, unknown>): Promise<void>;",
+    );
+    lines.push("    delete(iri: string): Promise<void>;");
+    lines.push("    list(): Promise<string[]>;\n  };\n}");
+    lines.push("");
+
+    lines.push("export interface Extension {");
+    lines.push("  identifier: string;");
+    lines.push("  request(name: string, payload?: unknown): Promise<unknown>;");
+    lines.push("}");
+    lines.push("");
+
+    lines.push("export interface TakosExtensionsAPI {");
+    lines.push("  get(identifier: string): Extension | undefined;");
+    lines.push(
+      "  onRequest(name: string, handler: (payload: unknown) => unknown | Promise<unknown>): () => void;",
+    );
+    lines.push("}");
+    lines.push("");
+
+    lines.push("export interface TakosServerAPI {");
+    lines.push("  kv: TakosKVAPI;");
+    lines.push("  ap: TakosActivityPubAPI;");
+    lines.push("  cdn: TakosCdnAPI;");
+    lines.push("  events: TakosEventsAPI;");
+    lines.push("  extensions: TakosExtensionsAPI;");
+    lines.push("  fetch(url: string, options?: RequestInit): Promise<Response>;");
+    lines.push("}");
+    lines.push("");
+
+    lines.push("export interface TakosClientAPI {");
+    lines.push("  kv: TakosKVAPI;");
+    lines.push("  events: TakosEventsAPI;");
+    lines.push("  extensions: TakosExtensionsAPI;");
+    lines.push("  fetch(url: string, options?: RequestInit): Promise<Response>;");
+    lines.push("}");
+    lines.push("");
+
+    lines.push("export interface TakosUIAPI {");
+    lines.push("  events: TakosEventsAPI;");
+    lines.push("  extensions: TakosExtensionsAPI;");
+    lines.push("}");
+    lines.push("");
+
+    if (options.context === "server") {
+      lines.push("declare global {");
+      lines.push("  namespace globalThis {");
+      lines.push("    var takos: TakosServerAPI;");
+      lines.push("  }");
+      lines.push("}");
+    } else if (options.context === "client") {
+      lines.push("export interface GlobalThisWithClientTakos {");
+      lines.push("  takos: TakosClientAPI;");
+      lines.push("}");
+      lines.push("declare const globalThis: GlobalThisWithClientTakos;");
+    } else if (options.context === "ui") {
+      lines.push("export interface GlobalThisWithUITakos {");
+      lines.push("  takos: TakosUIAPI;");
+      lines.push("}");
+      lines.push("declare const globalThis: GlobalThisWithUITakos;");
+    }
+
+    const content = lines.join("\n");
+    const typeCount = (content.match(/(interface|type)\s+\w+/g) || []).length;
+
+    return { filePath: options.outputPath, content, typeCount };
   }
 
   parseActivityTag(value: string, targetFunction: string): ActivityPubConfig | null {


### PR DESCRIPTION
## Summary
- implement `generateTypeDefinitions` in generator to output API typings for server, client and UI contexts

## Testing
- `deno test -A` in packages/builder
- `deno test -A` *(fails: JSR package manifest for '@std/assert' failed to load)*

------
https://chatgpt.com/codex/tasks/task_e_68619f720270832897a031cce6005c17