### PR TITLE
Fix selected room avatar display

### DIFF
--- a/app/client/src/components/Chat.tsx
+++ b/app/client/src/components/Chat.tsx
@@ -80,6 +80,12 @@ export function Chat() {
   );
   let poller: number | undefined;
 
+  const isUrl = (value?: string): boolean => {
+    return value
+      ? value.startsWith("http://") || value.startsWith("https://")
+      : false;
+  };
+
   const loadGroupStates = async () => {
     try {
       const stored = await loadMLSGroupStates();
@@ -395,8 +401,16 @@ export function Chat() {
                 >
                   <div class="flex items-center space-x-3">
                     <div class="relative">
-                      <div class="w-8 h-8 bg-gradient-to-br from-blue-500 to-purple-600 rounded-full flex items-center justify-center text-sm font-bold">
-                        {room.avatar}
+                      <div class="w-8 h-8 bg-gradient-to-br from-blue-500 to-purple-600 rounded-full flex items-center justify-center text-sm font-bold overflow-hidden">
+                        {isUrl(room.avatar)
+                          ? (
+                            <img
+                              src={room.avatar}
+                              alt="avatar"
+                              class="w-full h-full object-cover rounded-full"
+                            />
+                          )
+                          : room.avatar}
                       </div>
                       <Show when={room.isOnline}>
                         <div class="absolute -bottom-0.5 -right-0.5 w-2.5 h-2.5 bg-green-400 border-2 border-[#1a1a1a] rounded-full">
@@ -445,8 +459,16 @@ export function Chat() {
                 >
                   <div class="flex items-center space-x-3">
                     <div class="relative">
-                      <div class="w-8 h-8 bg-gradient-to-br from-green-500 to-teal-600 rounded-full flex items-center justify-center text-sm font-bold">
-                        {room.avatar}
+                      <div class="w-8 h-8 bg-gradient-to-br from-green-500 to-teal-600 rounded-full flex items-center justify-center text-sm font-bold overflow-hidden">
+                        {isUrl(room.avatar)
+                          ? (
+                            <img
+                              src={room.avatar}
+                              alt="avatar"
+                              class="w-full h-full object-cover rounded-full"
+                            />
+                          )
+                          : room.avatar}
                       </div>
                       <Show when={room.isOnline}>
                         <div class="absolute -bottom-0.5 -right-0.5 w-2.5 h-2.5 bg-green-400 border-2 border-[#1a1a1a] rounded-full">
@@ -516,8 +538,16 @@ export function Chat() {
                     </svg>
                   </button>
                 </Show>
-                <div class="w-10 h-10 bg-gradient-to-br from-blue-500 to-purple-600 rounded-full flex items-center justify-center text-white font-bold">
-                  {selectedRoomInfo()?.avatar}
+                <div class="w-10 h-10 bg-gradient-to-br from-blue-500 to-purple-600 rounded-full flex items-center justify-center text-white font-bold overflow-hidden">
+                  {isUrl(selectedRoomInfo()?.avatar)
+                    ? (
+                      <img
+                        src={selectedRoomInfo()?.avatar}
+                        alt="avatar"
+                        class="w-full h-full object-cover rounded-full"
+                      />
+                    )
+                    : selectedRoomInfo()?.avatar}
                 </div>
                 <div>
                   <h3 class="text-lg font-semibold text-white">
@@ -627,8 +657,16 @@ export function Chat() {
                       }`}
                     >
                       <Show when={!message.isMe}>
-                        <div class="w-8 h-8 bg-gradient-to-br from-green-500 to-teal-600 rounded-full flex items-center justify-center text-white font-bold text-sm flex-shrink-0">
-                          {message.avatar}
+                        <div class="w-8 h-8 bg-gradient-to-br from-green-500 to-teal-600 rounded-full flex items-center justify-center text-white font-bold text-sm flex-shrink-0 overflow-hidden">
+                          {isUrl(message.avatar)
+                            ? (
+                              <img
+                                src={message.avatar}
+                                alt="avatar"
+                                class="w-full h-full object-cover rounded-full"
+                              />
+                            )
+                            : message.avatar}
                         </div>
                       </Show>
                       <div


### PR DESCRIPTION
## Summary
- チャットヘッダーで選択中ルームのアバターURLを画像として表示

## Testing
- `deno fmt app/client/src/components/Chat.tsx`
- `deno lint app/client/src/components/Chat.tsx`


------
https://chatgpt.com/codex/tasks/task_e_686bec470a108328951c3735c78012cc