### PR TITLE
Fix remote key retrieval for DM

### DIFF
--- a/app/api/e2ee.ts
+++ b/app/api/e2ee.ts
@@ -12,7 +12,9 @@ import {
   createRemoveActivity,
   deliverActivityPubObject,
   fetchActorInbox,
+  fetchJson,
   getDomain,
+  resolveActor,
 } from "./utils/activitypub.ts";
 
 const app = new Hono();
@@ -50,8 +52,38 @@ async function deliverToFollowers(
 
 app.get("/users/:user/keyPackages", async (c) => {
   const user = c.req.param("user");
-  const list = await KeyPackage.find({ userName: user }).lean();
   const domain = getDomain(c);
+
+  // user@domain や URL で指定された場合はリモートから取得
+  if (user.includes("@") || user.startsWith("http")) {
+    let actorUrl = "";
+    if (user.startsWith("http")) {
+      actorUrl = user;
+    } else {
+      const [name, host] = user.split("@");
+      const actor = await resolveActor(name, host);
+      if (!actor) return c.json({ type: "Collection", items: [] });
+      actorUrl = actor.id;
+    }
+
+    try {
+      const actor = await fetchJson<{ keyPackages?: string | { id?: string } }>(
+        actorUrl,
+      );
+      const kpUrl = typeof actor.keyPackages === "string"
+        ? actor.keyPackages
+        : actor.keyPackages?.id;
+      if (!kpUrl) return c.json({ type: "Collection", items: [] });
+      const col = await fetchJson<{ items?: unknown[] }>(kpUrl);
+      const items = Array.isArray(col.items) ? col.items : [];
+      return c.json({ type: "Collection", items });
+    } catch (_err) {
+      console.error("remote keyPackages fetch failed", _err);
+      return c.json({ type: "Collection", items: [] });
+    }
+  }
+
+  const list = await KeyPackage.find({ userName: user }).lean();
   const items = list.map((doc) => ({
     id: `https://${domain}/users/${user}/keyPackage/${doc._id}`,
     type: "KeyPackage",

--- a/app/client/src/components/Chat.tsx
+++ b/app/client/src/components/Chat.tsx
@@ -142,13 +142,14 @@ export function Chat() {
     return pair;
   };
 
-  const getPartnerKey = async (userName: string) => {
-    if (partnerKeyCache.has(userName)) {
-      return partnerKeyCache.get(userName);
+  const getPartnerKey = async (userName: string, domain?: string) => {
+    const keyId = domain ? `${userName}@${domain}` : userName;
+    if (partnerKeyCache.has(keyId)) {
+      return partnerKeyCache.get(keyId);
     }
-    const keys = await fetchKeyPackages(userName);
+    const keys = await fetchKeyPackages(userName, domain);
     const pub = keys[0]?.content ?? null;
-    partnerKeyCache.set(userName, pub);
+    partnerKeyCache.set(keyId, pub);
     return pub;
   };
 
@@ -206,7 +207,10 @@ export function Chat() {
     if (!group) {
       const kp = await ensureKeyPair();
       if (!kp) return;
-      const partnerPub = await getPartnerKey(room.members[0]);
+      const partnerPub = await getPartnerKey(
+        room.members[0],
+        room.domain,
+      );
       if (!partnerPub) {
         return;
       }
@@ -252,7 +256,10 @@ export function Chat() {
     if (!group) {
       const kp = await ensureKeyPair();
       if (!kp) return;
-      const partnerPub = await getPartnerKey(room.members[0]);
+      const partnerPub = await getPartnerKey(
+        room.members[0],
+        room.domain,
+      );
       if (!partnerPub) {
         return;
       }

--- a/app/client/src/components/e2ee/api.ts
+++ b/app/client/src/components/e2ee/api.ts
@@ -17,10 +17,14 @@ export interface EncryptedMessage {
   createdAt: string;
 }
 
-export const fetchKeyPackages = async (user: string): Promise<KeyPackage[]> => {
+export const fetchKeyPackages = async (
+  user: string,
+  domain?: string,
+): Promise<KeyPackage[]> => {
   try {
+    const identifier = domain ? `${user}@${domain}` : user;
     const res = await fetch(
-      `/api/users/${encodeURIComponent(user)}/keyPackages`,
+      `/api/users/${encodeURIComponent(identifier)}/keyPackages`,
     );
     if (!res.ok) {
       throw new Error("Failed to fetch key packages");


### PR DESCRIPTION
## Summary
- fetch remote key packages on the server when user is remote
- support domain parameter in client key package API
- handle remote partner keys in chat

## Testing
- `deno lint app/api/e2ee.ts app/client/src/components/e2ee/api.ts app/client/src/components/Chat.tsx`


------
https://chatgpt.com/codex/tasks/task_e_686d4ed62e3c8328bf7302f832e8de51