### PR TITLE
通知機能をイベント連動型に拡張

### DIFF
--- a/app/api/services/notification.ts
+++ b/app/api/services/notification.ts
@@ -1,0 +1,14 @@
+import Notification from "../models/notification.ts";
+
+/**
+ * 通知を追加するユーティリティ関数
+ */
+export async function addNotification(
+  title: string,
+  message: string,
+  type: string = "info",
+) {
+  const n = new Notification({ title, message, type });
+  await n.save();
+  return n;
+}


### PR DESCRIPTION
## 概要
- Notification モデルを利用したユーティリティ `addNotification` を追加
- いいねやフォローが行われた際に通知を生成するよう `microblog.ts` と `accounts.ts` を更新

## テスト
- `deno fmt app/api/notifications.ts app/api/microblog.ts app/api/accounts.ts app/api/services/notification.ts`
- `deno lint app/api/notifications.ts app/api/microblog.ts app/api/accounts.ts app/api/services/notification.ts`


------
https://chatgpt.com/codex/tasks/task_e_68705bcf589883288856ef4d52539745