### PR TITLE
外部ユーザー情報をキャッシュする

### DIFF
--- a/app/api/models/remote_actor.ts
+++ b/app/api/models/remote_actor.ts
@@ -1,0 +1,18 @@
+import mongoose from "mongoose";
+
+const remoteActorSchema = new mongoose.Schema({
+  actorUrl: { type: String, required: true, unique: true },
+  name: { type: String, default: "" },
+  preferredUsername: { type: String, default: "" },
+  icon: { type: mongoose.Schema.Types.Mixed, default: null },
+  summary: { type: String, default: "" },
+  cachedAt: { type: Date, default: Date.now },
+});
+
+// 24時間後に自動削除されるTTLインデックス
+remoteActorSchema.index({ cachedAt: 1 }, { expireAfterSeconds: 60 * 60 * 24 });
+
+const RemoteActor = mongoose.model("RemoteActor", remoteActorSchema);
+
+export default RemoteActor;
+export { remoteActorSchema };


### PR DESCRIPTION
## Summary
- 外部ユーザー情報をDBへ保存する`RemoteActor`モデルを追加
- actor-proxyエンドポイントでキャッシュを利用

## Testing
- `deno fmt app/api/activitypub.ts app/api/models/remote_actor.ts`
- `deno lint app/api/activitypub.ts app/api/models/remote_actor.ts`


------
https://chatgpt.com/codex/tasks/task_e_6869c362e12c8328b8defee965448dd8