### PR TITLE
Load accounts when tools view mounted

### DIFF
--- a/app/client/src/components/Home.tsx
+++ b/app/client/src/components/Home.tsx
@@ -8,6 +8,7 @@ import { Setting } from "./Setting/index.tsx";
 import {
   accounts as accountsAtom,
   activeAccountId,
+  fetchAccounts,
 } from "../states/account.ts";
 
 export interface HomeProps {
@@ -87,8 +88,7 @@ export function Home(props: HomeProps) {
   // APIでアカウント一覧を取得
   const loadAccounts = async (preserveSelectedId?: string) => {
     try {
-      const response = await apiFetch("/api/accounts");
-      const results = await response.json();
+      const results = await fetchAccounts();
       setAccounts(results || []);
       if (preserveSelectedId) {
         const accountExists = results.some((acc: Account) =>

--- a/app/client/src/states/account.ts
+++ b/app/client/src/states/account.ts
@@ -1,4 +1,5 @@
 import { atom } from "solid-jotai";
+import { apiFetch } from "../utils/config.ts";
 
 export interface Account {
   id: string;
@@ -48,3 +49,12 @@ export const activeAccount = atom((get) => {
   if (!id) return null;
   return accs.find((a) => a.id === id) ?? null;
 });
+
+export async function fetchAccounts(): Promise<Account[]> {
+  try {
+    const res = await apiFetch("/api/accounts");
+    return await res.json();
+  } catch (_err) {
+    return [];
+  }
+}


### PR DESCRIPTION
## Summary
- クライアント状態 `account` に API から取得する関数 `fetchAccounts` を追加
- ホーム画面とツール画面のアカウント取得処理を `fetchAccounts` へ統一
- ツール画面表示時にアカウント情報を自動取得し未選択時は最初のアカウントを設定

## Testing
- `deno fmt app/client/src/components/Home.tsx app/client/src/components/home/UnifiedToolsContent.tsx app/client/src/states/account.ts`
- `deno lint app/client/src/components/Home.tsx app/client/src/components/home/UnifiedToolsContent.tsx app/client/src/states/account.ts`


------
https://chatgpt.com/codex/tasks/task_e_687032e6c56c83289cee9c445b3ccfb9