### PR TITLE
Fix key pair reset when changing account

### DIFF
--- a/app/client/src/components/Chat.tsx
+++ b/app/client/src/components/Chat.tsx
@@ -371,6 +371,8 @@ export function Chat() {
 
   createEffect(() => {
     account();
+    setKeyPair(null);
+    setGroups({});
     loadGroupStates();
     ensureKeyPair();
   });


### PR DESCRIPTION
## Summary
- アカウント切り替え後も以前の鍵ペアが保持され、受信メッセージが復号できなくなる問題を修正

## Testing
- `deno fmt app/client/src/components/Chat.tsx`
- `deno lint app/client/src/components/Chat.tsx`


------
https://chatgpt.com/codex/tasks/task_e_686d7ce0fea883288404c3107f214f33