### PR TITLE
Fix repeated user-info requests in Chat

### DIFF
--- a/app/client/src/components/Chat.tsx
+++ b/app/client/src/components/Chat.tsx
@@ -266,7 +266,14 @@ export function Chat() {
   });
 
   createEffect(() => {
+    account();
     loadRooms();
+  });
+
+  createEffect(() => {
+    selectedRoom();
+    groups();
+    account();
     loadMessages();
   });
 


### PR DESCRIPTION
## Summary
- クライアントのチャット画面で `loadRooms` が何度も呼ばれ続ける問題を修正しました
- `createEffect` を2つに分割し、`loadRooms` はアカウント変更時のみ実行するよう変更しました
- `loadMessages` は選択中ルームやグループ状態が変わった時だけ実行します

## Testing
- `deno fmt app/client/src/components/Chat.tsx`
- `deno lint app/client/src/components/Chat.tsx`


------
https://chatgpt.com/codex/tasks/task_e_686bda7765308328a294eb3208a443a0