### PR TITLE
無限スクロール対応

### DIFF
--- a/app/client/src/components/microblog/api.ts
+++ b/app/client/src/components/microblog/api.ts
@@ -39,9 +39,17 @@ export const fetchActivityPubObjects = async (
   }
 };
 
-export const fetchPosts = async (): Promise<MicroblogPost[]> => {
+export const fetchPosts = async (
+  params?: { limit?: number; before?: string },
+): Promise<MicroblogPost[]> => {
   try {
-    const response = await apiFetch("/api/microblog");
+    const search = new URLSearchParams();
+    if (params?.limit) search.set("limit", String(params.limit));
+    if (params?.before) search.set("before", params.before);
+    const query = search.toString();
+    const response = await apiFetch(
+      `/api/microblog${query ? `?${query}` : ""}`,
+    );
     if (!response.ok) {
       throw new Error("Failed to fetch posts");
     }


### PR DESCRIPTION
## 概要
- `/api/microblog` に `limit` と `before` を追加してページネーションを実装
- 投稿取得APIをパラメータ対応に変更
- フロントエンドで読み込み件数設定と無限スクロールを実装

## 動作確認
- `deno fmt` と `deno lint` が正常終了することを確認

------
https://chatgpt.com/codex/tasks/task_e_6870e8e4ccfc8328932bbeb6adb9f587