### PR TITLE
Actor URL handling for chat rooms

### DIFF
--- a/app/client/src/components/e2ee/mls.ts
+++ b/app/client/src/components/e2ee/mls.ts
@@ -1,5 +1,7 @@
 // MLSヘルパー関数の継続実装
 
+type ActorID = string;
+
 export interface MLSKeyPair {
   publicKey: string; // base64化した公開鍵
   privateKey: CryptoKey;
@@ -68,13 +70,13 @@ export const deriveMLSSecret = async (
  * AES-GCM鍵を作成しグループ状態を保持
  */
 export interface MLSGroupState {
-  members: string[];
+  members: ActorID[];
   epoch: number;
   secret: CryptoKey;
 }
 
 export const createMLSGroup = async (
-  members: string[],
+  members: ActorID[],
 ): Promise<MLSGroupState> => {
   const secret = await crypto.subtle.generateKey(
     { name: "AES-GCM", length: 256 },
@@ -136,7 +138,7 @@ export const decryptGroupMessage = async (
 };
 
 export interface StoredMLSGroupState {
-  members: string[];
+  members: ActorID[];
   epoch: number;
   secret: string;
 }


### PR DESCRIPTION
## Summary
- ChatRoom.membersをActor URLに統一
- splitActorユーティリティの追加
- MLS関連型をActorIDに対応
- ルーム一覧取得時にActor URLを保持するよう修正

## Testing
- `deno fmt app/client/src/components/Chat.tsx app/client/src/components/e2ee/mls.ts`
- `deno lint app/client/src/components/Chat.tsx app/client/src/components/e2ee/mls.ts`


------
https://chatgpt.com/codex/tasks/task_e_686d6cd4b6348328a542d419a4f9cb62