### PR TITLE
Add object delivery helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,20 @@ takosは、ActivityPubに追加で、以下の機能を提供します。
 cd app/api
 deno task dev
 ```
+
+## ActivityPub エンドポイント
+
+サーバーを起動すると以下の ActivityPub API が利用できます。
+
+- `/.well-known/webfinger` – WebFinger でアクターを検索
+- `/users/:username` – `Person` アクター情報を JSON-LD で返します
+- `/users/:username/outbox` – `Note` の投稿と取得
+
+`outbox` へ `POST` すると以下の形式でノートを作成できます。
+
+```json
+{
+  "type": "Note",
+  "content": "hello"
+}
+```

--- a/app/api/activitypub.ts
+++ b/app/api/activitypub.ts
@@ -1,0 +1,108 @@
+import { Hono } from "hono";
+import Account from "./models/account.ts";
+import Note from "./models/note.ts";
+import { deliverActivityPubObject } from "./utils/activitypub.ts";
+
+const app = new Hono();
+
+app.get("/.well-known/webfinger", async (c) => {
+  const resource = c.req.query("resource");
+  if (!resource?.startsWith("acct:")) {
+    return c.json({ error: "Bad Request" }, 400);
+  }
+  const [username, host] = resource.slice(5).split("@");
+  const domain = new URL(c.req.url).host;
+  if (host !== domain) {
+    return c.json({ error: "Not found" }, 404);
+  }
+  const account = await Account.findOne({ userName: username });
+  if (!account) return c.json({ error: "Not found" }, 404);
+  return c.json({
+    subject: `acct:${username}@${domain}`,
+    links: [
+      {
+        rel: "self",
+        type: "application/activity+json",
+        href: `https://${domain}/users/${username}`,
+      },
+    ],
+  });
+});
+
+app.get("/users/:username", async (c) => {
+  const username = c.req.param("username");
+  const account = await Account.findOne({ userName: username }).lean();
+  if (!account) return c.json({ error: "Not found" }, 404);
+  const domain = new URL(c.req.url).host;
+
+  c.header("content-type", "application/activity+json");
+  return c.json({
+    "@context": "https://www.w3.org/ns/activitystreams",
+    id: `https://${domain}/users/${username}`,
+    type: "Person",
+    preferredUsername: account.userName,
+    name: account.displayName,
+    inbox: `https://${domain}/inbox/${username}`,
+    outbox: `https://${domain}/users/${username}/outbox`,
+    followers: `https://${domain}/users/${username}/followers`,
+    following: `https://${domain}/users/${username}/following`,
+    publicKey: {
+      id: `https://${domain}/users/${username}#main-key`,
+      owner: `https://${domain}/users/${username}`,
+      publicKeyPem: account.publicKey,
+    },
+  });
+});
+
+app.get("/users/:username/outbox", async (c) => {
+  const username = c.req.param("username");
+  const domain = new URL(c.req.url).host;
+  const notes = await Note.find({ attributedTo: username }).sort({
+    published: -1,
+  }).lean();
+  c.header("content-type", "application/activity+json");
+  return c.json({
+    "@context": "https://www.w3.org/ns/activitystreams",
+    id: `https://${domain}/users/${username}/outbox`,
+    type: "OrderedCollection",
+    totalItems: notes.length,
+    orderedItems: notes.map((n) => ({
+      id: `https://${domain}/notes/${n._id}`,
+      type: "Note",
+      attributedTo: `https://${domain}/users/${username}`,
+      content: n.content,
+      published: n.published.toISOString(),
+    })),
+  });
+});
+
+app.post("/users/:username/outbox", async (c) => {
+  const username = c.req.param("username");
+  const body = await c.req.json();
+  if (body.type !== "Note" || typeof body.content !== "string") {
+    return c.json({ error: "Invalid body" }, 400);
+  }
+  const note = new Note({
+    attributedTo: username,
+    content: body.content,
+    to: body.to ?? [],
+    cc: body.cc ?? [],
+  });
+  await note.save();
+  const domain = new URL(c.req.url).host;
+  const activity = {
+    "@context": "https://www.w3.org/ns/activitystreams",
+    id: `https://${domain}/notes/${note._id}`,
+    type: "Note",
+    attributedTo: `https://${domain}/users/${username}`,
+    content: note.content,
+    published: note.published.toISOString(),
+  };
+  deliverActivityPubObject([...note.to, ...note.cc], activity).catch((err) => {
+    console.error("Delivery failed:", err);
+  });
+  c.header("content-type", "application/activity+json");
+  return c.json(activity, 201);
+});
+
+export default app;

--- a/app/api/index.ts
+++ b/app/api/index.ts
@@ -5,6 +5,7 @@ import login from "./login.ts";
 import session from "./session.ts";
 import accounts from "./accounts.ts";
 import notifications from "./notifications.ts";
+import activitypub from "./activitypub.ts";
 
 const env = await load();
 
@@ -17,5 +18,6 @@ app.route("/api", login);
 app.route("/api", session);
 app.route("/api", accounts);
 app.route("/api", notifications);
+app.route("/", activitypub);
 
 Deno.serve(app.fetch);

--- a/app/api/models/note.ts
+++ b/app/api/models/note.ts
@@ -1,0 +1,14 @@
+import mongoose from "mongoose";
+
+const noteSchema = new mongoose.Schema({
+  attributedTo: { type: String, required: true },
+  content: { type: String, required: true },
+  to: { type: [String], default: [] },
+  cc: { type: [String], default: [] },
+  published: { type: Date, default: Date.now },
+});
+
+const Note = mongoose.model("Note", noteSchema);
+
+export default Note;
+export { noteSchema };

--- a/app/api/utils/activitypub.ts
+++ b/app/api/utils/activitypub.ts
@@ -1,0 +1,34 @@
+export async function sendActivityPubObject(
+  inboxUrl: string,
+  object: unknown,
+): Promise<Response> {
+  const body = JSON.stringify(object);
+  const headers = new Headers({
+    "content-type": "application/activity+json",
+  });
+  try {
+    return await fetch(inboxUrl, {
+      method: "POST",
+      headers,
+      body,
+    });
+  } catch (err) {
+    console.error(`Failed to send ActivityPub object to ${inboxUrl}:`, err);
+    throw err;
+  }
+}
+
+export async function deliverActivityPubObject(
+  inboxes: string[],
+  object: unknown,
+): Promise<void> {
+  for (const inbox of inboxes) {
+    if (inbox.startsWith("http")) {
+      try {
+        await sendActivityPubObject(inbox, object);
+      } catch (_) {
+        /* ignore individual errors */
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add ActivityPub object delivery helpers
- use helper in outbox posting to forward notes

## Testing
- `deno lint app/api/activitypub.ts app/api/utils/activitypub.ts app/api/index.ts app/api/models/note.ts`
- `deno task dev` *(fails: JSR package manifest failed to load)*

------
https://chatgpt.com/codex/tasks/task_e_6866c70c44088328940e682b51ba0428