### PR TITLE
WebSocket送信をチャンク化

### DIFF
--- a/app/client/src/components/videos/api.ts
+++ b/app/client/src/components/videos/api.ts
@@ -46,8 +46,12 @@ export const createVideo = (
             }),
           );
         } else if (msg.status === "ready for binary") {
-          const buf = await data.file.arrayBuffer();
-          ws.send(buf);
+          const chunkSize = 1024 * 512; // 512KB 程度
+          for (let offset = 0; offset < data.file.size; offset += chunkSize) {
+            const slice = data.file.slice(offset, offset + chunkSize);
+            const buf = await slice.arrayBuffer();
+            ws.send(buf);
+          }
           ws.close();
           uploaded = true;
         }


### PR DESCRIPTION
## Summary
- 動画ファイルを512KB単位で分割送信するよう更新

## Testing
- `deno fmt app/client/src/components/videos/api.ts`
- `deno lint app/client/src/components/videos/api.ts`


------
https://chatgpt.com/codex/tasks/task_e_68702f7f37c88328986f1d45d6094524