### PR TITLE
Fix relay registration when system actor missing

### DIFF
--- a/app/api/accounts.ts
+++ b/app/api/accounts.ts
@@ -86,6 +86,10 @@ app.post("/accounts", async (c) => {
     }, 400);
   }
 
+  if (username.trim() === "system") {
+    return jsonResponse(c, { error: "このユーザー名は使用できません" }, 400);
+  }
+
   // Check if username already exists
   const existingAccount = await Account.findOne({ userName: username.trim() });
   if (existingAccount) {


### PR DESCRIPTION
## Summary
- systemアカウントが存在しない場合は自動生成
- `/accounts` で `system` を利用不可に

## Testing
- `deno fmt app/api/accounts.ts app/api/relays.ts`
- `deno lint app/api/accounts.ts app/api/relays.ts`


------
https://chatgpt.com/codex/tasks/task_e_6870225fb0f88328950a23f23add7168