### PR TITLE
鍵情報取得失敗時のアラート追加

### DIFF
--- a/app/client/src/components/Chat.tsx
+++ b/app/client/src/components/Chat.tsx
@@ -255,12 +255,16 @@ export function Chat() {
     let group = groups()[roomId];
     if (!group) {
       const kp = await ensureKeyPair();
-      if (!kp) return;
+      if (!kp) {
+        alert("鍵情報が取得できないため送信できません");
+        return;
+      }
       const partnerPub = await getPartnerKey(
         room.members[0],
         room.domain,
       );
       if (!partnerPub) {
+        alert("鍵情報が取得できないため送信できません");
         return;
       }
       const secret = await deriveMLSSecret(kp.privateKey, partnerPub);


### PR DESCRIPTION
## Summary
- Chat.tsx の `sendMessage` 関数で鍵情報が取得できない場合にアラートを表示

## Testing
- `deno fmt app/client/src/components/Chat.tsx`
- `deno lint app/client/src/components/Chat.tsx`


------
https://chatgpt.com/codex/tasks/task_e_686d57c49124832890b99babfcdc6aaf