### PR TITLE
チャット一覧に最新メッセージを表示

### DIFF
--- a/app/client/src/stylesheet.css
+++ b/app/client/src/stylesheet.css
@@ -565,11 +565,20 @@ input {
   font-weight: 400;
   font-size: 12px;
   color: #aaaaaa; /* ホワイトモード廃止: 文字色変更 */
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
 }
 .c-talk-rooms-msg p {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+.c-talk-rooms-time {
+  font-size: 10px;
+  color: #888888;
+  margin-left: 4px;
+  white-space: nowrap;
 }
 .c-talk-chat {
   display: flex;


### PR DESCRIPTION
## 概要
- チャットルーム情報に `lastMessageTime` を追加
- メッセージ読み込み時に最新メッセージと時刻を保存
- 送信直後もサイドバーの内容を更新
- サイドバーの表示を調整し、時刻を表示するスタイルを追加

## テスト
- `deno fmt`
- `deno lint`


------
https://chatgpt.com/codex/tasks/task_e_687048ea744c83288ef474dfae0cc6ad