### PR TITLE
グループActivityPub強化

### DIFF
--- a/app/api/models/group.ts
+++ b/app/api/models/group.ts
@@ -4,6 +4,8 @@ const groupSchema = new mongoose.Schema({
   name: { type: String, required: true, unique: true },
   description: { type: String, default: "" },
   followers: { type: [String], default: [] },
+  isPrivate: { type: Boolean, default: false },
+  pendingFollowers: { type: [String], default: [] },
 });
 
 const Group = mongoose.model("Group", groupSchema);

--- a/app/api/utils/activitypub.ts
+++ b/app/api/utils/activitypub.ts
@@ -565,6 +565,21 @@ export function createCreateActivity(
   };
 }
 
+/** Announce Activity を生成する */
+export function createAnnounceActivity(
+  domain: string,
+  actor: string,
+  object: string,
+) {
+  return {
+    "@context": "https://www.w3.org/ns/activitystreams",
+    id: createActivityId(domain),
+    type: "Announce",
+    actor,
+    object,
+  };
+}
+
 /* ===== ActivityPub主要実装互換ユーティリティ ===== */
 
 /**


### PR DESCRIPTION
## Summary
- Groupモデルに非公開設定とフォロー申請待ちリストを追加
- Announce生成ユーティリティを実装
- グループinboxでFollow/Create処理を拡張

## Testing
- `deno fmt app/api/group.ts app/api/models/group.ts app/api/utils/activitypub.ts`
- `deno lint app/api/group.ts app/api/models/group.ts app/api/utils/activitypub.ts`


------
https://chatgpt.com/codex/tasks/task_e_686a7abbb60483288577b60f426fcf45