### PR TITLE
プロフィールページに投稿とフォロー一覧を追加

### DIFF
--- a/app/client/src/components/microblog/api.ts
+++ b/app/client/src/components/microblog/api.ts
@@ -584,3 +584,31 @@ export const fetchActivityPubActor = async (actorUrl: string) => {
     return null;
   }
 };
+
+// 指定ユーザーのフォロワー一覧を取得
+export const fetchFollowers = async (username: string) => {
+  try {
+    const res = await fetch(
+      `/api/users/${encodeURIComponent(username)}/followers`,
+    );
+    if (!res.ok) throw new Error("Failed to fetch followers");
+    return await res.json();
+  } catch (error) {
+    console.error("Error fetching followers:", error);
+    return [];
+  }
+};
+
+// 指定ユーザーのフォロー中一覧を取得
+export const fetchFollowing = async (username: string) => {
+  try {
+    const res = await fetch(
+      `/api/users/${encodeURIComponent(username)}/following`,
+    );
+    if (!res.ok) throw new Error("Failed to fetch following");
+    return await res.json();
+  } catch (error) {
+    console.error("Error fetching following:", error);
+    return [];
+  }
+};


### PR DESCRIPTION
## 変更点
- API クライアントにフォロワー/フォロー中取得関数を追加
- プロフィール画面から投稿・フォロー・フォロワー一覧を閲覧できるようにUIを拡張

## 確認項目
- `deno fmt` と `deno lint` がエラーなく実行できること

------
https://chatgpt.com/codex/tasks/task_e_686bd930e6588328aae347f990c8d14c