### PR TITLE
Implement persistent MLS state

### DIFF
--- a/app/api/e2ee.ts
+++ b/app/api/e2ee.ts
@@ -181,7 +181,16 @@ app.post("/users/:user/messages", async (c) => {
 
 app.get("/users/:user/messages", async (c) => {
   const user = c.req.param("user");
-  const list = await EncryptedMessage.find({ to: user }).sort({ createdAt: -1 })
+  const partner = c.req.query("with");
+  const condition = partner
+    ? {
+      $or: [
+        { from: partner, to: user },
+        { from: user, to: partner },
+      ],
+    }
+    : { to: user };
+  const list = await EncryptedMessage.find(condition).sort({ createdAt: 1 })
     .lean();
   const messages = list.map((doc) => ({
     id: doc._id.toString(),

--- a/app/client/src/components/e2ee/api.ts
+++ b/app/client/src/components/e2ee/api.ts
@@ -97,9 +97,13 @@ export const sendEncryptedMessage = async (
 
 export const fetchEncryptedMessages = async (
   user: string,
+  partner?: string,
 ): Promise<EncryptedMessage[]> => {
   try {
-    const res = await fetch(`/api/users/${encodeURIComponent(user)}/messages`);
+    const url = `/api/users/${encodeURIComponent(user)}/messages${
+      partner ? `?with=${encodeURIComponent(partner)}` : ""
+    }`;
+    const res = await fetch(url);
     if (!res.ok) {
       throw new Error("Failed to fetch messages");
     }

--- a/app/client/src/components/e2ee/storage.ts
+++ b/app/client/src/components/e2ee/storage.ts
@@ -1,0 +1,84 @@
+import type { StoredMLSGroupState, StoredMLSKeyPair } from "./mls.ts";
+
+const DB_NAME = "takos";
+const STORE_NAME = "mlsGroups";
+const KEY_STORE = "mlsKeyPair";
+
+function openDB(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(DB_NAME, 2);
+    req.onupgradeneeded = () => {
+      const db = req.result;
+      if (!db.objectStoreNames.contains(STORE_NAME)) {
+        db.createObjectStore(STORE_NAME);
+      }
+      if (!db.objectStoreNames.contains(KEY_STORE)) {
+        db.createObjectStore(KEY_STORE);
+      }
+    };
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+export const loadMLSGroupStates = async (): Promise<
+  Record<string, StoredMLSGroupState>
+> => {
+  const db = await openDB();
+  const tx = db.transaction(STORE_NAME, "readonly");
+  const store = tx.objectStore(STORE_NAME);
+  return await new Promise((resolve, reject) => {
+    const req = store.openCursor();
+    const result: Record<string, StoredMLSGroupState> = {};
+    req.onsuccess = () => {
+      const cursor = req.result;
+      if (cursor) {
+        result[cursor.key as string] = cursor.value as StoredMLSGroupState;
+        cursor.continue();
+      } else {
+        resolve(result);
+      }
+    };
+    req.onerror = () => reject(req.error);
+  });
+};
+
+export const saveMLSGroupStates = async (
+  states: Record<string, StoredMLSGroupState>,
+): Promise<void> => {
+  const db = await openDB();
+  const tx = db.transaction(STORE_NAME, "readwrite");
+  const store = tx.objectStore(STORE_NAME);
+  store.clear();
+  for (const [id, state] of Object.entries(states)) {
+    store.put(state, id);
+  }
+  await new Promise((resolve, reject) => {
+    tx.oncomplete = () => resolve(undefined);
+    tx.onerror = () => reject(tx.error);
+  });
+};
+
+export const loadMLSKeyPair = async (): Promise<StoredMLSKeyPair | null> => {
+  const db = await openDB();
+  const tx = db.transaction(KEY_STORE, "readonly");
+  const store = tx.objectStore(KEY_STORE);
+  return await new Promise((resolve, reject) => {
+    const req = store.get("key");
+    req.onsuccess = () => resolve(req.result ?? null);
+    req.onerror = () => reject(req.error);
+  });
+};
+
+export const saveMLSKeyPair = async (
+  pair: StoredMLSKeyPair,
+): Promise<void> => {
+  const db = await openDB();
+  const tx = db.transaction(KEY_STORE, "readwrite");
+  const store = tx.objectStore(KEY_STORE);
+  store.put(pair, "key");
+  await new Promise((resolve, reject) => {
+    tx.oncomplete = () => resolve(undefined);
+    tx.onerror = () => reject(tx.error);
+  });
+};


### PR DESCRIPTION
## Summary
- MLSグループ状態をIndexedDBへ保存するロジックを追加
- Chat.tsxで保存・読み込み処理をストレージAPI経由に変更

## Testing
- `deno fmt app/client/src/components/Chat.tsx app/client/src/components/e2ee/storage.ts`
- `deno lint app/client/src/components/Chat.tsx app/client/src/components/e2ee/storage.ts`


------
https://chatgpt.com/codex/tasks/task_e_686bae3aab4c832897219b1e5cba8854