### PR TITLE
Fix chat input handler and lint issues

### DIFF
--- a/app/client/src/components/Chat.tsx
+++ b/app/client/src/components/Chat.tsx
@@ -679,7 +679,7 @@ export function Chat() {
               <div class="flex-1 relative">
                 <textarea
                   value={newMessage()}
-                  onInput={(e) => setNewMessage(e.target.value)}
+                  onInput={(e) => setNewMessage(e.currentTarget.value)}
                   placeholder={isMobile()
                     ? "メッセージ..."
                     : "メッセージを入力..."}

--- a/app/client/src/components/Microblog.tsx
+++ b/app/client/src/components/Microblog.tsx
@@ -26,7 +26,7 @@ export function Microblog() {
     "recommend",
   );
   const [newPostContent, setNewPostContent] = createSignal("");
-  const [showPostForm, setShowPostForm] = createSignal(false);
+  const [_showPostForm, _setShowPostForm] = createSignal(false);
   const [_replyingTo, _setReplyingTo] = createSignal<string | null>(null);
   const [searchQuery, setSearchQuery] = createSignal("");
   const [posts, { mutate, refetch }] = createResource(fetchPosts);
@@ -374,7 +374,7 @@ export function Microblog() {
         <div class="fixed bottom-0 left-0 w-full z-40 bg-gray-900/95 border-t border-gray-800">
           <div class="max-w-2xl mx-auto px-4 py-3">
             <PostForm
-              showPostForm={true}
+              showPostForm
               setShowPostForm={() => {}}
               newPostContent={newPostContent()}
               setNewPostContent={setNewPostContent}


### PR DESCRIPTION
## Summary
- fix textarea input handler to use currentTarget
- silence unused variable and boolean prop lint issues

## Testing
- `deno fmt app/client/src/components/Chat.tsx app/client/src/components/Microblog.tsx`
- `deno lint app/client/src/components/Chat.tsx app/client/src/components/Microblog.tsx`


------
https://chatgpt.com/codex/tasks/task_e_686be1ed40d88328a95d3201605c08d0