### PR TITLE
外部ユーザー表示のためのDMルーム取得修正

### DIFF
--- a/app/client/src/components/Chat.tsx
+++ b/app/client/src/components/Chat.tsx
@@ -152,17 +152,18 @@ export function Chat() {
       if (res.ok) {
         const infos = await res.json() as UserInfo[];
         const rooms = infos.reduce<ChatRoom[]>((acc, info) => {
-          if (!info.isLocal) return acc;
-          const localName = info.userName;
+          const id = info.domain
+            ? `${info.userName}@${info.domain}`
+            : info.userName;
           acc.push({
-            id: localName,
-            name: info.displayName || localName,
-            userName: localName,
+            id,
+            name: info.displayName || info.userName,
+            userName: info.userName,
             domain: info.domain,
-            avatar: info.authorAvatar || localName.charAt(0).toUpperCase(),
+            avatar: info.authorAvatar || info.userName.charAt(0).toUpperCase(),
             unreadCount: 0,
             type: "dm",
-            members: [localName],
+            members: [info.userName],
           });
           return acc;
         }, []);


### PR DESCRIPTION
## Summary
- DM一覧に外部ユーザーも表示できるよう `loadRooms` のフィルタを削除

## Testing
- `deno fmt app/client/src/components/Chat.tsx`
- `deno lint app/client/src/components/Chat.tsx`


------
https://chatgpt.com/codex/tasks/task_e_686bea739f188328b9287afdd62de3d0