### PR TITLE
チャットのDM一覧表示を修正

### DIFF
--- a/app/api/accounts.ts
+++ b/app/api/accounts.ts
@@ -68,6 +68,9 @@ app.get("/accounts", async (c) => {
     userName: doc.userName,
     displayName: doc.displayName,
     avatarInitial: doc.avatarInitial,
+    publicKey: doc.publicKey,
+    followers: doc.followers,
+    following: doc.following,
   }));
   return jsonResponse(c, formatted);
 });

--- a/app/client/src/components/Chat.tsx
+++ b/app/client/src/components/Chat.tsx
@@ -113,7 +113,12 @@ export function Chat() {
   const loadRooms = async () => {
     const user = account();
     if (!user) return;
-    const ids = Array.from(new Set([...user.followers, ...user.following]));
+    const ids = Array.from(
+      new Set([
+        ...(user.followers ?? []),
+        ...(user.following ?? []),
+      ]),
+    );
     if (ids.length === 0) {
       setChatRooms([]);
       return;


### PR DESCRIPTION
## 概要
- `/api/accounts` が followers と following を返すよう修正
- Chat 画面で followers/following 未取得時にエラーにならないよう対策

## 動作確認
- `deno fmt --check` でフォーマットを確認
- `deno lint` で lint を実行

------
https://chatgpt.com/codex/tasks/task_e_686bc46a7e8c8328b7dda91d40b83c18