### PR TITLE
KeyPackage 削除時に Delete Activity を配信

### DIFF
--- a/app/api/activitypub.ts
+++ b/app/api/activitypub.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 import Account from "./models/account.ts";
 import Group from "./models/group.ts";
 import ActivityPubObject from "./models/activitypub_object.ts";
+import KeyPackage from "./models/key_package.ts";
 
 import { activityHandlers } from "./activity_handlers.ts";
 import RemoteActor from "./models/remote_actor.ts";
@@ -73,6 +74,15 @@ app.get("/users/:username", async (c) => {
     displayName: account.displayName,
     publicKey: account.publicKey,
   });
+  const packages = await KeyPackage.find({ userName: username }).lean();
+  actor.keyPackages = {
+    type: "Collection",
+    id: `https://${domain}/users/${username}/keyPackages`,
+    totalItems: packages.length,
+    items: packages.map((p) =>
+      `https://${domain}/users/${username}/keyPackage/${p._id}`
+    ),
+  };
   return jsonResponse(c, actor, 200, "application/activity+json");
 });
 

--- a/app/api/e2ee.ts
+++ b/app/api/e2ee.ts
@@ -1,0 +1,198 @@
+import { Hono } from "hono";
+import KeyPackage from "./models/key_package.ts";
+import EncryptedMessage from "./models/encrypted_message.ts";
+import ActivityPubObject from "./models/activitypub_object.ts";
+import Account from "./models/account.ts";
+import authRequired from "./utils/auth.ts";
+import {
+  buildActivityFromStored,
+  createAddActivity,
+  createCreateActivity,
+  createDeleteActivity,
+  createRemoveActivity,
+  deliverActivityPubObject,
+  fetchActorInbox,
+  getDomain,
+} from "./utils/activitypub.ts";
+
+const app = new Hono();
+app.use("*", authRequired);
+
+async function deliverToFollowers(
+  user: string,
+  activity: unknown,
+  domain: string,
+) {
+  const account = await Account.findOne({ userName: user }).lean();
+  if (!account || !account.followers) return;
+  const followerInboxes = await Promise.all(
+    account.followers.map(async (actorUrl: string) => {
+      try {
+        const url = new URL(actorUrl);
+        if (url.host === domain && url.pathname.startsWith("/users/")) {
+          return null;
+        }
+        return await fetchActorInbox(actorUrl);
+      } catch {
+        return null;
+      }
+    }),
+  );
+  const validInboxes = followerInboxes.filter((i): i is string =>
+    typeof i === "string" && !!i
+  );
+  if (validInboxes.length > 0) {
+    deliverActivityPubObject(validInboxes, activity, user).catch((err) => {
+      console.error("Delivery failed:", err);
+    });
+  }
+}
+
+app.get("/users/:user/keyPackages", async (c) => {
+  const user = c.req.param("user");
+  const list = await KeyPackage.find({ userName: user }).lean();
+  const domain = getDomain(c);
+  const items = list.map((doc) => ({
+    id: `https://${domain}/users/${user}/keyPackage/${doc._id}`,
+    type: "KeyPackage",
+    content: doc.content,
+    mediaType: doc.mediaType,
+    encoding: doc.encoding,
+    createdAt: doc.createdAt,
+  }));
+  return c.json({ type: "Collection", items });
+});
+
+app.get("/users/:user/keyPackage/:keyId", async (c) => {
+  const user = c.req.param("user");
+  const keyId = c.req.param("keyId");
+  const doc = await KeyPackage.findOne({ _id: keyId, userName: user }).lean();
+  if (!doc) return c.body("Not Found", 404);
+  const domain = getDomain(c);
+  const object = {
+    "@context": [
+      "https://www.w3.org/ns/activitystreams",
+      "https://purl.archive.org/socialweb/mls",
+    ],
+    id: `https://${domain}/users/${user}/keyPackage/${keyId}`,
+    type: "KeyPackage",
+    attributedTo: `https://${domain}/users/${user}`,
+    to: ["https://www.w3.org/ns/activitystreams#Public"],
+    mediaType: doc.mediaType,
+    encoding: doc.encoding,
+    content: doc.content,
+  };
+  return c.json(object);
+});
+
+app.post("/users/:user/keyPackages", async (c) => {
+  const user = c.req.param("user");
+  const { content, mediaType, encoding } = await c.req.json();
+  if (typeof content !== "string") {
+    return c.json({ error: "content is required" }, 400);
+  }
+  const pkg = await KeyPackage.create({
+    userName: user,
+    content,
+    mediaType: mediaType ?? "message/mls",
+    encoding: encoding ?? "base64",
+  });
+  const domain = getDomain(c);
+  const actorId = `https://${domain}/users/${user}`;
+  const keyObj = {
+    "@context": [
+      "https://www.w3.org/ns/activitystreams",
+      "https://purl.archive.org/socialweb/mls",
+    ],
+    id: `https://${domain}/users/${user}/keyPackage/${pkg._id}`,
+    type: "KeyPackage",
+    attributedTo: actorId,
+    to: ["https://www.w3.org/ns/activitystreams#Public"],
+    mediaType: pkg.mediaType,
+    encoding: pkg.encoding,
+    content: pkg.content,
+  };
+  const addActivity = createAddActivity(domain, actorId, keyObj);
+  await deliverToFollowers(user, addActivity, domain);
+  return c.json({ result: "ok", keyId: pkg._id.toString() });
+});
+
+app.delete("/users/:user/keyPackages/:keyId", async (c) => {
+  const user = c.req.param("user");
+  const keyId = c.req.param("keyId");
+  await KeyPackage.deleteOne({ _id: keyId, userName: user });
+  const domain = getDomain(c);
+  const actorId = `https://${domain}/users/${user}`;
+  const removeActivity = createRemoveActivity(
+    domain,
+    actorId,
+    `https://${domain}/users/${user}/keyPackage/${keyId}`,
+  );
+  const deleteActivity = createDeleteActivity(
+    domain,
+    actorId,
+    `https://${domain}/users/${user}/keyPackage/${keyId}`,
+  );
+  await deliverToFollowers(user, removeActivity, domain);
+  await deliverToFollowers(user, deleteActivity, domain);
+  return c.json({ result: "removed" });
+});
+
+app.post("/users/:user/messages", async (c) => {
+  const sender = c.req.param("user");
+  const { to, content, mediaType, encoding } = await c.req.json();
+  if (!Array.isArray(to) || typeof content !== "string") {
+    return c.json({ error: "invalid body" }, 400);
+  }
+  const msg = await EncryptedMessage.create({
+    from: sender,
+    to,
+    content,
+    mediaType: mediaType ?? "message/mls",
+    encoding: encoding ?? "base64",
+  });
+  const domain = getDomain(c);
+  const actorId = `https://${domain}/users/${sender}`;
+  const object = await ActivityPubObject.create({
+    type: "PrivateMessage",
+    attributedTo: sender,
+    content,
+    to,
+    extra: { mediaType: msg.mediaType, encoding: msg.encoding },
+  });
+
+  const privateMessage = buildActivityFromStored(
+    { ...object.toObject(), content },
+    domain,
+    sender,
+    false,
+  );
+
+  const activity = createCreateActivity(domain, actorId, privateMessage);
+  // 個別配信
+  activity.to = to;
+  activity.cc = [];
+  deliverActivityPubObject(to, activity, sender).catch((err) => {
+    console.error("deliver failed", err);
+  });
+
+  return c.json({ result: "sent", id: msg._id.toString() });
+});
+
+app.get("/users/:user/messages", async (c) => {
+  const user = c.req.param("user");
+  const list = await EncryptedMessage.find({ to: user }).sort({ createdAt: -1 })
+    .lean();
+  const messages = list.map((doc) => ({
+    id: doc._id.toString(),
+    from: doc.from,
+    to: doc.to,
+    content: doc.content,
+    mediaType: doc.mediaType,
+    encoding: doc.encoding,
+    createdAt: doc.createdAt,
+  }));
+  return c.json(messages);
+});
+
+export default app;

--- a/app/api/index.ts
+++ b/app/api/index.ts
@@ -13,6 +13,7 @@ import users from "./users.ts";
 import userInfo from "./user-info.ts";
 import group from "./group.ts";
 import nodeinfo from "./nodeinfo.ts";
+import e2ee from "./e2ee.ts";
 
 const env = await load();
 
@@ -30,9 +31,11 @@ app.route("/api", search);
 app.route("/api", communities);
 app.route("/api", users);
 app.route("/api", userInfo);
+app.route("/api", e2ee);
 app.route("/api", activitypub); // ActivityPubプロキシAPI用
 app.route("/api", group);
 app.route("/", nodeinfo);
+app.route("/", e2ee);
 app.route("/", activitypub);
 app.route("/", group);
 

--- a/app/api/models/encrypted_message.ts
+++ b/app/api/models/encrypted_message.ts
@@ -1,0 +1,18 @@
+import mongoose from "mongoose";
+
+const encryptedMessageSchema = new mongoose.Schema({
+  from: { type: String, required: true },
+  to: { type: [String], required: true },
+  content: { type: String, required: true },
+  mediaType: { type: String, default: "message/mls" },
+  encoding: { type: String, default: "base64" },
+  createdAt: { type: Date, default: Date.now },
+});
+
+const EncryptedMessage = mongoose.model(
+  "EncryptedMessage",
+  encryptedMessageSchema,
+);
+
+export default EncryptedMessage;
+export { encryptedMessageSchema };

--- a/app/api/models/key_package.ts
+++ b/app/api/models/key_package.ts
@@ -1,0 +1,14 @@
+import mongoose from "mongoose";
+
+const keyPackageSchema = new mongoose.Schema({
+  userName: { type: String, required: true, index: true },
+  content: { type: String, required: true },
+  mediaType: { type: String, default: "message/mls" },
+  encoding: { type: String, default: "base64" },
+  createdAt: { type: Date, default: Date.now },
+});
+
+const KeyPackage = mongoose.model("KeyPackage", keyPackageSchema);
+
+export default KeyPackage;
+export { keyPackageSchema };

--- a/app/api/utils/activitypub.ts
+++ b/app/api/utils/activitypub.ts
@@ -554,6 +554,21 @@ export function createRemoveActivity(
   };
 }
 
+/** Delete Activity を生成する */
+export function createDeleteActivity(
+  domain: string,
+  actor: string,
+  object: unknown,
+) {
+  return {
+    "@context": "https://www.w3.org/ns/activitystreams",
+    id: createActivityId(domain),
+    type: "Delete",
+    actor,
+    object,
+  };
+}
+
 /** Create Activity を生成する */
 export function createCreateActivity(
   domain: string,

--- a/app/api/utils/auth.ts
+++ b/app/api/utils/auth.ts
@@ -1,0 +1,20 @@
+import { MiddlewareHandler } from "hono";
+import { getCookie } from "hono/cookie";
+import Session from "../models/session.ts";
+
+const authRequired: MiddlewareHandler = async (c, next) => {
+  const sessionId = getCookie(c, "sessionId");
+  if (!sessionId) {
+    return c.json({ error: "認証が必要です" }, 401);
+  }
+  const session = await Session.findOne({ sessionId });
+  if (!session || session.expiresAt <= new Date()) {
+    if (session) {
+      await Session.deleteOne({ sessionId });
+    }
+    return c.json({ error: "認証が必要です" }, 401);
+  }
+  await next();
+};
+
+export default authRequired;


### PR DESCRIPTION
## Summary
- KeyPackage 削除 API で Delete Activity も生成
- ActivityPub ユーティリティに createDeleteActivity を追加
- メッセージ送信時に Outbox へも保存
- E2EE API で認証を必須化

## Testing
- `deno fmt app/api/utils/activitypub.ts app/api/e2ee.ts app/api/utils/auth.ts`
- `deno lint app/api/e2ee.ts app/api/utils/activitypub.ts app/api/utils/auth.ts`


------
https://chatgpt.com/codex/tasks/task_e_686b8852923c83288b66868163765d9c