### PR TITLE
ユーザーとフォロー情報の自動取得

### DIFF
--- a/app/client/src/components/home/AccountSettingsContent.tsx
+++ b/app/client/src/components/home/AccountSettingsContent.tsx
@@ -76,7 +76,7 @@ const AccountSettingsContent: Component<{
     },
   );
 
-  const [followers] = createResource(
+  const [followers, { refetch: refetchFollowers }] = createResource(
     () => selectedAccount()?.userName,
     async (username) => {
       if (!username) return [];
@@ -84,7 +84,7 @@ const AccountSettingsContent: Component<{
     },
   );
 
-  const [followingList] = createResource(
+  const [followingList, { refetch: refetchFollowing }] = createResource(
     () => selectedAccount()?.userName,
     async (username) => {
       if (!username) return [];
@@ -118,6 +118,9 @@ const AccountSettingsContent: Component<{
         setFollowingCount(0);
         setFollowerCount(0);
       });
+      // フォロー・フォロワー情報を事前に取得
+      refetchFollowers();
+      refetchFollowing();
     }
   });
 


### PR DESCRIPTION
## 概要
アカウント設定画面でアカウントを選択した際、フォロワー/フォロー一覧はモーダル表示時に初めて取得していました。これをアカウント選択時点で取得するよう変更しました。

## 変更点
- `AccountSettingsContent.tsx` で `createResource` の返り値から `refetch` を受け取り、アカウント変更時に実行
- ユーザー統計情報取得と合わせてフォロワー/フォロー情報を事前に取得する処理を追加

## テスト
- `deno fmt app/client/src/components/home/AccountSettingsContent.tsx`
- `deno lint app/client/src/components/home/AccountSettingsContent.tsx`


------
https://chatgpt.com/codex/tasks/task_e_687016629d108328b060d98e7e95b28d