### PR TITLE
Fix tauri client build

### DIFF
--- a/app/client/src-tauri/Cargo.toml
+++ b/app/client/src-tauri/Cargo.toml
@@ -23,6 +23,7 @@ tauri-plugin-opener = "2.4.0"
 tauri-plugin-store = "2.3.0"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
+once_cell = "1.19.0"
 deno_runtime = "0.216.0"
 deno_core = "=0.351.0"
 deno_fs = "0.118.0"

--- a/app/client/src-tauri/src/lib.rs
+++ b/app/client/src-tauri/src/lib.rs
@@ -83,7 +83,7 @@ struct EventPayload {
 async fn op_publish_event(
     state: Rc<RefCell<OpState>>,
     #[string] event_name: String,
-    payload: serde_json::Value,
+    #[serde] payload: serde_json::Value,
 ) -> Result<(), CoreError> {
     let (app_handle, identifier) = {
         let state = state.borrow();


### PR DESCRIPTION
## Summary
- mark `op_publish_event` payload as serde convertible
- add missing `once_cell` dependency

## Testing
- `cargo check --manifest-path app/client/src-tauri/Cargo.toml` *(fails: glib-2.0 not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865664220808328bf5da475352883ad