### PR TITLE
受信処理をハンドラー化

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,10 @@ deno task dev
 - `/.well-known/webfinger` – WebFinger でアクターを検索
 - `/users/:username` – `Person` アクター情報を JSON-LD で返します
 - `/users/:username/outbox` – `Note` の投稿と取得
-- `/users/:username/inbox` – ActivityPub
-  受信エンドポイント（受信したオブジェクトは `ActivityPubObject`
-  コレクションに保存）
+- `/users/:username/inbox` – ActivityPub 受信エンドポイント。`Create` Activity
+  の場合はオブジェクトを `ActivityPubObject` として保存し、他の Activity
+  は保存せず処理のみ行います。処理は Activity タイプごとにハンドラー化し、
+  新しい Activity を追加しやすくしています。
 
 `outbox` へ `POST` すると以下の形式でノートを作成できます。
 

--- a/app/api/activity_handlers.ts
+++ b/app/api/activity_handlers.ts
@@ -1,0 +1,69 @@
+import Account from "./models/account.ts";
+import ActivityPubObject from "./models/activitypub_object.ts";
+import {
+  createAcceptActivity,
+  deliverActivityPubObject,
+  getDomain,
+} from "./utils/activitypub.ts";
+
+export type ActivityHandler = (
+  activity: Record<string, unknown>,
+  username: string,
+  c: unknown,
+) => Promise<void>;
+
+async function saveObject(
+  obj: Record<string, unknown>,
+  actor: string,
+) {
+  await ActivityPubObject.create({
+    type: obj.type ?? "Note",
+    attributedTo: typeof obj.attributedTo === "string"
+      ? obj.attributedTo
+      : actor,
+    content: obj.content,
+    to: Array.isArray(obj.to) ? obj.to : [],
+    cc: Array.isArray(obj.cc) ? obj.cc : [],
+    published: obj.published ? new Date(obj.published) : new Date(),
+    raw: obj,
+    extra: obj.extra ?? {},
+  });
+}
+
+export const activityHandlers: Record<string, ActivityHandler> = {
+  async Create(
+    activity: Record<string, unknown>,
+    username: string,
+    _c: unknown,
+  ) {
+    if (typeof activity.object === "object") {
+      const actor = typeof activity.actor === "string"
+        ? activity.actor
+        : username;
+      await saveObject(activity.object, actor);
+    }
+  },
+
+  async Follow(
+    activity: Record<string, unknown>,
+    username: string,
+    c: unknown,
+  ) {
+    if (typeof activity.actor !== "string") return;
+    await Account.updateOne(
+      { userName: username },
+      { $addToSet: { followers: activity.actor } },
+    );
+    const domain = getDomain(c);
+    const accept = createAcceptActivity(
+      domain,
+      `https://${domain}/users/${username}`,
+      activity,
+    );
+    deliverActivityPubObject([activity.actor], accept, username).catch(
+      (err) => {
+        console.error("Delivery failed:", err);
+      },
+    );
+  },
+};

--- a/app/api/models/activitypub_object.ts
+++ b/app/api/models/activitypub_object.ts
@@ -8,8 +8,6 @@ const activityPubObjectSchema = new mongoose.Schema({
   cc: { type: [String], default: [] },
   published: { type: Date, default: Date.now },
   extra: { type: mongoose.Schema.Types.Mixed, default: {} }, // type固有の追加情報
-  // Inbox 経由で受信した場合の保存先ユーザー名
-  inboxUser: { type: String },
   // 受信オブジェクトの生データ
   raw: { type: mongoose.Schema.Types.Mixed },
 });

--- a/docs/takos-web/sns/microblog.md
+++ b/docs/takos-web/sns/microblog.md
@@ -82,6 +82,8 @@ POST /api/microblog/:id/retweet
 ## ActivityPub 配信
 
 作成した投稿は ActivityPub 経由でフォロワーのサーバーへ配信されます。
-外部から受信した ActivityPub オブジェクトは `/users/:username/inbox` に
-送られ、`ActivityPubObject` コレクションに `inboxUser` フィールド付きで
-保存されます。
+外部から受信した ActivityPub の `Create` Activity は `/users/:username/inbox`
+に送られ、そのオブジェクトが `ActivityPubObject` コレクションへ保存されます。そ
+れ以外の Activity は保存せず必要な処理のみ行います。 `inbox` の処理は Activity
+ごとにハンドラーが分かれているため、将来的に対応活
+動を増やしやすい構造になっています。


### PR DESCRIPTION
## Summary
- inbox の処理を活動タイプごとのハンドラーで管理
- Activity ハンドラーを新規追加
- ドキュメントを更新して拡張しやすい設計を説明

## Testing
- `deno fmt README.md app/api/activity_handlers.ts app/api/activitypub.ts docs/takos-web/sns/microblog.md`
- `deno lint app/api/activity_handlers.ts app/api/activitypub.ts`


------
https://chatgpt.com/codex/tasks/task_e_68699eed4c5c8328997a4b2641a2cd11