### PR TITLE
Fix relay follow

### DIFF
--- a/app/api/relays.ts
+++ b/app/api/relays.ts
@@ -1,7 +1,13 @@
 import { Hono } from "hono";
 import Relay from "./models/relay.ts";
 import authRequired from "./utils/auth.ts";
-import { jsonResponse } from "./utils/activitypub.ts";
+import {
+  createFollowActivity,
+  createUndoFollowActivity,
+  getDomain,
+  jsonResponse,
+  sendActivityPubObject,
+} from "./utils/activitypub.ts";
 
 const app = new Hono();
 app.use("*", authRequired);
@@ -21,6 +27,15 @@ app.post("/relays", async (c) => {
   if (exists) return jsonResponse(c, { error: "Already exists" }, 409);
   const relay = new Relay({ inboxUrl });
   await relay.save();
+  try {
+    const domain = getDomain(c);
+    const actorId = `https://${domain}/users/system`;
+    const target = inboxUrl.replace(/\/inbox$/, "");
+    const follow = createFollowActivity(domain, actorId, target);
+    await sendActivityPubObject(inboxUrl, follow, "system");
+  } catch (err) {
+    console.error("Failed to follow relay:", err);
+  }
   return jsonResponse(c, { id: String(relay._id), inboxUrl: relay.inboxUrl });
 });
 
@@ -28,6 +43,15 @@ app.delete("/relays/:id", async (c) => {
   const id = c.req.param("id");
   const relay = await Relay.findByIdAndDelete(id);
   if (!relay) return jsonResponse(c, { error: "Relay not found" }, 404);
+  try {
+    const domain = getDomain(c);
+    const actorId = `https://${domain}/users/system`;
+    const target = relay.inboxUrl.replace(/\/inbox$/, "");
+    const undo = createUndoFollowActivity(domain, actorId, target);
+    await sendActivityPubObject(relay.inboxUrl, undo, "system");
+  } catch (err) {
+    console.error("Failed to undo follow relay:", err);
+  }
   return jsonResponse(c, { success: true });
 });
 


### PR DESCRIPTION
## Summary
- リレーを追加した際、自動でFollowリクエストを送信
- リレー削除時にUndo Followを送信

## Testing
- `deno fmt`
- `deno lint`
- `deno test` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6870179896a88328b64736fd4d0b12f5