### PR TITLE
オブジェクトストレージ機能拡充

### DIFF
--- a/app/api/.env.example
+++ b/app/api/.env.example
@@ -4,5 +4,20 @@ salt=88fffa6cabe7f4ae67fb0d1ba8eab619
 ACTIVITYPUB_DOMAIN=dev.takos.jp
 REGISTRY_URL=http://localhost:8080/_takopack
 
+# オブジェクトストレージの設定
+# どのプロバイダを使用するか選択します: "local", "s3", "r2", "minio", "gridfs"
+OBJECT_STORAGE_PROVIDER=local
+# local を使用する場合の保存先ディレクトリ
+LOCAL_STORAGE_DIR=uploads
+# s3 系を使用する場合の設定
+S3_BUCKET=your-bucket
+S3_REGION=ap-northeast-1
+S3_ENDPOINT=
+S3_FORCE_PATH_STYLE=false
+S3_ACCESS_KEY=
+S3_SECRET_KEY=
+# GridFS を使用する場合の設定
+GRIDFS_BUCKET=uploads
+
 FIREBASE_SERVICE_ACCOUNT={"type":"service_account","project_id":"your-project-id","private_key_id":"your_private_key_id","private_key":"-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n","client_email":"firebase-adminsdk-xxxx@your-project-id.iam.gserviceaccount.com","client_id":"123456789012345678901","auth_uri":"https://accounts.google.com/o/oauth2/auth","token_uri":"https://oauth2.googleapis.com/token","auth_provider_x509_cert_url":"https://www.googleapis.com/oauth2/v1/certs","client_x509_cert_url":"https://www.googleapis.com/robot/v1/metadata/x509/firebase-adminsdk-xxxx%40your-project-id.iam.gserviceaccount.com","universe_domain":"googleapis.com"}
 FIREBASE_CLIENT_CONFIG={"project_info":{"project_number":"123456789012","project_id":"your-project-id","storage_bucket":"your-project-id.appspot.com"},"client":[{"client_info":{"mobilesdk_app_id":"1:123456789012:android:abcdef1234567890abcdef","android_client_info":{"package_name":"com.example.app"}},"oauth_client":[],"api_key":[{"current_key":"your_api_key"}],"services":{"appinvite_service":{"other_platform_oauth_client":[]}}}],"configuration_version":"1"}

--- a/app/api/deno.json
+++ b/app/api/deno.json
@@ -6,7 +6,9 @@
     "@std/path": "jsr:@std/path@^1.1.0",
     "hono": "npm:hono@^4.7.11",
     "mongoose": "npm:mongoose@^8.15.1",
-    "zod": "npm:zod@^3.25.56"
+    "zod": "npm:zod@^3.25.56",
+    "@aws-sdk/client-s3": "npm:@aws-sdk/client-s3@^3.528.0",
+    "mongodb": "npm:mongodb@^6.17.0"
   },
   "tasks": {
     "dev": "deno run -A --unstable-worker-options --watch --no-prompt index.ts"

--- a/app/api/services/object-storage.ts
+++ b/app/api/services/object-storage.ts
@@ -1,0 +1,165 @@
+export interface ObjectStorage {
+  put(key: string, data: Uint8Array): Promise<string>;
+  get(key: string): Promise<Uint8Array | null>;
+  delete(key: string): Promise<void>;
+}
+
+import { ensureDir } from "@std/fs";
+import { join } from "@std/path";
+import { env } from "../utils/env.ts";
+
+import {
+  DeleteObjectCommand,
+  GetObjectCommand,
+  PutObjectCommand,
+  S3Client,
+} from "@aws-sdk/client-s3";
+
+export class LocalStorage implements ObjectStorage {
+  constructor(private baseDir: string) {}
+
+  async put(key: string, data: Uint8Array): Promise<string> {
+    const filePath = join(this.baseDir, key);
+    await ensureDir(this.baseDir);
+    await Deno.writeFile(filePath, data);
+    return filePath;
+  }
+
+  async get(key: string): Promise<Uint8Array | null> {
+    const filePath = join(this.baseDir, key);
+    try {
+      return await Deno.readFile(filePath);
+    } catch {
+      return null;
+    }
+  }
+
+  async delete(key: string): Promise<void> {
+    const filePath = join(this.baseDir, key);
+    await Deno.remove(filePath).catch(() => {});
+  }
+}
+
+export class S3Storage implements ObjectStorage {
+  private client: S3Client;
+  constructor(
+    private bucket: string,
+    region: string,
+    accessKey: string,
+    secretKey: string,
+    private endpoint?: string,
+    private forcePathStyle = false,
+  ) {
+    this.client = new S3Client({
+      region,
+      credentials: { accessKeyId: accessKey, secretAccessKey: secretKey },
+      endpoint: endpoint || undefined,
+      forcePathStyle,
+    });
+  }
+
+  async put(key: string, data: Uint8Array): Promise<string> {
+    await this.client.send(
+      new PutObjectCommand({
+        Bucket: this.bucket,
+        Key: key,
+        Body: data,
+      }),
+    );
+    if (this.endpoint) {
+      const base = this.endpoint.replace(/\/$/, "");
+      const prefix = this.forcePathStyle ? `${base}/${this.bucket}` : base;
+      return `${prefix}/${key}`;
+    }
+    return `https://${this.bucket}.s3.${this.client.config.region}.amazonaws.com/${key}`;
+  }
+
+  async get(key: string): Promise<Uint8Array | null> {
+    const res = await this.client.send(
+      new GetObjectCommand({ Bucket: this.bucket, Key: key }),
+    );
+    if (res.Body) {
+      const arrayBuffer = await res.Body.arrayBuffer();
+      return new Uint8Array(arrayBuffer);
+    }
+    return null;
+  }
+
+  async delete(key: string): Promise<void> {
+    await this.client.send(
+      new DeleteObjectCommand({ Bucket: this.bucket, Key: key }),
+    );
+  }
+}
+
+import mongoose from "mongoose";
+import { GridFSBucket } from "mongodb";
+import { once } from "node:events";
+import { Buffer } from "node:buffer";
+
+export class GridFSStorage implements ObjectStorage {
+  private bucket: GridFSBucket;
+  constructor(bucketName: string) {
+    this.bucket = new GridFSBucket(mongoose.connection.db, { bucketName });
+  }
+
+  async put(key: string, data: Uint8Array): Promise<string> {
+    const stream = this.bucket.openUploadStream(key);
+    stream.end(Buffer.from(data));
+    await once(stream, "finish");
+    return key;
+  }
+
+  async get(key: string): Promise<Uint8Array | null> {
+    const download = this.bucket.openDownloadStreamByName(key);
+    const chunks: Uint8Array[] = [];
+    try {
+      for await (const chunk of download) {
+        chunks.push(chunk as Buffer);
+      }
+      const size = chunks.reduce((s, c) => s + c.length, 0);
+      const data = new Uint8Array(size);
+      let offset = 0;
+      for (const chunk of chunks) {
+        data.set(chunk, offset);
+        offset += chunk.length;
+      }
+      return data;
+    } catch {
+      return null;
+    }
+  }
+
+  async delete(key: string): Promise<void> {
+    const files = await this.bucket.find({ filename: key }).toArray();
+    for (const file of files) {
+      await this.bucket.delete(file._id).catch(() => {});
+    }
+  }
+}
+
+export function createStorage(): ObjectStorage {
+  const provider = env["OBJECT_STORAGE_PROVIDER"] || "local";
+  if (provider === "s3" || provider === "r2" || provider === "minio") {
+    const bucket = env["S3_BUCKET"] || "";
+    const region = env["S3_REGION"] || "us-east-1";
+    const accessKey = env["S3_ACCESS_KEY"] || "";
+    const secretKey = env["S3_SECRET_KEY"] || "";
+    const endpoint = env["S3_ENDPOINT"] || undefined;
+    const forcePathStyle = env["S3_FORCE_PATH_STYLE"] === "true";
+    return new S3Storage(
+      bucket,
+      region,
+      accessKey,
+      secretKey,
+      endpoint,
+      forcePathStyle,
+    );
+  }
+  if (provider === "gridfs") {
+    const bucketName = env["GRIDFS_BUCKET"] || "uploads";
+    return new GridFSStorage(bucketName);
+  }
+  const dir = env["LOCAL_STORAGE_DIR"] || "uploads";
+  return new LocalStorage(dir);
+}


### PR DESCRIPTION
## Summary
- R2・MinIO・GridFS 用のストレージ実装を追加
- `.env.example` に各プロバイダの設定例を追記
- `deno.json` に `mongodb` 依存を登録

## Testing
- `deno fmt app/api/services/object-storage.ts app/api/.env.example app/api/deno.json`
- `deno lint app/api/services/object-storage.ts app/api/videos.ts`
- `deno cache -c app/api/deno.json app/api/services/object-storage.ts` *(fails: JSR package manifest failed to load)*

------
https://chatgpt.com/codex/tasks/task_e_68700b3945788328b169dbca94128178