### PR TITLE
Implement simple settings page

### DIFF
--- a/app/client/src/App.css
+++ b/app/client/src/App.css
@@ -8,8 +8,16 @@ body {
     Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+}
+
+body.dark {
   background-color: #1a1a1a;
   color: #f3f4f6;
+}
+
+body.light {
+  background-color: #ffffff;
+  color: #1a1a1a;
 }
 
 input::placeholder {

--- a/app/client/src/App.tsx
+++ b/app/client/src/App.tsx
@@ -1,6 +1,7 @@
-import { onMount, Show } from "solid-js";
+import { createEffect, onMount, Show } from "solid-js";
 import { useAtom } from "solid-jotai";
 import { loginState } from "./states/session.ts";
+import { darkModeState, languageState } from "./states/settings.ts";
 import { LoginForm } from "./components/LoginForm.tsx";
 import { Aplication } from "./components/Aplication.tsx";
 import "./App.css";
@@ -8,6 +9,8 @@ import "./stylesheet.css";
 
 function App() {
   const [isLoggedIn, setIsLoggedIn] = useAtom(loginState);
+  const [darkMode, setDarkMode] = useAtom(darkModeState);
+  const [language, setLanguage] = useAtom(languageState);
 
   // アプリケーション初期化時にログイン状態を確認
   onMount(async () => {
@@ -19,15 +22,39 @@ function App() {
       console.error("Failed to fetch login status:", err);
       setIsLoggedIn(false);
     }
+
+    const storedDark = localStorage.getItem("darkMode");
+    if (storedDark !== null) {
+      setDarkMode(storedDark === "true");
+    }
+    const storedLang = localStorage.getItem("language");
+    if (storedLang) {
+      setLanguage(storedLang);
+    }
+  });
+
+  createEffect(() => {
+    if (darkMode()) {
+      document.body.classList.add("dark");
+      document.body.classList.remove("light");
+    } else {
+      document.body.classList.remove("dark");
+      document.body.classList.add("light");
+    }
+    localStorage.setItem("darkMode", String(darkMode()));
+  });
+
+  createEffect(() => {
+    localStorage.setItem("language", language());
   });
 
   return (
-      <Show
-        when={isLoggedIn()}
-        fallback={<LoginForm onLoginSuccess={() => setIsLoggedIn(true)} />}
-      >
-        <Aplication />
-      </Show>
+    <Show
+      when={isLoggedIn()}
+      fallback={<LoginForm onLoginSuccess={() => setIsLoggedIn(true)} />}
+    >
+      <Aplication />
+    </Show>
   );
 }
 

--- a/app/client/src/components/Setting/index.tsx
+++ b/app/client/src/components/Setting/index.tsx
@@ -1,8 +1,34 @@
+import { useAtom } from "solid-jotai";
+import { darkModeState, languageState } from "../../states/settings.ts";
+
 export function Setting() {
+  const [darkMode, setDarkMode] = useAtom(darkModeState);
+  const [language, setLanguage] = useAtom(languageState);
+
+  const toggleDark = () => setDarkMode(!darkMode());
+
   return (
-    <div>
-      <h1>Setting Page</h1>
-      <p>This is the setting page content.</p>
+    <div class="space-y-6">
+      <div class="flex items-center space-x-3">
+        <input
+          id="darkmode"
+          type="checkbox"
+          checked={darkMode()}
+          onChange={toggleDark}
+        />
+        <label for="darkmode">ダークモード</label>
+      </div>
+      <div>
+        <label for="lang" class="block mb-1">言語</label>
+        <select
+          id="lang"
+          value={language()}
+          onChange={(e) => setLanguage(e.currentTarget.value)}
+        >
+          <option value="ja">日本語</option>
+          <option value="en">English</option>
+        </select>
+      </div>
     </div>
   );
 }

--- a/app/client/src/states/settings.ts
+++ b/app/client/src/states/settings.ts
@@ -1,0 +1,4 @@
+import { atom } from "solid-jotai";
+
+export const darkModeState = atom(true);
+export const languageState = atom("ja");


### PR DESCRIPTION
## Summary
- add state store for dark mode and language
- implement settings UI
- apply theme class based on stored preference

## Testing
- `deno fmt app/client/src/components/Setting/index.tsx app/client/src/states/settings.ts app/client/src/App.tsx app/client/src/App.css`

------
https://chatgpt.com/codex/tasks/task_e_6866c4debb508328b8ef84dd58deab2a