### PR TITLE
Add relay management UI

### DIFF
--- a/app/client/src/components/Setting/RelaySettings.tsx
+++ b/app/client/src/components/Setting/RelaySettings.tsx
@@ -1,0 +1,64 @@
+import { Component, createResource, createSignal, For } from "solid-js";
+import { addRelay, deleteRelay, fetchRelays, Relay } from "./relaysApi.ts";
+
+const RelaySettings: Component = () => {
+  const [relays, { mutate }] = createResource(fetchRelays);
+  const [url, setUrl] = createSignal("");
+
+  const onAdd = async () => {
+    const inboxUrl = url().trim();
+    if (!inboxUrl) return;
+    const result = await addRelay(inboxUrl);
+    if (result) {
+      mutate((prev) => [...(prev ?? []), result]);
+      setUrl("");
+    }
+  };
+
+  const onDelete = async (id: string) => {
+    const ok = await deleteRelay(id);
+    if (ok) {
+      mutate((prev) => prev?.filter((r) => r.id !== id) ?? []);
+    }
+  };
+
+  return (
+    <div class="space-y-2">
+      <h3 class="text-xl font-bold">リレーサーバー設定</h3>
+      <div class="flex space-x-2">
+        <input
+          class="flex-1 px-2 py-1 border rounded"
+          type="text"
+          placeholder="Relay inbox URL"
+          value={url()}
+          onInput={(e) => setUrl(e.currentTarget.value)}
+        />
+        <button
+          type="button"
+          class="px-3 py-1 bg-blue-500 text-white rounded"
+          onClick={onAdd}
+        >
+          追加
+        </button>
+      </div>
+      <ul class="space-y-1">
+        <For each={relays()}>
+          {(relay: Relay) => (
+            <li class="flex justify-between items-center border-b pb-1">
+              <span class="break-all">{relay.inboxUrl}</span>
+              <button
+                type="button"
+                class="text-sm text-red-500"
+                onClick={() => onDelete(relay.id)}
+              >
+                削除
+              </button>
+            </li>
+          )}
+        </For>
+      </ul>
+    </div>
+  );
+};
+
+export default RelaySettings;

--- a/app/client/src/components/Setting/index.tsx
+++ b/app/client/src/components/Setting/index.tsx
@@ -1,5 +1,6 @@
 import { useAtom } from "solid-jotai";
 import { darkModeState, languageState } from "../../states/settings.ts";
+import RelaySettings from "./RelaySettings.tsx";
 
 export function Setting() {
   const [darkMode, setDarkMode] = useAtom(darkModeState);
@@ -29,6 +30,7 @@ export function Setting() {
           <option value="en">English</option>
         </select>
       </div>
+      <RelaySettings />
     </div>
   );
 }

--- a/app/client/src/components/Setting/relaysApi.ts
+++ b/app/client/src/components/Setting/relaysApi.ts
@@ -1,0 +1,41 @@
+export interface Relay {
+  id: string;
+  inboxUrl: string;
+}
+
+export const fetchRelays = async (): Promise<Relay[]> => {
+  try {
+    const res = await fetch("/api/relays");
+    if (!res.ok) throw new Error("Failed to fetch relays");
+    const data = await res.json();
+    return Array.isArray(data.relays) ? data.relays : [];
+  } catch (err) {
+    console.error("Error fetching relays:", err);
+    return [];
+  }
+};
+
+export const addRelay = async (inboxUrl: string): Promise<Relay | null> => {
+  try {
+    const res = await fetch("/api/relays", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ inboxUrl }),
+    });
+    if (!res.ok) return null;
+    return await res.json();
+  } catch (err) {
+    console.error("Error adding relay:", err);
+    return null;
+  }
+};
+
+export const deleteRelay = async (id: string): Promise<boolean> => {
+  try {
+    const res = await fetch(`/api/relays/${id}`, { method: "DELETE" });
+    return res.ok;
+  } catch (err) {
+    console.error("Error deleting relay:", err);
+    return false;
+  }
+};


### PR DESCRIPTION
## Summary
- 管理画面(Setting)にRelaySettingsコンポーネントを追加
- リレーサーバー一覧の取得・追加・削除APIを実装

## Testing
- `deno fmt app/client/src/components/Setting/index.tsx app/client/src/components/Setting/RelaySettings.tsx app/client/src/components/Setting/relaysApi.ts`
- `deno lint app/client/src/components/Setting/index.tsx app/client/src/components/Setting/RelaySettings.tsx app/client/src/components/Setting/relaysApi.ts`


------
https://chatgpt.com/codex/tasks/task_e_686bdef5b5e48328b7ad9ace425b6283