### PR TITLE
Add client helper functions for ActivityPub e2ee

### DIFF
--- a/app/client/src/components/e2ee/api.ts
+++ b/app/client/src/components/e2ee/api.ts
@@ -1,0 +1,112 @@
+export interface KeyPackage {
+  id: string;
+  type: "KeyPackage";
+  content: string;
+  mediaType: string;
+  encoding: string;
+  createdAt: string;
+}
+
+export interface EncryptedMessage {
+  id: string;
+  from: string;
+  to: string[];
+  content: string;
+  mediaType: string;
+  encoding: string;
+  createdAt: string;
+}
+
+export const fetchKeyPackages = async (user: string): Promise<KeyPackage[]> => {
+  try {
+    const res = await fetch(
+      `/api/users/${encodeURIComponent(user)}/keyPackages`,
+    );
+    if (!res.ok) {
+      throw new Error("Failed to fetch key packages");
+    }
+    const data = await res.json();
+    return Array.isArray(data.items) ? data.items : [];
+  } catch (err) {
+    console.error("Error fetching key packages:", err);
+    return [];
+  }
+};
+
+export const addKeyPackage = async (
+  user: string,
+  pkg: { content: string; mediaType?: string; encoding?: string },
+): Promise<string | null> => {
+  try {
+    const res = await fetch(
+      `/api/users/${encodeURIComponent(user)}/keyPackages`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(pkg),
+      },
+    );
+    if (!res.ok) return null;
+    const data = await res.json();
+    return typeof data.keyId === "string" ? data.keyId : null;
+  } catch (err) {
+    console.error("Error adding key package:", err);
+    return null;
+  }
+};
+
+export const deleteKeyPackage = async (
+  user: string,
+  keyId: string,
+): Promise<boolean> => {
+  try {
+    const res = await fetch(
+      `/api/users/${encodeURIComponent(user)}/keyPackages/${
+        encodeURIComponent(keyId)
+      }`,
+      { method: "DELETE" },
+    );
+    return res.ok;
+  } catch (err) {
+    console.error("Error deleting key package:", err);
+    return false;
+  }
+};
+
+export const sendEncryptedMessage = async (
+  user: string,
+  data: {
+    to: string[];
+    content: string;
+    mediaType?: string;
+    encoding?: string;
+  },
+): Promise<boolean> => {
+  try {
+    const res = await fetch(`/api/users/${encodeURIComponent(user)}/messages`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(data),
+    });
+    return res.ok;
+  } catch (err) {
+    console.error("Error sending message:", err);
+    return false;
+  }
+};
+
+export const fetchEncryptedMessages = async (
+  user: string,
+): Promise<EncryptedMessage[]> => {
+  try {
+    const res = await fetch(`/api/users/${encodeURIComponent(user)}/messages`);
+    if (!res.ok) {
+      throw new Error("Failed to fetch messages");
+    }
+    const data = await res.json();
+    return Array.isArray(data) ? data : [];
+  } catch (err) {
+    console.error("Error fetching messages:", err);
+    return [];
+  }
+};

--- a/app/client/src/components/e2ee/mls.ts
+++ b/app/client/src/components/e2ee/mls.ts
@@ -1,0 +1,91 @@
+// MLSヘルパー関数の継続実装
+
+export interface MLSKeyPair {
+  publicKey: string; // base64化した公開鍵
+  privateKey: CryptoKey;
+}
+
+/**
+ * ECDHで鍵ペアを生成する
+ */
+export const generateMLSKeyPair = async (): Promise<MLSKeyPair> => {
+  const keyPair = await crypto.subtle.generateKey(
+    { name: "ECDH", namedCurve: "P-256" },
+    true,
+    ["deriveKey"],
+  );
+  const raw = await crypto.subtle.exportKey("raw", keyPair.publicKey);
+  const pub = btoa(String.fromCharCode(...new Uint8Array(raw)));
+  return { publicKey: pub, privateKey: keyPair.privateKey };
+};
+
+/**
+ * AES-GCM鍵を作成しグループ状態を保持
+ */
+export interface MLSGroupState {
+  members: string[];
+  epoch: number;
+  secret: CryptoKey;
+}
+
+export const createMLSGroup = async (
+  members: string[],
+): Promise<MLSGroupState> => {
+  const secret = await crypto.subtle.generateKey(
+    { name: "AES-GCM", length: 256 },
+    true,
+    ["encrypt", "decrypt"],
+  );
+  return { members, epoch: Date.now(), secret };
+};
+
+function strToBuf(str: string): Uint8Array {
+  return new TextEncoder().encode(str);
+}
+
+function bufToB64(buf: ArrayBuffer): string {
+  const u8 = new Uint8Array(buf);
+  return btoa(String.fromCharCode(...u8));
+}
+
+function b64ToBuf(b64: string): Uint8Array {
+  const bin = atob(b64);
+  return Uint8Array.from(bin, (c) => c.charCodeAt(0));
+}
+
+/**
+ * MLS風にメッセージを暗号化
+ */
+export const encryptGroupMessage = async (
+  group: MLSGroupState,
+  plaintext: string,
+): Promise<string> => {
+  const iv = crypto.getRandomValues(new Uint8Array(12));
+  const enc = await crypto.subtle.encrypt(
+    { name: "AES-GCM", iv },
+    group.secret,
+    strToBuf(plaintext),
+  );
+  return `${bufToB64(iv)}:${bufToB64(enc)}`;
+};
+
+/**
+ * 暗号化メッセージを解証
+ */
+export const decryptGroupMessage = async (
+  group: MLSGroupState,
+  cipher: string,
+): Promise<string | null> => {
+  const [ivB64, dataB64] = cipher.split(":");
+  if (!ivB64 || !dataB64) return null;
+  try {
+    const plain = await crypto.subtle.decrypt(
+      { name: "AES-GCM", iv: b64ToBuf(ivB64) },
+      group.secret,
+      b64ToBuf(dataB64),
+    );
+    return new TextDecoder().decode(plain);
+  } catch {
+    return null;
+  }
+};


### PR DESCRIPTION
## Summary
- create e2ee helper functions under app/client

## Testing
- `deno fmt app/client/src/components/e2ee/api.ts`
- `deno lint app/client/src/components/e2ee/api.ts`


------
https://chatgpt.com/codex/tasks/task_e_686ba3e7362c8328a3f81a6defaafc89