### PR TITLE
ActivityPub utils cleanup

### DIFF
--- a/app/api/microblog.ts
+++ b/app/api/microblog.ts
@@ -1,11 +1,12 @@
 import { Hono } from "hono";
 import ActivityPubObject from "./models/activitypub_object.ts";
 import Account from "./models/account.ts";
-import { env } from "./utils/env.ts";
+import { getDomain } from "./utils/activitypub.ts";
 
 const app = new Hono();
 
 app.get("/microblog", async (c) => {
+  const domain = getDomain(c);
   const list = await ActivityPubObject.find({ type: "Note" }).sort({
     published: -1,
   }).lean();
@@ -25,7 +26,7 @@ app.get("/microblog", async (c) => {
         authorAvatar: account?.avatarInitial || "",
         content: doc.content,
         createdAt: doc.published,
-        domain: env.ACTIVITYPUB_DOMAIN,
+        domain,
       };
     }),
   );
@@ -33,6 +34,7 @@ app.get("/microblog", async (c) => {
 });
 
 app.post("/microblog", async (c) => {
+  const domain = getDomain(c);
   const { author, content } = await c.req.json();
   if (typeof author !== "string" || typeof content !== "string") {
     return c.json({ error: "Invalid body" }, 400);
@@ -51,11 +53,12 @@ app.post("/microblog", async (c) => {
     authorAvatar: account?.avatarInitial || "",
     content: post.content,
     createdAt: post.published,
-    domain: env.ACTIVITYPUB_DOMAIN,
+    domain,
   }, 201);
 });
 
 app.get("/microblog/:id", async (c) => {
+  const domain = getDomain(c);
   const id = c.req.param("id");
   const post = await ActivityPubObject.findById(id).lean();
   if (!post) return c.json({ error: "Not found" }, 404);
@@ -67,11 +70,12 @@ app.get("/microblog/:id", async (c) => {
     authorAvatar: account?.avatarInitial || "",
     content: post.content,
     createdAt: post.published,
-    domain: env.ACTIVITYPUB_DOMAIN,
+    domain,
   });
 });
 
 app.put("/microblog/:id", async (c) => {
+  const domain = getDomain(c);
   const id = c.req.param("id");
   const { content } = await c.req.json();
   if (typeof content !== "string") {
@@ -89,7 +93,7 @@ app.put("/microblog/:id", async (c) => {
     authorAvatar: account?.avatarInitial || "",
     content: post.content,
     createdAt: post.published,
-    domain: env.ACTIVITYPUB_DOMAIN,
+    domain,
   });
 });
 

--- a/app/api/search.ts
+++ b/app/api/search.ts
@@ -1,7 +1,7 @@
 import { Hono } from "hono";
 import Account from "./models/account.ts";
 import ActivityPubObject from "./models/activitypub_object.ts";
-import { env } from "./utils/env.ts";
+import { getDomain } from "./utils/activitypub.ts";
 
 interface SearchResult {
   type: "user" | "post";
@@ -31,7 +31,7 @@ app.get("/search", async (c) => {
     })
       .limit(20)
       .lean();
-    const domain = env["ACTIVITYPUB_DOMAIN"] ?? new URL(c.req.url).host;
+    const domain = getDomain(c);
     for (const u of users) {
       results.push({
         type: "user",
@@ -49,7 +49,7 @@ app.get("/search", async (c) => {
     const posts = await ActivityPubObject.find({ type: "Note", content: regex })
       .limit(20)
       .lean();
-    const domain = env["ACTIVITYPUB_DOMAIN"] ?? new URL(c.req.url).host;
+    const domain = getDomain(c);
     for (const p of posts) {
       results.push({
         type: "post",


### PR DESCRIPTION
## Summary
- ChatGroup と ChatMessage 関連のユーティリティを削除しました

## Testing
- `deno fmt app/api/utils/activitypub.ts app/api/accounts.ts app/api/activitypub.ts app/api/microblog.ts app/api/search.ts`
- `deno lint app/api/utils/activitypub.ts app/api/accounts.ts app/api/activitypub.ts app/api/microblog.ts app/api/search.ts`


------
https://chatgpt.com/codex/tasks/task_e_68695bc00f388328b0a2e753d4f90cf4