### PR TITLE
Add account cache initialization

### DIFF
--- a/app/client/src/components/Home.tsx
+++ b/app/client/src/components/Home.tsx
@@ -85,6 +85,7 @@ export function Home() {
       const response = await fetch("/api/accounts");
       const results = await response.json();
       setAccounts(results || []);
+      localStorage.setItem("takos-accounts", JSON.stringify(results || []));
 
       if (preserveSelectedId) {
         const accountExists = results.some((acc: Account) =>
@@ -218,7 +219,21 @@ export function Home() {
   };
 
   onMount(() => {
-    loadAccounts();
+    const saved = localStorage.getItem("takos-accounts");
+    if (saved) {
+      try {
+        const parsed = JSON.parse(saved) as Account[];
+        setAccounts(parsed);
+        if (!actId() && parsed.length > 0) {
+          setActId(parsed[0].id);
+        }
+      } catch (err) {
+        console.error("Failed to parse stored accounts:", err);
+        loadAccounts();
+      }
+    } else {
+      loadAccounts();
+    }
 
     // タッチイベントリスナーを追加
     const addTouchListeners = () => {

--- a/app/client/src/states/account.ts
+++ b/app/client/src/states/account.ts
@@ -11,8 +11,20 @@ export interface Account {
 }
 
 const STORAGE_KEY = "takos-active-account-id";
+const ACCOUNTS_KEY = "takos-accounts";
 
-export const accounts = atom<Account[]>([]);
+const savedAccounts = localStorage.getItem(ACCOUNTS_KEY);
+export const accounts = atom<Account[]>(
+  savedAccounts ? JSON.parse(savedAccounts) as Account[] : [],
+);
+
+export const setAccounts = atom(
+  (get) => get(accounts),
+  (_get, set, newAccounts: Account[]) => {
+    set(accounts, newAccounts);
+    localStorage.setItem(ACCOUNTS_KEY, JSON.stringify(newAccounts));
+  },
+);
 
 // 選択中アカウントIDの初期値を localStorage から取得
 const initialAccountId = localStorage.getItem(STORAGE_KEY);


### PR DESCRIPTION
## Summary
- アカウント一覧を localStorage から読み込み
- API 取得時は localStorage へ保存

## Testing
- `deno fmt app/client/src/states/account.ts app/client/src/components/Home.tsx`
- `deno lint app/client/src/states/account.ts app/client/src/components/Home.tsx`

------
https://chatgpt.com/codex/tasks/task_e_686be17994548328821880f379de1187