### PR TITLE
Add HTML sanitizer for Mastodon posts

### DIFF
--- a/app/client/src/utils/sanitize.ts
+++ b/app/client/src/utils/sanitize.ts
@@ -1,0 +1,23 @@
+export function sanitizeHTML(html: string): string {
+  const doc = new DOMParser().parseFromString(html, "text/html");
+  if (!doc) return "";
+  for (const el of doc.querySelectorAll("script,style")) {
+    el.remove();
+  }
+  for (const el of doc.querySelectorAll("*")) {
+    for (const attr of Array.from(el.attributes)) {
+      const name = attr.name.toLowerCase();
+      if (name.startsWith("on")) {
+        el.removeAttribute(attr.name);
+        continue;
+      }
+      if (
+        (name === "src" || name === "href") &&
+        attr.value.trim().startsWith("javascript:")
+      ) {
+        el.removeAttribute(attr.name);
+      }
+    }
+  }
+  return doc.body.innerHTML;
+}


### PR DESCRIPTION
## Summary
- sanitize HTML contents on posts with a small utility
- render sanitized HTML in microblog posts

## Testing
- `deno fmt app/client/src/utils/sanitize.ts app/client/src/components/microblog/Post.tsx`
- `deno lint app/client/src/utils/sanitize.ts app/client/src/components/microblog/Post.tsx`

------
https://chatgpt.com/codex/tasks/task_e_686a17adbeec83289da25bdbb7f1ac86