### PR TITLE
動画投稿をActivityPubで配信

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,15 @@ deno task dev
 - `POST /api/microblog/:id/like` – いいねを追加
 - `POST /api/microblog/:id/retweet` – リツイートを追加
 
+## 動画 API
+
+ActivityPub の `Video` オブジェクトを利用して動画を投稿できます。
+
+- `GET /api/videos` – 動画一覧を取得
+- `POST /api/videos` – 動画を作成するとフォロワーへ `Create` Activity を配信
+- `POST /api/videos/:id/like` – いいね数を増加
+- `POST /api/videos/:id/view` – 再生数を増加
+
 ## グループ機能
 
 takos では ActivityPub の Group


### PR DESCRIPTION
## Summary
- 動画APIで Video オブジェクトを投稿した際にフォロワーへ Create Activity を配信
- Video API 追加の説明を README に追記

## Testing
- `deno fmt`
- `deno lint`


------
https://chatgpt.com/codex/tasks/task_e_686e135e10e8832883b8728da2e4e2b4