### PR TITLE
Fix relay follow target

### DIFF
--- a/app/api/relays.ts
+++ b/app/api/relays.ts
@@ -79,7 +79,7 @@ app.post("/relays", async (c) => {
     }
     const domain = getDomain(c);
     const actorId = `https://${domain}/users/system`;
-    const target = inboxUrl.replace(/\/inbox$/, "");
+    const target = "https://www.w3.org/ns/activitystreams#Public";
     const follow = createFollowActivity(domain, actorId, target);
     await sendActivityPubObject(inboxUrl, follow, "system");
   } catch (err) {
@@ -109,7 +109,7 @@ app.delete("/relays/:id", async (c) => {
     }
     const domain = getDomain(c);
     const actorId = `https://${domain}/users/system`;
-    const target = relay.inboxUrl.replace(/\/inbox$/, "");
+    const target = "https://www.w3.org/ns/activitystreams#Public";
     const undo = createUndoFollowActivity(domain, actorId, target);
     await sendActivityPubObject(relay.inboxUrl, undo, "system");
   } catch (err) {


### PR DESCRIPTION
## Summary
- relay登録・解除時のFollowアクティビティの対象をPublicに修正

## Testing
- `deno fmt app/api/relays.ts`
- `deno lint app/api/relays.ts`


------
https://chatgpt.com/codex/tasks/task_e_6870423dec30832895844e6ddcaf3699