### PR TITLE
Fix extension update detection

### DIFF
--- a/app/client/src/lib/extensionLoader.ts
+++ b/app/client/src/lib/extensionLoader.ts
@@ -34,28 +34,29 @@ interface LoadedExtension {
  */
 export const getExtensionManifest = async (extId: string): Promise<ExtensionManifest | null> => {
   try {
-    // キャッシュから取得を試行
+    // まずAPIからmanifestを取得して最新バージョンを確認
+    console.log(`🌐 Fetching manifest for ${extId} from API`);
+    const response = await fetch(`/api/extensions/${extId}/manifest.json`);
+    if (response.ok) {
+      return await response.json() as ExtensionManifest;
+    }
+    console.warn(`Manifest fetch failed for ${extId}: ${response.status}`);
+  } catch (error) {
+    console.warn(`Manifest fetch error for ${extId}, falling back to cache:`, error);
+  }
+
+  // API取得に失敗した場合はキャッシュを利用
+  try {
     const cached = await getCachedExtension(extId);
     if (cached) {
       console.log(`📦 Using cached manifest for ${extId}`);
       return cached.manifest;
     }
-
-    // キャッシュにない場合、APIから取得
-    console.log(`🌐 Fetching manifest for ${extId} from API`);
-    const response = await fetch(`/api/extensions/${extId}/manifest.json`);
-    if (!response.ok) {
-      if (response.status === 404) {
-        console.warn(`Manifest not found in API for ${extId}, this may indicate the extension is not properly installed`);
-      }
-      throw new Error(`Failed to fetch manifest: ${response.status}`);
-    }
-
-    return await response.json() as ExtensionManifest;
-  } catch (error) {
-    console.error(`Failed to get manifest for ${extId}:`, error);
-    return null;
+  } catch (cacheError) {
+    console.error(`Failed to read cached manifest for ${extId}:`, cacheError);
   }
+
+  return null;
 };
 
 /**

--- a/docs/takopack/cache-system.md
+++ b/docs/takopack/cache-system.md
@@ -119,8 +119,8 @@ refreshExtensionCache(extId: string): Promise<LoadedExtension | null>
 1. ExtensionFrame読み込み開始
 2. loadExtension(extId) 呼び出し
 3. キャッシュ確認 → 存在する
-4. バージョン確認 → 最新
-5. キャッシュからデータ取得
+4. APIからmanifest取得 → バージョン確認
+5. 最新の場合 → キャッシュからデータ取得
 6. ExtensionFrameでBlobURL経由読み込み
 ```
 


### PR DESCRIPTION
## Summary
- always fetch manifest from API before checking cache
- update caching documentation to mention API-based version check

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686537c1d93883289d0c55d908116841