### PR TITLE
暗号化キー用パスワードのハッシュを共通化

### DIFF
--- a/app/client/src/components/EncryptionKeyForm.tsx
+++ b/app/client/src/components/EncryptionKeyForm.tsx
@@ -5,7 +5,7 @@ import { activeAccount } from "../states/account.ts";
 import { resetKeyData } from "./e2ee/api.ts";
 import { deleteMLSDatabase } from "./e2ee/storage.ts";
 import { getDomain } from "../utils/config.ts";
-import { sha256 } from "../utils/crypto.ts";
+import { hashEncryptionPassword } from "../utils/crypto.ts";
 
 interface EncryptionKeyFormProps {
   onComplete: () => void;
@@ -26,7 +26,7 @@ export function EncryptionKeyForm(props: EncryptionKeyFormProps) {
       return;
     }
     setIsLoading(true);
-    const hashed = await sha256(key());
+    const hashed = await hashEncryptionPassword(key());
     setEncryptionKey(hashed);
     localStorage.setItem("encryptionKey", hashed);
     props.onComplete();

--- a/app/client/src/utils/crypto.ts
+++ b/app/client/src/utils/crypto.ts
@@ -73,3 +73,15 @@ export const sha256 = async (text: string): Promise<string> => {
     .map((b) => b.toString(16).padStart(2, "0"))
     .join("");
 };
+
+const ENCRYPTION_PASS_SALT = "takos";
+
+/**
+ * 暗号化キー用パスワードをハッシュ化する
+ * 別アカウントでも同一の入力で同じ値になるよう共通ソルトを利用
+ */
+export const hashEncryptionPassword = async (
+  password: string,
+): Promise<string> => {
+  return await sha256(ENCRYPTION_PASS_SALT + password);
+};


### PR DESCRIPTION
## Summary
- 暗号化キー入力処理で利用するハッシュを共通ソルト付きに変更
- ソルトを追加した `hashEncryptionPassword` を実装し各フォームで利用

## Testing
- `deno fmt app/client/src/utils/crypto.ts app/client/src/components/EncryptionKeyForm.tsx`
- `deno lint app/client/src/utils/crypto.ts app/client/src/components/EncryptionKeyForm.tsx`


------
https://chatgpt.com/codex/tasks/task_e_686fe9c1b88483289ce0b9439db25b5b