### PR TITLE
暗号化キー入力を設定画面へ移動

### DIFF
--- a/app/client/src/components/Application.tsx
+++ b/app/client/src/components/Application.tsx
@@ -43,7 +43,7 @@ export function Application(props: ApplicationProps) {
       <Header />
       <main class={wrapperClass()}>
         <Show when={selectedApp() === "home"}>
-          <Home />
+          <Home onShowEncryptionKeyForm={props.onShowEncryptionKeyForm} />
         </Show>
         <Show when={selectedApp() === "microblog"}>
           <Microblog />
@@ -61,16 +61,6 @@ export function Application(props: ApplicationProps) {
         <Show when={selectedApp() === "videos"}>
           <Videos />
         </Show>
-        {/* 暗号化キー再入力ボタン */}
-        <div class="flex justify-end p-4">
-          <button
-            type="button"
-            class="bg-blue-700 text-white px-4 py-2 rounded hover:bg-blue-800 transition"
-            onClick={() => props.onShowEncryptionKeyForm?.()}
-          >
-            暗号化キー再入力
-          </button>
-        </div>
       </main>
     </>
   );

--- a/app/client/src/components/Home.tsx
+++ b/app/client/src/components/Home.tsx
@@ -10,7 +10,11 @@ import {
   activeAccountId,
 } from "../states/account.ts";
 
-export function Home() {
+export interface HomeProps {
+  onShowEncryptionKeyForm?: () => void;
+}
+
+export function Home(props: HomeProps) {
   const [activeSection, setActiveSection] = createSignal("account");
 
   // スワイプ機能用の状態
@@ -268,7 +272,9 @@ export function Home() {
               </p>
             </div>
             <div class="max-w-4xl mx-auto">
-              <Setting />
+              <Setting
+                onShowEncryptionKeyForm={props.onShowEncryptionKeyForm}
+              />
             </div>
           </div>
         );

--- a/app/client/src/components/Setting/index.tsx
+++ b/app/client/src/components/Setting/index.tsx
@@ -2,7 +2,10 @@ import { useAtom } from "solid-jotai";
 import { darkModeState, languageState } from "../../states/settings.ts";
 import RelaySettings from "./RelaySettings.tsx";
 
-export function Setting() {
+export interface SettingProps {
+  onShowEncryptionKeyForm?: () => void;
+}
+export function Setting(props: SettingProps) {
   const [darkMode, setDarkMode] = useAtom(darkModeState);
   const [language, setLanguage] = useAtom(languageState);
 
@@ -31,6 +34,15 @@ export function Setting() {
         </select>
       </div>
       <RelaySettings />
+      <div class="flex justify-end">
+        <button
+          type="button"
+          class="bg-blue-700 text-white px-4 py-2 rounded hover:bg-blue-800 transition"
+          onClick={() => props.onShowEncryptionKeyForm?.()}
+        >
+          暗号化キー再入力
+        </button>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## 概要
- 暗号化キー再入力ボタンを `Application` から削除
- `Home` と `Setting` コンポーネントにプロパティを追加し、設定画面で再入力ボタンを表示

## 変更理由
暗号化キーの再入力操作を設定画面で行えるようにするため

## 動作確認
- `deno fmt` と `deno lint` を実行しエラーがないことを確認

------
https://chatgpt.com/codex/tasks/task_e_68702b02266c8328979d0ee60c318e20