### PR TITLE
PWA 対応を追加

### DIFF
--- a/app/client/deno.json
+++ b/app/client/deno.json
@@ -29,6 +29,7 @@
     "tailwindcss": "npm:tailwindcss@^4.1.7",
     "vite": "npm:vite@^5.4.19",
     "vite-plugin-solid": "npm:vite-plugin-solid@^2.11.6",
+    "vite-plugin-pwa": "npm:vite-plugin-pwa@^1.0.1",
     "zod": "npm:zod@^3.24.4"
   },
   "nodeModulesDir": "auto"

--- a/app/client/index.html
+++ b/app/client/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="manifest" href="/manifest.json" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite + Solid + TS</title>
   </head>

--- a/app/client/public/manifest.json
+++ b/app/client/public/manifest.json
@@ -1,0 +1,20 @@
+{
+  "name": "Takos",
+  "short_name": "Takos",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#ffffff",
+  "icons": [
+    {
+      "src": "/vite.svg",
+      "sizes": "192x192",
+      "type": "image/svg+xml"
+    },
+    {
+      "src": "/vite.svg",
+      "sizes": "512x512",
+      "type": "image/svg+xml"
+    }
+  ]
+}

--- a/app/client/src/main.tsx
+++ b/app/client/src/main.tsx
@@ -1,6 +1,9 @@
 /* @refresh reload */
 import { render } from "solid-js/web";
+import { registerSW } from "virtual:pwa-register";
 
 import App from "./App.tsx";
 
 render(() => <App />, document.getElementById("root")!);
+// サービスワーカーを登録してPWAを有効化
+registerSW({ immediate: true });

--- a/app/client/vite.config.mts
+++ b/app/client/vite.config.mts
@@ -1,12 +1,14 @@
 import { defineConfig } from "vite";
 import solid from "vite-plugin-solid";
 import tailwindcss from "@tailwindcss/vite";
+import { VitePWA } from "vite-plugin-pwa";
 import process from "node:process";
 
 export default defineConfig({
   plugins: [
     solid(),
     tailwindcss(),
+    VitePWA({ registerType: "autoUpdate" }),
   ],
 
   clearScreen: false,


### PR DESCRIPTION
## Summary
- PWA 用の manifest を追加
- `vite-plugin-pwa` を導入してサービスワーカー登録
- `index.html` で manifest を読み込み
- `main.tsx` でサービスワーカーを登録

## Testing
- `deno fmt`
- `deno lint`


------
https://chatgpt.com/codex/tasks/task_e_687038e48dcc832887b655737605c040