### PR TITLE
Add microblog attachments and thread features

### DIFF
--- a/app/api/services/user-info.ts
+++ b/app/api/services/user-info.ts
@@ -319,6 +319,12 @@ export function formatUserInfoForPost(
       : (postData.extra as Record<string, unknown>)?.likes ?? 0,
     retweets: (postData.extra as Record<string, unknown>)?.retweets ?? 0,
     replies: (postData.extra as Record<string, unknown>)?.replies ?? 0,
+    attachments:
+      Array.isArray((postData.extra as Record<string, unknown>)?.attachments)
+        ? (postData.extra as Record<string, unknown>).attachments as unknown[]
+        : [],
+    parentId: (postData.extra as Record<string, unknown>)?.inReplyTo,
+    quoteId: (postData.extra as Record<string, unknown>)?.quoteId,
     domain: userInfo.domain,
   };
 }

--- a/app/client/src/components/microblog/api.ts
+++ b/app/client/src/components/microblog/api.ts
@@ -60,6 +60,19 @@ export const fetchPosts = async (
   }
 };
 
+export const fetchPostById = async (
+  id: string,
+): Promise<MicroblogPost | null> => {
+  try {
+    const res = await apiFetch(`/api/microblog/${id}`);
+    if (!res.ok) return null;
+    return await res.json();
+  } catch (error) {
+    console.error("Error fetching post:", error);
+    return null;
+  }
+};
+
 export const fetchFollowingPosts = async (
   username: string,
 ): Promise<MicroblogPost[]> => {
@@ -252,6 +265,9 @@ export const unfollowUser = async (
 export const createPost = async (
   content: string,
   author: string,
+  attachments?: { url: string; type: "image" | "video" | "audio" }[],
+  parentId?: string,
+  quoteId?: string,
 ): Promise<boolean> => {
   try {
     const response = await apiFetch("/api/microblog", {
@@ -259,7 +275,7 @@ export const createPost = async (
       headers: {
         "Content-Type": "application/json",
       },
-      body: JSON.stringify({ author, content }),
+      body: JSON.stringify({ author, content, attachments, parentId, quoteId }),
     });
     return response.ok;
   } catch (error) {

--- a/app/client/src/components/microblog/types.ts
+++ b/app/client/src/components/microblog/types.ts
@@ -11,9 +11,11 @@ export interface MicroblogPost {
   isLiked?: boolean;
   isRetweeted?: boolean;
   images?: string[];
+  attachments?: { url: string; type: "image" | "video" | "audio" }[];
   hashtags?: string[];
   mentions?: string[];
   parentId?: string; // 返信の場合の親投稿ID
+  quoteId?: string; // 引用元投稿ID
   domain?: string;
 }
 

--- a/app/client/src/utils/sanitize.ts
+++ b/app/client/src/utils/sanitize.ts
@@ -19,5 +19,10 @@ export function sanitizeHTML(html: string): string {
       }
     }
   }
-  return doc.body.innerHTML;
+  const cleaned = doc.body.innerHTML;
+  return cleaned.replace(
+    /(https?:\/\/[^\s]+)/g,
+    (m) =>
+      `<a href="${m}" class="text-blue-400 underline" target="_blank" rel="noopener noreferrer">${m}</a>`,
+  );
 }


### PR DESCRIPTION
## Summary
- マイクロブログ投稿に画像・動画・音声の添付を追加
- 返信・引用投稿の処理と取得APIを拡張
- 投稿表示で添付メディアと引用ツイートを表示
- URL を自動リンク化
- 投稿フォームを有効化し添付・返信・引用をサポート

## Testing
- `deno fmt`
- `deno lint`


------
https://chatgpt.com/codex/tasks/task_e_6870ebba009c832899d853faa019ceb9