### PR TITLE
Proxy ActivityPub endpoints

### DIFF
--- a/app/client/README.md
+++ b/app/client/README.md
@@ -10,6 +10,11 @@ Start a dev server:
 $ deno task dev
 ```
 
+The development server proxies API requests to `localhost:8000`. To allow
+Mastodon and other ActivityPub clients to reach your backend while using the
+Vite dev server, the proxy is also configured for `/.well-known`, `/users` and
+`/inbox` paths.
+
 ## Deploy
 
 Build production assets:

--- a/app/client/vite.config.mts
+++ b/app/client/vite.config.mts
@@ -20,7 +20,19 @@ export default defineConfig({
         target: "http://localhost:8000", // APIサーバーのポート
         changeOrigin: true,
       },
-    }
+      "/.well-known": {
+        target: "http://localhost:8000",
+        changeOrigin: true,
+      },
+      "/users": {
+        target: "http://localhost:8000",
+        changeOrigin: true,
+      },
+      "/inbox": {
+        target: "http://localhost:8000",
+        changeOrigin: true,
+      },
+    },
   },
   // 3. `TAURI_DEBUG` などの環境変数を利用するため
   envPrefix: ["VITE_", "TAURI_"],


### PR DESCRIPTION
## Summary
- proxy `/.well-known`, `/users` and `/inbox` in Vite dev server
- update dev instructions about ActivityPub proxy

## Testing
- `deno fmt app/client/vite.config.mts app/client/README.md`
- `deno lint app/client/vite.config.mts app/client/README.md`

------
https://chatgpt.com/codex/tasks/task_e_6866dc555b30832882d346182542c8f2