### PR TITLE
Fix webfinger host validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ takosは、ActivityPubに追加で、以下の機能を提供します。
 
 環境変数を設定したら、`app/api` ディレクトリからサーバーを起動します。
 
+特に `ACTIVITYPUB_DOMAIN` は Mastodon など外部からアクセスされる公開ドメインを
+設定してください。未設定の場合はリクエストされたホスト名が利用されます。
+
 ```bash
 cd app/api
 deno task dev

--- a/app/api/activitypub.ts
+++ b/app/api/activitypub.ts
@@ -17,12 +17,14 @@ app.get("/.well-known/webfinger", async (c) => {
     return c.json({ error: "Bad Request" }, 400);
   }
   const [username, host] = resource.slice(5).split("@");
-  const domain = env["ACTIVITYPUB_DOMAIN"];
-  if (host !== domain) {
+  const expected = env["ACTIVITYPUB_DOMAIN"];
+  if (expected && host !== expected) {
     return c.json({ error: "Not found" }, 404);
   }
+  const domain = expected ?? host;
   const account = await Account.findOne({ userName: username });
   if (!account) return c.json({ error: "Not found" }, 404);
+  c.header("content-type", "application/jrd+json");
   return c.json({
     subject: `acct:${username}@${domain}`,
     links: [


### PR DESCRIPTION
## Summary
- allow webfinger to use request host if ACTIVITYPUB_DOMAIN is unset
- set correct content type for webfinger responses
- note ACTIVITYPUB_DOMAIN in README

## Testing
- `deno fmt app/api/activitypub.ts README.md`
- `deno lint app/api/activitypub.ts`

------
https://chatgpt.com/codex/tasks/task_e_6866e82c2ce48328a1c5fdf41bd74d8e