### PR TITLE
ActivityPubルートの認証解除

### DIFF
--- a/app/api/index.ts
+++ b/app/api/index.ts
@@ -40,9 +40,10 @@ app.route("/api", e2ee);
 app.route("/api", activitypub); // ActivityPubプロキシAPI用
 app.route("/api", group);
 app.route("/", nodeinfo);
-app.route("/", e2ee);
 app.route("/", activitypub);
 app.route("/", group);
 app.route("/", rootInbox);
+// e2ee アプリは最後に配置し、ActivityPub ルートへ認証不要でアクセスできるようにする
+app.route("/", e2ee);
 
 Deno.serve(app.fetch);


### PR DESCRIPTION
## 概要
リレーへのフォロー要求時に `https://dev.takos.jp/users/system#main-key` への取得が 401 となる問題を修正しました。`app/api/index.ts` で E2EE ルートが ActivityPub ルートより前に登録されていたため、未認証リクエストが 401 で遮断されていました。E2EE ルートを最後に移動し、コメントを追加しています。

## テスト
- `deno fmt` 実行
- `deno lint` 実行


------
https://chatgpt.com/codex/tasks/task_e_687030c36a088328945b3355a160a168