### PR TITLE
IndexedDBをアカウント単位で管理

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,4 +120,9 @@ curl "https://takos.example/.well-known/webfinger?resource=acct:!team@takos.exam
 - `GET  /api/communities/:id/pending-followers` 未承認フォロワー一覧を取得。
 - `POST /api/communities/:id/pending-followers/approve` 承認して `Accept`
   を送信。
-- `POST /api/communities/:id/pending-followers/reject` フォロー申請を拒否。
+  - `POST /api/communities/:id/pending-followers/reject` フォロー申請を拒否。
+
+## クライアントでのデータ保存
+
+チャット機能で利用するMLS関連データは、ブラウザのIndexedDBに保存します。データベースは
+アカウントIDごとに分割されており、別アカウントの情報が混在しないようになっています。

--- a/app/client/src/components/e2ee/storage.ts
+++ b/app/client/src/components/e2ee/storage.ts
@@ -1,12 +1,13 @@
 import type { StoredMLSGroupState, StoredMLSKeyPair } from "./mls.ts";
 
-const DB_NAME = "takos";
+const DB_VERSION = 2;
 const STORE_NAME = "mlsGroups";
 const KEY_STORE = "mlsKeyPair";
 
-function openDB(): Promise<IDBDatabase> {
+function openDB(accountId: string): Promise<IDBDatabase> {
+  const name = `takos_${accountId}`;
   return new Promise((resolve, reject) => {
-    const req = indexedDB.open(DB_NAME, 2);
+    const req = indexedDB.open(name, DB_VERSION);
     req.onupgradeneeded = () => {
       const db = req.result;
       if (!db.objectStoreNames.contains(STORE_NAME)) {
@@ -21,10 +22,10 @@ function openDB(): Promise<IDBDatabase> {
   });
 }
 
-export const loadMLSGroupStates = async (): Promise<
-  Record<string, StoredMLSGroupState>
-> => {
-  const db = await openDB();
+export const loadMLSGroupStates = async (
+  accountId: string,
+): Promise<Record<string, StoredMLSGroupState>> => {
+  const db = await openDB(accountId);
   const tx = db.transaction(STORE_NAME, "readonly");
   const store = tx.objectStore(STORE_NAME);
   return await new Promise((resolve, reject) => {
@@ -44,9 +45,10 @@ export const loadMLSGroupStates = async (): Promise<
 };
 
 export const saveMLSGroupStates = async (
+  accountId: string,
   states: Record<string, StoredMLSGroupState>,
 ): Promise<void> => {
-  const db = await openDB();
+  const db = await openDB(accountId);
   const tx = db.transaction(STORE_NAME, "readwrite");
   const store = tx.objectStore(STORE_NAME);
   store.clear();
@@ -59,8 +61,10 @@ export const saveMLSGroupStates = async (
   });
 };
 
-export const loadMLSKeyPair = async (): Promise<StoredMLSKeyPair | null> => {
-  const db = await openDB();
+export const loadMLSKeyPair = async (
+  accountId: string,
+): Promise<StoredMLSKeyPair | null> => {
+  const db = await openDB(accountId);
   const tx = db.transaction(KEY_STORE, "readonly");
   const store = tx.objectStore(KEY_STORE);
   return await new Promise((resolve, reject) => {
@@ -71,9 +75,10 @@ export const loadMLSKeyPair = async (): Promise<StoredMLSKeyPair | null> => {
 };
 
 export const saveMLSKeyPair = async (
+  accountId: string,
   pair: StoredMLSKeyPair,
 ): Promise<void> => {
-  const db = await openDB();
+  const db = await openDB(accountId);
   const tx = db.transaction(KEY_STORE, "readwrite");
   const store = tx.objectStore(KEY_STORE);
   store.put(pair, "key");


### PR DESCRIPTION
## Summary
- E2EE用のIndexedDBをアカウントIDごとに切り替え
- ChatコンポーネントからアカウントIDを渡して保存/読込
- ドキュメントにIndexedDBの取り扱いを追記

## Testing
- `deno fmt`
- `deno lint README.md app/client/src/components/e2ee/storage.ts app/client/src/components/Chat.tsx`


------
https://chatgpt.com/codex/tasks/task_e_686c0917ae8083289b93e07d42e6cf00