### PR TITLE
クライアントのドメイン依存を解消

### DIFF
--- a/app/client/src/App.tsx
+++ b/app/client/src/App.tsx
@@ -4,6 +4,7 @@ import { loginState } from "./states/session.ts";
 import { darkModeState, languageState } from "./states/settings.ts";
 import { LoginForm } from "./components/LoginForm.tsx";
 import { Application } from "./components/Application.tsx";
+import { apiFetch } from "./utils/config.ts";
 import "./App.css";
 import "./stylesheet.css";
 
@@ -15,7 +16,7 @@ function App() {
   // アプリケーション初期化時にログイン状態を確認
   onMount(async () => {
     try {
-      const res = await fetch("/api/session/status");
+      const res = await apiFetch("/api/session/status");
       const result = await res.json();
       setIsLoggedIn(result.login ?? false);
     } catch (err) {

--- a/app/client/src/components/Home.tsx
+++ b/app/client/src/components/Home.tsx
@@ -1,4 +1,5 @@
 import { createSignal, onMount } from "solid-js";
+import { apiFetch } from "../utils/config.ts";
 import { useAtom } from "solid-jotai";
 import AccountSettingsContent from "./home/AccountSettingsContent.tsx";
 import NotificationsContent from "./home/NotificationsContent.tsx";
@@ -82,7 +83,7 @@ export function Home() {
   // APIでアカウント一覧を取得
   const loadAccounts = async (preserveSelectedId?: string) => {
     try {
-      const response = await fetch("/api/accounts");
+      const response = await apiFetch("/api/accounts");
       const results = await response.json();
       setAccounts(results || []);
       if (preserveSelectedId) {
@@ -105,7 +106,7 @@ export function Home() {
   // 新規アカウント追加機能
   const addNewAccount = async (username: string, displayName?: string) => {
     try {
-      const response = await fetch("/api/accounts", {
+      const response = await apiFetch("/api/accounts", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -174,7 +175,7 @@ export function Home() {
       }
       // payload.avatarInitial が未定義の場合、サーバー側はアイコンを変更しない
 
-      const response = await fetch(`/api/accounts/${id}`, {
+      const response = await apiFetch(`/api/accounts/${id}`, {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(payload),
@@ -196,7 +197,7 @@ export function Home() {
       const currentAccount = accounts().find((acc) => acc.id === id);
       if (!currentAccount) return;
 
-      const response = await fetch(`/api/accounts/${id}`, {
+      const response = await apiFetch(`/api/accounts/${id}`, {
         method: "DELETE",
       });
 
@@ -217,7 +218,7 @@ export function Home() {
   };
 
   onMount(() => {
-      loadAccounts();
+    loadAccounts();
     // タッチイベントリスナーを追加
     const addTouchListeners = () => {
       if (mainContentRef) {

--- a/app/client/src/components/LoginForm.tsx
+++ b/app/client/src/components/LoginForm.tsx
@@ -1,4 +1,5 @@
 import { createSignal, Show } from "solid-js";
+import { apiFetch } from "../utils/config.ts";
 
 interface LoginFormProps {
   onLoginSuccess: () => void;
@@ -21,7 +22,7 @@ export function LoginForm(props: LoginFormProps) {
     setIsLoading(true);
 
     try {
-      const res = await fetch("/api/login", {
+      const res = await apiFetch("/api/login", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({

--- a/app/client/src/components/Setting/relaysApi.ts
+++ b/app/client/src/components/Setting/relaysApi.ts
@@ -1,3 +1,5 @@
+import { apiFetch } from "../../utils/config.ts";
+
 export interface Relay {
   id: string;
   inboxUrl: string;
@@ -5,7 +7,7 @@ export interface Relay {
 
 export const fetchRelays = async (): Promise<Relay[]> => {
   try {
-    const res = await fetch("/api/relays");
+    const res = await apiFetch("/api/relays");
     if (!res.ok) throw new Error("Failed to fetch relays");
     const data = await res.json();
     return Array.isArray(data.relays) ? data.relays : [];
@@ -17,7 +19,7 @@ export const fetchRelays = async (): Promise<Relay[]> => {
 
 export const addRelay = async (inboxUrl: string): Promise<Relay | null> => {
   try {
-    const res = await fetch("/api/relays", {
+    const res = await apiFetch("/api/relays", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ inboxUrl }),
@@ -32,7 +34,7 @@ export const addRelay = async (inboxUrl: string): Promise<Relay | null> => {
 
 export const deleteRelay = async (id: string): Promise<boolean> => {
   try {
-    const res = await fetch(`/api/relays/${id}`, { method: "DELETE" });
+    const res = await apiFetch(`/api/relays/${id}`, { method: "DELETE" });
     return res.ok;
   } catch (err) {
     console.error("Error deleting relay:", err);

--- a/app/client/src/components/e2ee/api.ts
+++ b/app/client/src/components/e2ee/api.ts
@@ -1,3 +1,5 @@
+import { apiFetch } from "../../utils/config.ts";
+
 export interface KeyPackage {
   id: string;
   type: "KeyPackage";
@@ -23,7 +25,7 @@ export const fetchKeyPackages = async (
 ): Promise<KeyPackage[]> => {
   try {
     const identifier = domain ? `${user}@${domain}` : user;
-    const res = await fetch(
+    const res = await apiFetch(
       `/api/users/${encodeURIComponent(identifier)}/keyPackages`,
     );
     if (!res.ok) {
@@ -42,7 +44,7 @@ export const addKeyPackage = async (
   pkg: { content: string; mediaType?: string; encoding?: string },
 ): Promise<string | null> => {
   try {
-    const res = await fetch(
+    const res = await apiFetch(
       `/api/users/${encodeURIComponent(user)}/keyPackages`,
       {
         method: "POST",
@@ -64,7 +66,7 @@ export const deleteKeyPackage = async (
   keyId: string,
 ): Promise<boolean> => {
   try {
-    const res = await fetch(
+    const res = await apiFetch(
       `/api/users/${encodeURIComponent(user)}/keyPackages/${
         encodeURIComponent(keyId)
       }`,
@@ -87,11 +89,14 @@ export const sendEncryptedMessage = async (
   },
 ): Promise<boolean> => {
   try {
-    const res = await fetch(`/api/users/${encodeURIComponent(user)}/messages`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(data),
-    });
+    const res = await apiFetch(
+      `/api/users/${encodeURIComponent(user)}/messages`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(data),
+      },
+    );
     return res.ok;
   } catch (err) {
     console.error("Error sending message:", err);
@@ -107,7 +112,7 @@ export const fetchEncryptedMessages = async (
     const url = `/api/users/${encodeURIComponent(user)}/messages${
       partner ? `?with=${encodeURIComponent(partner)}` : ""
     }`;
-    const res = await fetch(url);
+    const res = await apiFetch(url);
     if (!res.ok) {
       throw new Error("Failed to fetch messages");
     }
@@ -139,7 +144,7 @@ export const sendPublicMessage = async (
   },
 ): Promise<boolean> => {
   try {
-    const res = await fetch(
+    const res = await apiFetch(
       `/api/users/${encodeURIComponent(user)}/publicMessages`,
       {
         method: "POST",
@@ -162,7 +167,7 @@ export const fetchPublicMessages = async (
     const url = `/api/users/${encodeURIComponent(user)}/publicMessages${
       partner ? `?with=${encodeURIComponent(partner)}` : ""
     }`;
-    const res = await fetch(url);
+    const res = await apiFetch(url);
     if (!res.ok) {
       throw new Error("Failed to fetch public messages");
     }

--- a/app/client/src/components/home/NotificationsContent.tsx
+++ b/app/client/src/components/home/NotificationsContent.tsx
@@ -1,9 +1,10 @@
 import { Component, createResource, createSignal, For, Show } from "solid-js";
 import type { Notification } from "./types.ts";
+import { apiFetch } from "../../utils/config.ts";
 
 const fetchNotifications = async (): Promise<Notification[]> => {
   try {
-    const res = await fetch("/api/notifications");
+    const res = await apiFetch("/api/notifications");
     if (!res.ok) {
       throw new Error(`HTTP error! status: ${res.status}`);
     }
@@ -22,7 +23,7 @@ const NotificationsContent: Component = () => {
 
   const markAsRead = async (id: string) => {
     try {
-      const res = await fetch(`/api/notifications/${id}/read`, {
+      const res = await apiFetch(`/api/notifications/${id}/read`, {
         method: "PATCH",
       });
       if (!res.ok) throw new Error("Failed to mark as read");
@@ -40,7 +41,9 @@ const NotificationsContent: Component = () => {
     setDeletingIds(new Set([...currentDeleting, id]));
 
     try {
-      const res = await fetch(`/api/notifications/${id}`, { method: "DELETE" });
+      const res = await apiFetch(`/api/notifications/${id}`, {
+        method: "DELETE",
+      });
       if (!res.ok) throw new Error("Failed to delete notification");
 
       mutate((prev) => prev?.filter((n) => n.id !== id) || []);
@@ -60,7 +63,7 @@ const NotificationsContent: Component = () => {
     try {
       await Promise.all(
         list.map((n) =>
-          fetch(`/api/notifications/${n.id}`, { method: "DELETE" })
+          apiFetch(`/api/notifications/${n.id}`, { method: "DELETE" })
         ),
       );
       mutate([]);

--- a/app/client/src/components/home/UnifiedToolsContent.tsx
+++ b/app/client/src/components/home/UnifiedToolsContent.tsx
@@ -7,6 +7,7 @@ import {
 } from "solid-js";
 import { useAtom } from "solid-jotai";
 import { activeAccount, activeAccountId } from "../../states/account.ts";
+import { apiFetch, getOrigin } from "../../utils/config.ts";
 
 export interface User {
   id: string;
@@ -179,7 +180,7 @@ export default function UnifiedToolsContent() {
     if (!id) return;
     (async () => {
       try {
-        const res = await fetch(`/api/accounts/${id}/following`);
+        const res = await apiFetch(`/api/accounts/${id}/following`);
         if (res.ok) {
           const data = await res.json();
           const map: Record<string, boolean> = {};
@@ -237,7 +238,7 @@ export default function UnifiedToolsContent() {
     async (url) => {
       if (!url) return [] as SearchResult[];
       try {
-        const res = await fetch(url);
+        const res = await apiFetch(url);
         if (!res.ok) return [] as SearchResult[];
         return await res.json();
       } catch {
@@ -280,7 +281,7 @@ export default function UnifiedToolsContent() {
             title: user.displayName,
             subtitle: `@${user.username}`,
             actor: localActor(user.username),
-            origin: globalThis.location.host,
+            origin: new URL(getOrigin()).host,
             metadata: {
               followers: user.followerCount,
             },
@@ -308,7 +309,7 @@ export default function UnifiedToolsContent() {
             id: community.id,
             title: community.name,
             subtitle: community.description,
-            origin: globalThis.location.host,
+            origin: new URL(getOrigin()).host,
             metadata: {
               members: community.memberCount,
             },
@@ -335,15 +336,14 @@ export default function UnifiedToolsContent() {
   const searchResults = () => getFilteredResults();
 
   const localActor = (name: string) => {
-    const { protocol, host } = globalThis.location;
-    return `${protocol}//${host}/users/${name}`;
+    return `${getOrigin()}/users/${name}`;
   };
 
   // フォロー関連の処理
   const handleFollow = async (actor: string, userId?: string) => {
     try {
       if (selectedAccountId()) {
-        await fetch(`/api/accounts/${selectedAccountId()}/follow`, {
+        await apiFetch(`/api/accounts/${selectedAccountId()}/follow`, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
@@ -374,7 +374,7 @@ export default function UnifiedToolsContent() {
   const handleUnfollow = async (actor: string, userId?: string) => {
     try {
       if (selectedAccountId()) {
-        await fetch(`/api/accounts/${selectedAccountId()}/follow`, {
+        await apiFetch(`/api/accounts/${selectedAccountId()}/follow`, {
           method: "DELETE",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ target: actor }),

--- a/app/client/src/components/microblog/Post.tsx
+++ b/app/client/src/components/microblog/Post.tsx
@@ -1,5 +1,6 @@
 import { createResource, createSignal, For } from "solid-js";
 import { sanitizeHTML } from "../../utils/sanitize.ts";
+import { getDomain } from "../../utils/config.ts";
 import type { MicroblogPost } from "./types.ts";
 import { UserAvatar } from "./UserAvatar.tsx";
 import {
@@ -51,7 +52,7 @@ function formatUserInfo(post: MicroblogPost) {
   }
 
   // 自サーバーのドメインかどうかを判定（実際のサーバードメインに置き換えてください）
-  const isLocalUser = !domain || domain === globalThis.location?.hostname ||
+  const isLocalUser = !domain || domain === getDomain() ||
     domain === "localhost";
 
   return {

--- a/app/client/src/components/microblog/api.ts
+++ b/app/client/src/components/microblog/api.ts
@@ -1,4 +1,5 @@
 import type { ActivityPubObject, MicroblogPost, Story } from "./types.ts";
+import { apiFetch } from "../../utils/config.ts";
 
 /**
  * ActivityPub Object（Note, Story, etc.）を取得
@@ -13,7 +14,7 @@ export const fetchActivityPubObjects = async (
         encodeURIComponent(type)
       }`
       : `/users/${encodeURIComponent(username)}/outbox`;
-    const response = await fetch(url);
+    const response = await apiFetch(url);
     if (!response.ok) {
       throw new Error("Failed to fetch ActivityPub objects");
     }
@@ -39,7 +40,7 @@ export const fetchActivityPubObjects = async (
 
 export const fetchPosts = async (): Promise<MicroblogPost[]> => {
   try {
-    const response = await fetch("/api/microblog");
+    const response = await apiFetch("/api/microblog");
     if (!response.ok) {
       throw new Error("Failed to fetch posts");
     }
@@ -54,7 +55,7 @@ export const fetchFollowingPosts = async (
   username: string,
 ): Promise<MicroblogPost[]> => {
   try {
-    const response = await fetch(`/api/users/${username}/timeline`);
+    const response = await apiFetch(`/api/users/${username}/timeline`);
     if (!response.ok) {
       throw new Error("Failed to fetch following posts");
     }
@@ -67,7 +68,7 @@ export const fetchFollowingPosts = async (
 
 export const fetchCommunities = async () => {
   try {
-    const response = await fetch("/api/communities");
+    const response = await apiFetch("/api/communities");
     if (!response.ok) {
       throw new Error("Failed to fetch communities");
     }
@@ -87,7 +88,7 @@ export const createCommunity = async (data: {
   banner?: string;
 }) => {
   try {
-    const response = await fetch("/api/communities", {
+    const response = await apiFetch("/api/communities", {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -103,7 +104,7 @@ export const createCommunity = async (data: {
 
 export const joinCommunity = async (communityId: string, username: string) => {
   try {
-    const response = await fetch(`/api/communities/${communityId}/join`, {
+    const response = await apiFetch(`/api/communities/${communityId}/join`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -119,7 +120,7 @@ export const joinCommunity = async (communityId: string, username: string) => {
 
 export const leaveCommunity = async (communityId: string, username: string) => {
   try {
-    const response = await fetch(`/api/communities/${communityId}/leave`, {
+    const response = await apiFetch(`/api/communities/${communityId}/leave`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -135,7 +136,7 @@ export const leaveCommunity = async (communityId: string, username: string) => {
 
 export const fetchCommunityPosts = async (communityId: string) => {
   try {
-    const response = await fetch(`/api/communities/${communityId}/posts`);
+    const response = await apiFetch(`/api/communities/${communityId}/posts`);
     if (!response.ok) {
       throw new Error("Failed to fetch community posts");
     }
@@ -152,7 +153,7 @@ export const createCommunityPost = async (
   author: string,
 ) => {
   try {
-    const response = await fetch(`/api/communities/${communityId}/posts`, {
+    const response = await apiFetch(`/api/communities/${communityId}/posts`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -171,7 +172,7 @@ export const likeCommunityPost = async (
   postId: string,
 ) => {
   try {
-    const response = await fetch(
+    const response = await apiFetch(
       `/api/communities/${communityId}/posts/${postId}/like`,
       {
         method: "POST",
@@ -188,7 +189,7 @@ export const likeCommunityPost = async (
 
 export const searchUsers = async (query: string) => {
   try {
-    const response = await fetch(
+    const response = await apiFetch(
       `/api/users/search?q=${encodeURIComponent(query)}`,
     );
     if (!response.ok) {
@@ -206,7 +207,7 @@ export const followUser = async (
   followerUsername: string,
 ) => {
   try {
-    const response = await fetch(`/api/users/${username}/follow`, {
+    const response = await apiFetch(`/api/users/${username}/follow`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -225,7 +226,7 @@ export const unfollowUser = async (
   followerUsername: string,
 ) => {
   try {
-    const response = await fetch(`/api/users/${username}/unfollow`, {
+    const response = await apiFetch(`/api/users/${username}/unfollow`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -244,7 +245,7 @@ export const createPost = async (
   author: string,
 ): Promise<boolean> => {
   try {
-    const response = await fetch("/api/microblog", {
+    const response = await apiFetch("/api/microblog", {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -263,7 +264,7 @@ export const updatePost = async (
   content: string,
 ): Promise<boolean> => {
   try {
-    const response = await fetch(`/api/microblog/${id}`, {
+    const response = await apiFetch(`/api/microblog/${id}`, {
       method: "PUT",
       headers: {
         "Content-Type": "application/json",
@@ -279,7 +280,7 @@ export const updatePost = async (
 
 export const deletePost = async (id: string): Promise<boolean> => {
   try {
-    const response = await fetch(`/api/microblog/${id}`, {
+    const response = await apiFetch(`/api/microblog/${id}`, {
       method: "DELETE",
     });
     return response.ok;
@@ -294,7 +295,7 @@ export const likePost = async (
   username: string,
 ): Promise<number | null> => {
   try {
-    const response = await fetch(`/api/microblog/${id}/like`, {
+    const response = await apiFetch(`/api/microblog/${id}/like`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ username }),
@@ -310,7 +311,7 @@ export const likePost = async (
 
 export const retweetPost = async (id: string): Promise<number | null> => {
   try {
-    const response = await fetch(`/api/microblog/${id}/retweet`, {
+    const response = await apiFetch(`/api/microblog/${id}/retweet`, {
       method: "POST",
     });
     if (!response.ok) return null;
@@ -327,7 +328,7 @@ export const _replyToPost = async (
   content: string,
 ): Promise<boolean> => {
   try {
-    const response = await fetch("/api/microblog", {
+    const response = await apiFetch("/api/microblog", {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -343,7 +344,7 @@ export const _replyToPost = async (
 
 export const fetchStories = async (): Promise<Story[]> => {
   try {
-    const response = await fetch("/api/stories");
+    const response = await apiFetch("/api/stories");
     if (!response.ok) {
       throw new Error("Failed to fetch stories");
     }
@@ -362,7 +363,7 @@ export const createStory = async (
   textColor?: string,
 ): Promise<boolean> => {
   try {
-    const response = await fetch("/api/stories", {
+    const response = await apiFetch("/api/stories", {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -385,7 +386,7 @@ export const createStory = async (
 
 export const viewStory = async (id: string): Promise<boolean> => {
   try {
-    const response = await fetch(`/api/stories/${id}/view`, {
+    const response = await apiFetch(`/api/stories/${id}/view`, {
       method: "POST",
     });
     return response.ok;
@@ -397,7 +398,7 @@ export const viewStory = async (id: string): Promise<boolean> => {
 
 export const deleteStory = async (id: string): Promise<boolean> => {
   try {
-    const response = await fetch(`/api/stories/${id}`, {
+    const response = await apiFetch(`/api/stories/${id}`, {
       method: "DELETE",
     });
     return response.ok;
@@ -410,7 +411,9 @@ export const deleteStory = async (id: string): Promise<boolean> => {
 // ユーザー情報を取得
 export const fetchUserProfile = async (username: string) => {
   try {
-    const response = await fetch(`/api/users/${encodeURIComponent(username)}`);
+    const response = await apiFetch(
+      `/api/users/${encodeURIComponent(username)}`,
+    );
     if (!response.ok) {
       throw new Error("Failed to fetch user profile");
     }
@@ -464,7 +467,7 @@ export const fetchUserInfo = async (
       return cached;
     }
 
-    const response = await fetch(
+    const response = await apiFetch(
       `/api/user-info/${encodeURIComponent(identifier)}`,
     );
     if (!response.ok) {
@@ -504,7 +507,7 @@ export const fetchUserInfoBatch = async (
     // キャッシュにないものをAPIから取得
     let fetchedInfos: UserInfo[] = [];
     if (uncached.length > 0) {
-      const response = await fetch("/api/user-info/batch", {
+      const response = await apiFetch("/api/user-info/batch", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -552,7 +555,7 @@ export const fetchActivityPubActor = async (actorUrl: string) => {
     }
 
     // プロキシ経由でActivityPubアクターを取得
-    const response = await fetch(
+    const response = await apiFetch(
       `/api/activitypub/actor-proxy?url=${encodeURIComponent(actorUrl)}`,
     );
     if (!response.ok) {
@@ -588,7 +591,7 @@ export const fetchActivityPubActor = async (actorUrl: string) => {
 // 指定ユーザーのフォロワー一覧を取得
 export const fetchFollowers = async (username: string) => {
   try {
-    const res = await fetch(
+    const res = await apiFetch(
       `/api/users/${encodeURIComponent(username)}/followers`,
     );
     if (!res.ok) throw new Error("Failed to fetch followers");
@@ -602,7 +605,7 @@ export const fetchFollowers = async (username: string) => {
 // 指定ユーザーのフォロー中一覧を取得
 export const fetchFollowing = async (username: string) => {
   try {
-    const res = await fetch(
+    const res = await apiFetch(
       `/api/users/${encodeURIComponent(username)}/following`,
     );
     if (!res.ok) throw new Error("Failed to fetch following");

--- a/app/client/src/components/videos/api.ts
+++ b/app/client/src/components/videos/api.ts
@@ -1,8 +1,9 @@
 import type { Video } from "./types.ts";
+import { apiFetch } from "../../utils/config.ts";
 
 export const fetchVideos = async (): Promise<Video[]> => {
   try {
-    const res = await fetch("/api/videos");
+    const res = await apiFetch("/api/videos");
     if (!res.ok) throw new Error("Failed to fetch videos");
     return await res.json();
   } catch (err) {
@@ -21,7 +22,7 @@ export const createVideo = async (
   } & { author: string },
 ): Promise<Video | null> => {
   try {
-    const res = await fetch("/api/videos", {
+    const res = await apiFetch("/api/videos", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(data),
@@ -36,7 +37,7 @@ export const createVideo = async (
 
 export const likeVideo = async (id: string): Promise<number | null> => {
   try {
-    const res = await fetch(`/api/videos/${id}/like`, { method: "POST" });
+    const res = await apiFetch(`/api/videos/${id}/like`, { method: "POST" });
     if (!res.ok) return null;
     const data = await res.json();
     return typeof data.likes === "number" ? data.likes : null;
@@ -48,7 +49,7 @@ export const likeVideo = async (id: string): Promise<number | null> => {
 
 export const addView = async (id: string): Promise<number | null> => {
   try {
-    const res = await fetch(`/api/videos/${id}/view`, { method: "POST" });
+    const res = await apiFetch(`/api/videos/${id}/view`, { method: "POST" });
     if (!res.ok) return null;
     const data = await res.json();
     return typeof data.views === "number" ? data.views : null;

--- a/app/client/src/utils/config.ts
+++ b/app/client/src/utils/config.ts
@@ -1,0 +1,24 @@
+export const API_BASE = import.meta.env.VITE_API_BASE || "";
+
+export const ORIGIN = API_BASE
+  ? new URL(API_BASE).origin
+  : globalThis.location.origin;
+
+export const DOMAIN = import.meta.env.VITE_ACTIVITYPUB_DOMAIN ||
+  new URL(ORIGIN).hostname;
+
+export function apiUrl(path: string): string {
+  return API_BASE ? `${API_BASE}${path}` : path;
+}
+
+export function apiFetch(path: string, init?: RequestInit) {
+  return fetch(apiUrl(path), init);
+}
+
+export function getDomain(): string {
+  return DOMAIN;
+}
+
+export function getOrigin(): string {
+  return ORIGIN;
+}


### PR DESCRIPTION
## Summary
- API ベース URL を設定できる `apiFetch` 関数を追加
- 各コンポーネントの fetch 呼び出しを `apiFetch` へ変更
- ドメイン取得に `getDomain` を使用し Tauri でも動作するよう調整

## Testing
- `deno fmt`
- `deno lint`


------
https://chatgpt.com/codex/tasks/task_e_686d9ac5ec048328be318dda58e70266