### PR TITLE
鍵情報消失時の自動再生成

### DIFF
--- a/app/client/src/components/Chat.tsx
+++ b/app/client/src/components/Chat.tsx
@@ -129,13 +129,24 @@ export function Chat() {
     const user = account();
     if (!user) return null;
     if (!pair) {
-      const stored = await loadMLSKeyPair(user.id);
-      if (stored) {
-        pair = await importKeyPair(stored as StoredMLSKeyPair);
-      } else {
+      try {
+        const stored = await loadMLSKeyPair(user.id);
+        if (stored) {
+          pair = await importKeyPair(stored as StoredMLSKeyPair);
+        }
+      } catch (err) {
+        console.error("鍵ペアの読み込みに失敗しました", err);
+        pair = null;
+      }
+      if (!pair) {
         pair = await generateMLSKeyPair();
-        await saveMLSKeyPair(user.id, await exportKeyPair(pair));
-        await addKeyPackage(user.userName, { content: pair.publicKey });
+        try {
+          await saveMLSKeyPair(user.id, await exportKeyPair(pair));
+          await addKeyPackage(user.userName, { content: pair.publicKey });
+        } catch (err) {
+          console.error("鍵ペアの保存に失敗しました", err);
+          return null;
+        }
       }
       setKeyPair(pair);
     }


### PR DESCRIPTION
## Summary
- ensureKeyPair 関数を強化し、保存済み鍵の読み込み失敗時に再生成するよう変更

## Testing
- `deno fmt`
- `deno lint app/client/src/components/Chat.tsx`
- `deno lint` *(fails: no-unused-vars in Microblog.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_686d592d51e08328aa536884f7a0aa88