### PR TITLE
暗号化キー入力画面の分離

### DIFF
--- a/app/client/src/App.tsx
+++ b/app/client/src/App.tsx
@@ -1,8 +1,9 @@
 import { createEffect, onMount, Show } from "solid-js";
 import { useAtom } from "solid-jotai";
-import { loginState } from "./states/session.ts";
+import { encryptionKeyState, loginState } from "./states/session.ts";
 import { darkModeState, languageState } from "./states/settings.ts";
 import { LoginForm } from "./components/LoginForm.tsx";
+import { EncryptionKeyForm } from "./components/EncryptionKeyForm.tsx";
 import { Application } from "./components/Application.tsx";
 import { apiFetch } from "./utils/config.ts";
 import "./App.css";
@@ -10,6 +11,7 @@ import "./stylesheet.css";
 
 function App() {
   const [isLoggedIn, setIsLoggedIn] = useAtom(loginState);
+  const [encryptionKey] = useAtom(encryptionKeyState);
   const [darkMode, setDarkMode] = useAtom(darkModeState);
   const [language, setLanguage] = useAtom(languageState);
 
@@ -54,7 +56,12 @@ function App() {
       when={isLoggedIn()}
       fallback={<LoginForm onLoginSuccess={() => setIsLoggedIn(true)} />}
     >
-      <Application />
+      <Show
+        when={encryptionKey()}
+        fallback={<EncryptionKeyForm onComplete={() => {}} />}
+      >
+        <Application />
+      </Show>
     </Show>
   );
 }

--- a/app/client/src/components/Chat.tsx
+++ b/app/client/src/components/Chat.tsx
@@ -75,7 +75,7 @@ interface ChatRoom {
 export function Chat() {
   const [selectedRoom, setSelectedRoom] = useAtom(selectedRoomState); // グローバル状態を使用
   const [account] = useAtom(activeAccount);
-  const [encryptionKey] = useAtom(encryptionKeyState);
+  const [encryptionKey, setEncryptionKey] = useAtom(encryptionKeyState);
   const [newMessage, setNewMessage] = createSignal("");
   const [showRoomList, setShowRoomList] = createSignal(true); // モバイル用: 部屋リスト表示制御
   const [isMobile, setIsMobile] = createSignal(false); // モバイル判定
@@ -172,6 +172,11 @@ export function Chat() {
               const storedPair = JSON.parse(json) as StoredMLSKeyPair;
               pair = await importKeyPair(storedPair);
               await saveMLSKeyPair(user.id, storedPair);
+            } else {
+              alert("暗号化キーが正しくありません");
+              setEncryptionKey(null);
+              setIsGeneratingKeyPair(false);
+              return null;
             }
           } catch (err) {
             console.error("鍵ペアの復号に失敗しました", err);

--- a/app/client/src/components/EncryptionKeyForm.tsx
+++ b/app/client/src/components/EncryptionKeyForm.tsx
@@ -1,0 +1,74 @@
+import { createSignal, Show } from "solid-js";
+import { useAtom } from "solid-jotai";
+import { encryptionKeyState } from "../states/session.ts";
+
+interface EncryptionKeyFormProps {
+  onComplete: () => void;
+}
+
+export function EncryptionKeyForm(props: EncryptionKeyFormProps) {
+  const [key, setKey] = createSignal("");
+  const [error, setError] = createSignal("");
+  const [, setEncryptionKey] = useAtom(encryptionKeyState);
+  const [isLoading, setIsLoading] = createSignal(false);
+
+  const handleSubmit = (e: Event) => {
+    e.preventDefault();
+    setError("");
+    if (!key()) {
+      setError("暗号化キーを入力してください");
+      return;
+    }
+    setIsLoading(true);
+    setEncryptionKey(key());
+    props.onComplete();
+    setIsLoading(false);
+  };
+
+  return (
+    <div class="min-h-screen flex flex-col bg-[#181818] text-gray-100">
+      <main class="flex-grow flex items-center justify-center px-4 py-12">
+        <div class="w-full max-w-md bg-[#212121] p-8 rounded-lg shadow-xl">
+          <div class="mb-8 text-center">
+            <h2 class="text-2xl font-semibold mb-2 text-white">
+              暗号化キー入力
+            </h2>
+            <p class="text-gray-400">チャットの鍵復号に使用します</p>
+          </div>
+          <form onSubmit={handleSubmit} class="space-y-6">
+            <div>
+              <label
+                for="encryptionKey"
+                class="block text-sm font-medium text-gray-300 mb-2"
+              >
+                暗号化キー
+              </label>
+              <input
+                type="password"
+                id="encryptionKey"
+                value={key()}
+                onInput={(e) => setKey(e.currentTarget.value)}
+                class="w-full px-4 py-3 bg-gray-700 border border-gray-600 rounded-md text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 placeholder-gray-500 transition-colors"
+                disabled={isLoading()}
+                placeholder="暗号化キーを入力"
+                required
+              />
+            </div>
+            <Show when={error()}>
+              <p class="text-red-400 text-sm font-medium bg-red-900/30 p-3 rounded-md">
+                {error()}
+              </p>
+            </Show>
+            <button
+              type="submit"
+              class="w-full bg-blue-600 text-white py-3 px-4 rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-gray-800 transition-colors duration-200 disabled:opacity-60 disabled:cursor-not-allowed flex items-center justify-center"
+              disabled={isLoading()}
+            >
+              {isLoading() ? "設定中..." : "設定"}
+            </button>
+          </form>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/app/client/src/components/LoginForm.tsx
+++ b/app/client/src/components/LoginForm.tsx
@@ -1,7 +1,5 @@
 import { createSignal, Show } from "solid-js";
 import { apiFetch } from "../utils/config.ts";
-import { useAtom } from "solid-jotai";
-import { encryptionKeyState } from "../states/session.ts";
 
 interface LoginFormProps {
   onLoginSuccess: () => void;
@@ -9,10 +7,8 @@ interface LoginFormProps {
 
 export function LoginForm(props: LoginFormProps) {
   const [loginPassword, setLoginPassword] = createSignal("");
-  const [encryptionKey, setEncryptionKey] = createSignal("");
   const [error, setError] = createSignal("");
   const [isLoading, setIsLoading] = createSignal(false);
-  const [, setEncryptionKeyStateValue] = useAtom(encryptionKeyState);
 
   const handleLogin = async (e: Event) => {
     e.preventDefault();
@@ -20,10 +16,6 @@ export function LoginForm(props: LoginFormProps) {
 
     if (!loginPassword()) {
       setError("ログイン用パスワードを入力してください");
-      return;
-    }
-    if (!encryptionKey()) {
-      setError("暗号化キーを入力してください");
       return;
     }
 
@@ -40,7 +32,6 @@ export function LoginForm(props: LoginFormProps) {
 
       const results = await res.json();
       if (results.success) {
-        setEncryptionKeyStateValue(encryptionKey());
         props.onLoginSuccess();
       } else {
         setError(results.error || "ログインに失敗しました");
@@ -86,24 +77,6 @@ export function LoginForm(props: LoginFormProps) {
                 class="w-full px-4 py-3 bg-gray-700 border border-gray-600 rounded-md text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 placeholder-gray-500 transition-colors"
                 disabled={isLoading()}
                 placeholder="パスワードを入力"
-                required
-              />
-            </div>
-            <div>
-              <label
-                for="encryptionKey"
-                class="block text-sm font-medium text-gray-300 mb-2"
-              >
-                暗号化キー
-              </label>
-              <input
-                type="password"
-                id="encryptionKey"
-                value={encryptionKey()}
-                onInput={(e) => setEncryptionKey(e.currentTarget.value)}
-                class="w-full px-4 py-3 bg-gray-700 border border-gray-600 rounded-md text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 placeholder-gray-500 transition-colors"
-                disabled={isLoading()}
-                placeholder="暗号化キーを入力"
                 required
               />
             </div>


### PR DESCRIPTION
## 概要
- ログインフォームから暗号化キー欄を削除
- ログイン後に暗号化キーを入力する `EncryptionKeyForm` を追加
- App コンポーネントでログイン直後に暗号化キー入力を促すよう変更
- 鍵ペア復号失敗時はユーザーへ通知し再入力を要求
- `deno fmt` と `deno lint` を実行済み

## テスト
- `deno fmt`
- `deno lint`


------
https://chatgpt.com/codex/tasks/task_e_686e1d82f9548328b3738a1bcbef218e