### PR TITLE
Highlight selected account

### DIFF
--- a/app/client/src/components/Home.tsx
+++ b/app/client/src/components/Home.tsx
@@ -1,8 +1,10 @@
-import { createSignal, onMount } from "solid-js";
+import { createMemo, createSignal, onMount } from "solid-js";
 import AccountSettingsContent from "./home/AccountSettingsContent.tsx";
 import NotificationsContent from "./home/NotificationsContent.tsx";
 import { Account, isDataUrl } from "./home/types.ts";
 import { Setting } from "./Setting/index.tsx";
+import { useAtom } from "solid-jotai";
+import { selectedAccountIdState } from "../states/accounts.ts";
 
 export function Home() {
   const [activeSection, setActiveSection] = createSignal("account");
@@ -10,8 +12,19 @@ export function Home() {
   // サンプルアカウントデータ
   const [accounts, setAccounts] = createSignal<Account[]>([]);
 
-  // 現在選択中のアカウントID
-  const [selectedAccountId, setSelectedAccountId] = createSignal("");
+  // 選択中のアカウントを先頭にした並び順
+  const sortedAccounts = createMemo(() => {
+    const currentId = selectedAccountId();
+    const list = accounts();
+    const selected = list.find((acc) => acc.id === currentId);
+    const others = list.filter((acc) => acc.id !== currentId);
+    return selected ? [selected, ...others] : list;
+  });
+
+  // 現在選択中のアカウントID(グローバル状態)
+  const [selectedAccountId, setSelectedAccountId] = useAtom(
+    selectedAccountIdState,
+  );
 
   // APIでアカウント一覧を取得
   const loadAccounts = async (preserveSelectedId?: string) => {
@@ -145,7 +158,7 @@ export function Home() {
       case "account":
         return (
           <AccountSettingsContent
-            accounts={accounts()}
+            accounts={sortedAccounts()}
             selectedAccountId={selectedAccountId()}
             setSelectedAccountId={setSelectedAccountId}
             addNewAccount={addNewAccount}

--- a/app/client/src/components/home/AccountSettingsContent.tsx
+++ b/app/client/src/components/home/AccountSettingsContent.tsx
@@ -152,10 +152,10 @@ const AccountSettingsContent: Component<{
               {(account) => (
                 <button
                   type="button"
-                  class={`group relative flex flex-col items-center p-4 rounded-xl transition-all duration-300 transform hover:scale-105 focus:scale-105 focus:outline-none focus:ring-2 focus:ring-teal-500/50 ${
+                  class={`group relative flex flex-col items-center p-4 rounded-xl transition-all duration-300 transform focus:scale-105 focus:outline-none focus:ring-2 focus:ring-teal-500/50 ${
                     props.selectedAccountId === account.id
-                      ? "bg-gradient-to-br from-teal-600/20 to-teal-700/20 ring-2 ring-teal-500/50 shadow-lg shadow-teal-500/10"
-                      : "bg-gray-800/30 hover:bg-gray-700/40 hover:shadow-lg"
+                      ? "scale-105 bg-gradient-to-br from-teal-600/20 to-teal-700/20 ring-2 ring-teal-500/50 shadow-lg shadow-teal-500/10"
+                      : "bg-gray-800/30 opacity-60 hover:opacity-100 hover:bg-gray-700/40 hover:shadow-lg"
                   }`}
                   onClick={() => props.setSelectedAccountId(account.id)}
                   aria-label={`${account.displayName}のアカウントを選択`}

--- a/app/client/src/states/accounts.ts
+++ b/app/client/src/states/accounts.ts
@@ -1,0 +1,4 @@
+import { atom } from "solid-jotai";
+
+// 現在選択中のアカウントIDを管理する状態
+export const selectedAccountIdState = atom<string>("");


### PR DESCRIPTION
## Summary
- add a global `selectedAccountIdState` with Jotai
- show the selected account first and fade the others
- update Home component to use the new state

## Testing
- `deno fmt app/client/src/components/Home.tsx app/client/src/components/home/AccountSettingsContent.tsx app/client/src/states/accounts.ts`
- `deno lint app/client/src/components/Home.tsx app/client/src/components/home/AccountSettingsContent.tsx app/client/src/states/accounts.ts`


------
https://chatgpt.com/codex/tasks/task_e_6866b899a4248328bde41c3846829aa3