### PR TITLE
チャット送信時の警告とボタン属性の修正

### DIFF
--- a/app/client/src/components/Chat.tsx
+++ b/app/client/src/components/Chat.tsx
@@ -174,7 +174,10 @@ export function Chat() {
       const kp = await ensureKeyPair();
       if (!kp) return;
       const partnerPub = await getPartnerKey(room.members[0]);
-      if (!partnerPub) return;
+      if (!partnerPub) {
+        alert("相手が鍵を登録していないため、メッセージを送れません");
+        return;
+      }
       const secret = await deriveMLSSecret(kp.privateKey, partnerPub);
       group = {
         members: [user.userName, ...room.members],
@@ -213,7 +216,10 @@ export function Chat() {
       const kp = await ensureKeyPair();
       if (!kp) return;
       const partnerPub = await getPartnerKey(room.members[0]);
-      if (!partnerPub) return;
+      if (!partnerPub) {
+        alert("相手が鍵を登録していないため、メッセージを送れません");
+        return;
+      }
       const secret = await deriveMLSSecret(kp.privateKey, partnerPub);
       group = {
         members: [user.userName, ...room.members],

--- a/app/client/src/components/home/AccountSettingsContent.tsx
+++ b/app/client/src/components/home/AccountSettingsContent.tsx
@@ -61,9 +61,17 @@ const AccountSettingsContent: Component<{
         displayName: selectedAccount()?.displayName || username,
         authorAvatar: selectedAccount()?.avatarInitial || "",
         createdAt: o.published,
-        likes: typeof (o.extra as Record<string, unknown>)?.likes === "number" ? (o.extra as Record<string, unknown>)?.likes as number : 0,
-        retweets: typeof (o.extra as Record<string, unknown>)?.retweets === "number" ? (o.extra as Record<string, unknown>)?.retweets as number : 0,
-        replies: typeof (o.extra as Record<string, unknown>)?.replies === "number" ? (o.extra as Record<string, unknown>)?.replies as number : 0,
+        likes: typeof (o.extra as Record<string, unknown>)?.likes === "number"
+          ? (o.extra as Record<string, unknown>)?.likes as number
+          : 0,
+        retweets:
+          typeof (o.extra as Record<string, unknown>)?.retweets === "number"
+            ? (o.extra as Record<string, unknown>)?.retweets as number
+            : 0,
+        replies:
+          typeof (o.extra as Record<string, unknown>)?.replies === "number"
+            ? (o.extra as Record<string, unknown>)?.replies as number
+            : 0,
       }));
     },
   );
@@ -439,11 +447,23 @@ const AccountSettingsContent: Component<{
             </Show>
             {/* フォロー中モーダル */}
             <Show when={showFollowingModal()}>
-              <div class="fixed inset-0 z-50 flex items-center justify-center bg-black/60" onClick={() => setShowFollowingModal(false)}>
-                <div class="bg-gray-900 rounded-lg p-6 max-w-sm w-full max-h-[70vh] overflow-y-auto shadow-xl" onClick={e => e.stopPropagation()}>
+              <div
+                class="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+                onClick={() => setShowFollowingModal(false)}
+              >
+                <div
+                  class="bg-gray-900 rounded-lg p-6 max-w-sm w-full max-h-[70vh] overflow-y-auto shadow-xl"
+                  onClick={(e) => e.stopPropagation()}
+                >
                   <div class="flex justify-between items-center mb-4">
                     <h3 class="text-lg font-bold text-white">フォロー中</h3>
-                    <button class="text-gray-400 hover:text-white" onClick={() => setShowFollowingModal(false)}>×</button>
+                    <button
+                      type="button"
+                      class="text-gray-400 hover:text-white"
+                      onClick={() => setShowFollowingModal(false)}
+                    >
+                      ×
+                    </button>
                   </div>
                   <div class="space-y-2">
                     <For each={followingList() || []}>
@@ -454,7 +474,9 @@ const AccountSettingsContent: Component<{
                             username={u.userName}
                             size="w-8 h-8"
                           />
-                          <span class="text-sm text-white">{u.displayName}</span>
+                          <span class="text-sm text-white">
+                            {u.displayName}
+                          </span>
                         </div>
                       )}
                     </For>
@@ -464,11 +486,23 @@ const AccountSettingsContent: Component<{
             </Show>
             {/* フォロワーモーダル */}
             <Show when={showFollowersModal()}>
-              <div class="fixed inset-0 z-50 flex items-center justify-center bg-black/60" onClick={() => setShowFollowersModal(false)}>
-                <div class="bg-gray-900 rounded-lg p-6 max-w-sm w-full max-h-[70vh] overflow-y-auto shadow-xl" onClick={e => e.stopPropagation()}>
+              <div
+                class="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+                onClick={() => setShowFollowersModal(false)}
+              >
+                <div
+                  class="bg-gray-900 rounded-lg p-6 max-w-sm w-full max-h-[70vh] overflow-y-auto shadow-xl"
+                  onClick={(e) => e.stopPropagation()}
+                >
                   <div class="flex justify-between items-center mb-4">
                     <h3 class="text-lg font-bold text-white">フォロワー</h3>
-                    <button class="text-gray-400 hover:text-white" onClick={() => setShowFollowersModal(false)}>×</button>
+                    <button
+                      type="button"
+                      class="text-gray-400 hover:text-white"
+                      onClick={() => setShowFollowersModal(false)}
+                    >
+                      ×
+                    </button>
                   </div>
                   <div class="space-y-2">
                     <For each={followers() || []}>
@@ -479,7 +513,9 @@ const AccountSettingsContent: Component<{
                             username={u.userName}
                             size="w-8 h-8"
                           />
-                          <span class="text-sm text-white">{u.displayName}</span>
+                          <span class="text-sm text-white">
+                            {u.displayName}
+                          </span>
                         </div>
                       )}
                     </For>


### PR DESCRIPTION
## Summary
- sendMessageとloadMessagesで相手の鍵がない場合に警告を表示
- フォロー中/フォロワーモーダルの閉じるボタンに`type="button"`を付与

## Testing
- `deno fmt app/client/src/components/Chat.tsx app/client/src/components/home/AccountSettingsContent.tsx`
- `deno lint app/client/src/components/Chat.tsx app/client/src/components/home/AccountSettingsContent.tsx`


------
https://chatgpt.com/codex/tasks/task_e_686be35893d48328ba5d5f9e5bc83939