### PR TITLE
メッセージ送信失敗時の警告表示を追加

### DIFF
--- a/app/client/src/components/Chat.tsx
+++ b/app/client/src/components/Chat.tsx
@@ -224,10 +224,14 @@ export function Chat() {
       saveGroupStates();
     }
     const cipher = await encryptGroupMessage(group, text);
-    await sendEncryptedMessage(user.userName, {
+    const success = await sendEncryptedMessage(user.userName, {
       to: room.members,
       content: cipher,
     });
+    if (!success) {
+      alert("メッセージの送信に失敗しました");
+      return;
+    }
     setNewMessage("");
     loadMessages();
   };


### PR DESCRIPTION
## Summary
- メッセージ送信に失敗した場合、アラートを表示するよう修正

## Testing
- `deno fmt app/client/src/components/Chat.tsx`
- `deno lint app/client/src/components/Chat.tsx`


------
https://chatgpt.com/codex/tasks/task_e_686bdcd1de608328a8049c856698c22d