### PR TITLE
選択中アカウントの状態を保存

### DIFF
--- a/app/client/src/states/account.ts
+++ b/app/client/src/states/account.ts
@@ -14,26 +14,24 @@ const STORAGE_KEY = "takos-active-account-id";
 
 export const accounts = atom<Account[]>([]);
 
-// Create an atom for the active account ID with localStorage persistence.
+// 選択中アカウントIDの初期値を localStorage から取得
 const initialAccountId = localStorage.getItem(STORAGE_KEY);
-export const activeAccountId = atom<string | null>(initialAccountId);
 
-activeAccountId.onMount = (set) => {
-  const storedId = localStorage.getItem(STORAGE_KEY);
-  if (storedId) {
-    set(storedId);
-  }
-};
+// 内部用のAtom
+const baseActiveAccountId = atom<string | null>(initialAccountId);
 
-// A derived atom to write to localStorage whenever the activeAccountId changes.
-atom((get) => {
-  const id = get(activeAccountId);
-  if (id) {
-    localStorage.setItem(STORAGE_KEY, id);
-  } else {
-    localStorage.removeItem(STORAGE_KEY);
-  }
-});
+// 書き込み時にlocalStorageへ保存するAtom
+export const activeAccountId = atom(
+  (get) => get(baseActiveAccountId),
+  (_get, set, newId: string | null) => {
+    set(baseActiveAccountId, newId);
+    if (newId) {
+      localStorage.setItem(STORAGE_KEY, newId);
+    } else {
+      localStorage.removeItem(STORAGE_KEY);
+    }
+  },
+);
 
 export const activeAccount = atom((get) => {
   const accs = get(accounts);


### PR DESCRIPTION
## 概要
選択中のユーザー(アカウント)を再読込後も保持できるよう `activeAccountId` を更新しました。これにより状態変更時に自動で `localStorage` へ保存し、初期値として読み込む仕組みになります。

## 変更点
- `states/account.ts` を修正し、内部用 `baseActiveAccountId` を追加
- `activeAccountId` を書き込み時に `localStorage` を更新する構造に変更

## 動作確認
- `deno fmt` と `deno lint` を実行しエラーが無いことを確認


------
https://chatgpt.com/codex/tasks/task_e_686b6f13ab608328832980baf532b1d8