### PR TITLE
NodeInfoとインスタンス情報APIを実装

### DIFF
--- a/app/api/index.ts
+++ b/app/api/index.ts
@@ -12,6 +12,7 @@ import communities from "./communities.ts";
 import users from "./users.ts";
 import userInfo from "./user-info.ts";
 import group from "./group.ts";
+import nodeinfo from "./nodeinfo.ts";
 
 const env = await load();
 
@@ -31,6 +32,7 @@ app.route("/api", users);
 app.route("/api", userInfo);
 app.route("/api", activitypub); // ActivityPubプロキシAPI用
 app.route("/api", group);
+app.route("/", nodeinfo);
 app.route("/", activitypub);
 app.route("/", group);
 

--- a/app/api/nodeinfo.ts
+++ b/app/api/nodeinfo.ts
@@ -1,0 +1,87 @@
+import { Hono } from "hono";
+import Account from "./models/account.ts";
+import ActivityPubObject from "./models/activitypub_object.ts";
+import { getDomain } from "./utils/activitypub.ts";
+import { env } from "./utils/env.ts";
+
+const app = new Hono();
+
+app.get("/.well-known/nodeinfo", (c) => {
+  const domain = getDomain(c);
+  return c.json({
+    links: [
+      {
+        rel: "http://nodeinfo.diaspora.software/ns/schema/2.0",
+        href: `https://${domain}/nodeinfo/2.0`,
+      },
+    ],
+  });
+});
+
+app.get("/nodeinfo/2.0", async (c) => {
+  const version = env["TAKOS_VERSION"] ?? "1.0.0";
+  const users = await Account.countDocuments();
+  const posts = await ActivityPubObject.countDocuments();
+
+  return c.json({
+    version: "2.0",
+    software: {
+      name: "takos",
+      version,
+    },
+    protocols: ["activitypub"],
+    services: { inbound: [], outbound: [] },
+    openRegistrations: false,
+    usage: {
+      users: { total: users, activeMonth: users, activeHalfyear: users },
+      localPosts: posts,
+    },
+    metadata: {},
+  });
+});
+
+app.get("/api/v1/instance", async (c) => {
+  const domain = getDomain(c);
+  const version = env["TAKOS_VERSION"] ?? "1.0.0";
+  const userCount = await Account.countDocuments();
+  const statusCount = await ActivityPubObject.countDocuments();
+
+  return c.json({
+    uri: domain,
+    title: "Takos Instance",
+    short_description: "分散SNSサーバー",
+    description: "Takosで運用されている分散SNSサーバーです。",
+    email: `info@${domain}`,
+    version,
+    urls: {},
+    stats: {
+      user_count: userCount,
+      status_count: statusCount,
+      domain_count: 1,
+    },
+    thumbnail: null,
+    languages: ["ja"],
+    registrations: false,
+    approval_required: false,
+    invites_enabled: false,
+  });
+});
+
+app.get("/.well-known/x-nodeinfo2", async (c) => {
+  const version = env["TAKOS_VERSION"] ?? "1.0.0";
+  const users = await Account.countDocuments();
+  const posts = await ActivityPubObject.countDocuments();
+
+  return c.json({
+    software: "takos",
+    version,
+    protocols: ["activitypub"],
+    openRegistrations: false,
+    usage: {
+      users: { total: users },
+      localPosts: posts,
+    },
+  });
+});
+
+export default app;


### PR DESCRIPTION
## Summary
- NodeInfo や x-nodeinfo2 を返すエンドポイントを追加
- `/api/v1/instance` を実装し Mastodon 互換の情報を提供
- ルートに NodeInfo ルータを登録

## Testing
- `deno fmt app/api/nodeinfo.ts app/api/index.ts`
- `deno lint app/api/nodeinfo.ts app/api/index.ts`


------
https://chatgpt.com/codex/tasks/task_e_686b7beb744c8328801d635bc7e9c668