### PR TITLE
Fix chat key package fetch path

### DIFF
--- a/app/client/src/components/Chat.tsx
+++ b/app/client/src/components/Chat.tsx
@@ -132,15 +132,16 @@ export function Chat() {
       });
       if (res.ok) {
         const infos = await res.json() as UserInfo[];
-        const rooms = infos.reduce<ChatRoom[]>((acc, info, idx) => {
+        const rooms = infos.reduce<ChatRoom[]>((acc, info) => {
           if (!info.isLocal) return acc;
+          const localName = info.userName;
           acc.push({
-            id: ids[idx],
-            name: info.displayName || info.userName,
-            avatar: info.authorAvatar || info.userName.charAt(0).toUpperCase(),
+            id: localName,
+            name: info.displayName || localName,
+            avatar: info.authorAvatar || localName.charAt(0).toUpperCase(),
             unreadCount: 0,
             type: "dm",
-            members: [ids[idx]],
+            members: [localName],
           });
           return acc;
         }, []);


### PR DESCRIPTION
## Summary
- チャットルーム構築時にローカルユーザー名のみを使用するよう修正
- これにより `/api/users/https://.../keyPackages` となる誤ったURLを解消

## Testing
- `deno fmt`
- `deno lint app/client/src/components/Chat.tsx`

------
https://chatgpt.com/codex/tasks/task_e_686bd723bad08328bbeb58ce8a0c2ede