### PR TITLE
Fix regex injection in search API

### DIFF
--- a/app/api/search.ts
+++ b/app/api/search.ts
@@ -19,6 +19,10 @@ interface SearchResult {
 const app = new Hono();
 app.use("*", authRequired);
 
+function escapeRegex(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 app.get("/search", async (c) => {
   let q = c.req.query("q")?.trim();
   const type = c.req.query("type") ?? "all";
@@ -33,7 +37,7 @@ app.get("/search", async (c) => {
     }
   }
 
-  const regex = new RegExp(q, "i");
+  const regex = new RegExp(escapeRegex(q), "i");
   const results: SearchResult[] = [];
 
   if (type === "all" || type === "users") {


### PR DESCRIPTION
## Summary
- sanitize query string in search API to prevent regex injection

## Testing
- `deno fmt app/api/search.ts`
- `deno lint app/api/search.ts`


------
https://chatgpt.com/codex/tasks/task_e_686ded5536d48328be2bd4dccb3ed827