### PR TITLE
暗号化非対応ユーザーへの警告をポップアップ化

### DIFF
--- a/app/client/src/components/Chat.tsx
+++ b/app/client/src/components/Chat.tsx
@@ -479,6 +479,12 @@ export function Chat(props: ChatProps) {
     adjustHeight();
   });
 
+  createEffect(() => {
+    if (useEncryption() && !partnerHasKey()) {
+      alert("このユーザーは暗号化された会話に対応していません。");
+    }
+  });
+
   onCleanup(() => {
     globalThis.removeEventListener("resize", checkMobile);
     if (poller) clearInterval(poller);
@@ -694,13 +700,7 @@ export function Chat(props: ChatProps) {
                 >
                   <Show
                     when={useEncryption() ? partnerHasKey() : true}
-                    fallback={
-                      <div class="text-center py-4">
-                        <p class="text-gray-400 text-sm">
-                          このユーザーは暗号化された会話に対応していません。
-                        </p>
-                      </div>
-                    }
+                    fallback={null}
                   >
                     <form
                       class="p-talk-chat-send__form m-0"


### PR DESCRIPTION
## Summary
- 暗号化非対応ユーザーの場合に表示していた警告メッセージをポップアップ(アラート)で通知するよう変更
- 送信UIでは警告文を表示しないよう変更

## Testing
- `deno fmt app/client/src/components/Chat.tsx`
- `deno lint app/client/src/components/Chat.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68701de187f88328be3ef8da63a7701e