### PR TITLE
リンクの自動変換処理を安全に改良

### DIFF
--- a/app/client/src/utils/linkify.ts
+++ b/app/client/src/utils/linkify.ts
@@ -1,25 +1,47 @@
+// マイクロブログの投稿テキスト中のURLを安全なリンクへ変換するユーティリティ
 
-const URL_PREFIX = /(^|\s|\u3000|[\(\[\{「『【〈《（])(https?:\/\/[^\s<>{}\[\]「」『』【】〈〉《》()]+)/giu;
+const URL_RE =
+  /(^|[\s\u3000(<{\[「『【〈《（])(?:https?:\/\/[^\s<>{}\[\]「」『』【】〈〉《》()]+?)(?=[\s\u3000)>}\]」』】〉》）.,!?。、・…]|$)/giu;
+
+function sanitizeUrl(raw: string): string {
+  let url = raw.replace(/[\u200B-\u200D\uFEFF]/g, "");
+
+  while (true) {
+    const last = url.slice(-1);
+    if (/[\)\]\}>」』】〉》）]/u.test(last)) {
+      url = url.slice(0, -1);
+      continue;
+    }
+    if (/[.,!?。、・…]/u.test(last) && url.slice(-2, -1) !== "/") {
+      url = url.slice(0, -1);
+      continue;
+    }
+    break;
+  }
+
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      return "";
+    }
+    // hostname を参照するだけで Punycode へ変換される
+    const _ = parsed.hostname;
+    return parsed.toString();
+  } catch {
+    return "";
+  }
+}
 
 export function linkify(text: string): string {
-  return text.replace(URL_PREFIX, (match, p1, url) => {
-    let cleanUrl = url;
-    // 末尾の句読点や閉じ括弧を削除
-    while (/[.,!?。、・…\)\]\}」』】〉》）]$/u.test(cleanUrl)) {
-      // ただし、URLの末尾がスラッシュで終わる場合は、その直前の句読点は削除しない
-      if (cleanUrl.endsWith('/') && /[.,!?。、・…]$/.test(cleanUrl.slice(0, -1))) {
-          break;
-      }
-      cleanUrl = cleanUrl.slice(0, -1);
-    }
-    
-    try {
-      // URLが有効かどうかの最終検証
-      new URL(cleanUrl);
-      return `${p1}<a href="${cleanUrl}" rel="noopener noreferrer" target="_blank">${cleanUrl}</a>`;
-    } catch (e) {
-      // 無効なURLの場合は、元のテキストをそのまま返す
-      return match;
-    }
+  if (text.length > 2 * 1024 * 1024) return text;
+
+  const re = new RegExp(URL_RE.source, "giu");
+  const matches = [...text.matchAll(re)];
+  if (matches.length > 10) return text;
+
+  return text.replace(re, (match, p1, url) => {
+    const safe = sanitizeUrl(url);
+    if (!safe) return match;
+    return `${p1}<a href="${safe}" rel="noopener noreferrer" target="_blank">${url}</a>`;
   });
 }

--- a/linkify_test.ts
+++ b/linkify_test.ts
@@ -1,0 +1,34 @@
+import {
+  assertEquals,
+  assertMatch,
+  assertStringIncludes,
+} from "https://deno.land/std@0.208.0/assert/mod.ts";
+import { linkify } from "./app/client/src/utils/linkify.ts";
+
+Deno.test("wraps basic URL", () => {
+  const result = linkify("Visit https://ex.com!");
+  assertStringIncludes(result, '<a href="https://ex.com"');
+});
+
+Deno.test("handles full-width brackets", () => {
+  const r = linkify("（https://例.jp）");
+  assertMatch(r, /<a href="https:\/\/xn--fsq.jp"/);
+});
+
+Deno.test("keeps trailing slash", () => {
+  const r = linkify("https://ex.com/");
+  assertStringIncludes(r, "ex.com/");
+});
+
+Deno.test("removes dangling punctuation", () => {
+  const r = linkify("https://ex.com,");
+  if (r.includes("<a")) {
+    const linkPart = r.match(/<a[^>]+>([^<]+)<\/a>/)?.[1] ?? "";
+    assertEquals(linkPart.endsWith(","), false);
+  }
+});
+
+Deno.test("rejects non-http schemes", () => {
+  const r = linkify("javascript:alert(1)");
+  assertEquals(r, "javascript:alert(1)");
+});


### PR DESCRIPTION
## 概要
- マイクロブログ投稿内のURLを安全にリンク化する `linkify` を改良
- URL検証を行う `sanitizeUrl` を実装し、危険なスキームを排除
- URLの候補が多すぎる場合は処理を中断
- 日本語を含むURLのPunycode変換に対応
- `linkify` のテストを追加

## テスト結果
- `deno fmt` と `deno lint` を実行し問題ないことを確認
- `deno test` は外部モジュール取得時に証明書エラーで失敗
  - `error: Import 'https://deno.land/std@0.208.0/assert/mod.ts' failed.`

------
https://chatgpt.com/codex/tasks/task_e_6870f41d2ca88328b1e88639dcd44e52