### PR TITLE
Add visual feedback for account switching

### DIFF
--- a/app/client/src/App.css
+++ b/app/client/src/App.css
@@ -4,17 +4,8 @@ body {
   margin: 0;
   padding: 0;
   font-family:
-    system-ui,
-    -apple-system,
-    BlinkMacSystemFont,
-    "Segoe UI",
-    Roboto,
-    Oxygen,
-    Ubuntu,
-    Cantarell,
-    "Open Sans",
-    "Helvetica Neue",
-    sans-serif;
+    system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen,
+    Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   background-color: #1a1a1a;
@@ -48,4 +39,19 @@ button {
 .hover\:bg-purple-600:hover {
   background-color: #9333ea;
   box-shadow: 0 0 15px rgba(139, 92, 246, 0.3);
+}
+
+@keyframes account-switch {
+  from {
+    opacity: 0;
+    transform: scale(0.95);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+.account-switch {
+  animation: account-switch 0.3s ease-out;
 }

--- a/app/client/src/components/Home.tsx
+++ b/app/client/src/components/Home.tsx
@@ -3,6 +3,7 @@ import {
   createEffect,
   createSignal,
   For,
+  onCleanup,
   onMount,
   Show,
 } from "solid-js";
@@ -41,6 +42,15 @@ const AccountSettingsContent: Component<{
   const [hasChanges, setHasChanges] = createSignal(false);
   const [showDeleteConfirm, setShowDeleteConfirm] = createSignal(false);
   const [isLoading, setIsLoading] = createSignal(false);
+  const [isSwitching, setIsSwitching] = createSignal(false);
+
+  // アカウントが切り替わった際のアニメーション用
+  createEffect(() => {
+    props.selectedAccountId;
+    setIsSwitching(true);
+    const t = setTimeout(() => setIsSwitching(false), 300);
+    onCleanup(() => clearTimeout(t));
+  });
 
   // 選択されたアカウントが変更されたときにローカル状態を更新
   createEffect(() => {
@@ -233,7 +243,11 @@ const AccountSettingsContent: Component<{
 
       {/* アカウント設定フォーム */}
       <Show when={selectedAccount()}>
-        <div class="bg-gradient-to-br from-[#1a1a1a] to-[#161616] rounded-2xl shadow-xl border border-gray-800/50 overflow-hidden animate-in slide-in-from-right-4 duration-500">
+        <div
+          class={`bg-gradient-to-br from-[#1a1a1a] to-[#161616] rounded-2xl shadow-xl border border-gray-800/50 overflow-hidden animate-in slide-in-from-right-4 duration-500 ${
+            isSwitching() ? "account-switch" : ""
+          }`}
+        >
           <div class="p-6 border-b border-gray-800/50">
             <h3 class="text-xl font-semibold text-gray-100">アカウント設定</h3>
             <p class="text-gray-400 mt-1">プロファイル情報を編集できます</p>


### PR DESCRIPTION
## Summary
- add `account-switch` animation in App.css
- animate the account settings panel when selected account changes

## Testing
- `deno fmt app/client/src/components/Home.tsx app/client/src/App.css`
- `deno lint app/client/src/components/Home.tsx app/client/src/App.css`


------
https://chatgpt.com/codex/tasks/task_e_6866b24bb1888328a1ed657d0212415b