### PR TITLE
microblog API pagination

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,9 @@ deno task dev
 
 簡単なテキスト投稿を行う `/api/microblog` エンドポイントも利用できます。
 
-- `GET /api/microblog` – 投稿を新しい順で取得
+- `GET /api/microblog` – 投稿を新しい順で取得。`page` と `limit` クエリ
+  パラメータでページネーションが可能です（デフォルト: `page=1`、`limit=20`、
+  最大100件まで）。
 - `POST /api/microblog` – 投稿を作成
   (`{ "author": "user", "content": "hello" }`)
 - `PUT /api/microblog/:id` – 投稿を更新 (`{ "content": "edited" }`)

--- a/app/api/microblog.ts
+++ b/app/api/microblog.ts
@@ -93,9 +93,14 @@ app.use("*", authRequired);
 
 app.get("/microblog", async (c) => {
   const domain = getDomain(c);
-  const list = await ActivityPubObject.find({ type: "Note" }).sort({
-    published: -1,
-  }).lean();
+  const page = parseInt(c.req.query("page") ?? "1", 10);
+  const limit = Math.min(parseInt(c.req.query("limit") ?? "20", 10), 100);
+  const skip = (page - 1) * limit;
+  const list = await ActivityPubObject.find({ type: "Note" })
+    .sort({ published: -1 })
+    .skip(skip)
+    .limit(limit)
+    .lean();
 
   // ユーザー情報をバッチで取得
   const identifiers = list.map((doc: ActivityPubObjectType) =>


### PR DESCRIPTION
## Summary
- add pagination parameters to GET /microblog in backend
- document pagination usage in README

## Testing
- `deno fmt app/api/microblog.ts`
- `deno fmt README.md`
- `deno lint app/api/microblog.ts README.md`


------
https://chatgpt.com/codex/tasks/task_e_6870e7a0a88c83288066f0ff6b8b5421