### PR TITLE
Add README group feature section

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,3 +61,47 @@ deno task dev
 - `DELETE /api/microblog/:id` – 投稿を削除
 - `POST /api/microblog/:id/like` – いいねを追加
 - `POST /api/microblog/:id/retweet` – リツイートを追加
+
+## グループ機能
+
+takos では ActivityPub の Group
+アクターを利用して複数ユーザーで投稿を共有できます。グループアクターは
+`GET /groups/:name` で取得できます。
+
+### WebFinger での発見例
+
+`!team@takos.example` を検索する場合は次のようにリクエストします。
+
+```bash
+curl "https://takos.example/.well-known/webfinger?resource=acct:!team@takos.example"
+```
+
+レスポンス例:
+
+```json
+{
+  "subject": "acct:!team@takos.example",
+  "links": [
+    {
+      "rel": "self",
+      "type": "application/activity+json",
+      "href": "https://takos.example/groups/team"
+    }
+  ]
+}
+```
+
+### 参加 (Follow) 手順
+
+1. `/groups/:name/inbox` へ `Follow` Activity を送信します。
+2. 非公開グループでは `pendingFollowers`
+   に追加され、承認後フォロワーとなります。公開グループの場合はすぐに `Accept`
+   が返送され `followers` に登録されます。
+
+### 投稿から `Announce` 配信まで
+
+1. フォロワーが `Create` Activity をグループの `inbox`
+   に送信すると投稿オブジェクトが保存されます。
+2. グループはその投稿を対象とした `Announce` Activity
+   を生成し、フォロワーへ配信します。
+3. フォロワーは受信した `Announce` から投稿を取得できます。

--- a/app/api/notifications.ts
+++ b/app/api/notifications.ts
@@ -5,6 +5,7 @@ const app = new Hono();
 
 app.get("/notifications", async (c) => {
   const list = await Notification.find().sort({ createdAt: -1 }).lean();
+  // deno-lint-ignore no-explicit-any
   const formatted = list.map((doc: any) => ({
     id: doc._id.toString(),
     title: doc.title,


### PR DESCRIPTION
## Summary
- document how to use the group feature in Japanese
- fix lint error in notifications API

## Testing
- `deno fmt README.md app/api/.env.example`
- `deno lint`

------
https://chatgpt.com/codex/tasks/task_e_686a7bcbe35c8328b66df035bd4cdd91