### PR TITLE
Add limit parameters and infinite scroll for messages

### DIFF
--- a/app/api/e2ee.ts
+++ b/app/api/e2ee.ts
@@ -411,8 +411,17 @@ app.get("/users/:user/messages", async (c) => {
     }
     : { to: { $in: [actorId, acct] } };
 
-  const list = await EncryptedMessage.find(condition).sort({ createdAt: 1 })
-    .lean();
+  const limit = Math.min(
+    parseInt(c.req.query("limit") ?? "50", 10) || 50,
+    100,
+  );
+  const before = c.req.query("before");
+  const after = c.req.query("after");
+  const query = EncryptedMessage.find(condition);
+  if (before) query.where("createdAt").lt(new Date(before));
+  if (after) query.where("createdAt").gt(new Date(after));
+  const list = await query.sort({ createdAt: -1 }).limit(limit).lean();
+  list.reverse();
   const messages = list.map((doc) => ({
     id: doc._id.toString(),
     from: doc.from,
@@ -458,8 +467,17 @@ app.get("/users/:user/publicMessages", async (c) => {
     }
     : { to: { $in: [actorId, acct] } };
 
-  const list = await PublicMessage.find(condition).sort({ createdAt: 1 })
-    .lean();
+  const limit = Math.min(
+    parseInt(c.req.query("limit") ?? "50", 10) || 50,
+    100,
+  );
+  const before = c.req.query("before");
+  const after = c.req.query("after");
+  const query = PublicMessage.find(condition);
+  if (before) query.where("createdAt").lt(new Date(before));
+  if (after) query.where("createdAt").gt(new Date(after));
+  const list = await query.sort({ createdAt: -1 }).limit(limit).lean();
+  list.reverse();
   const messages = list.map((doc) => ({
     id: doc._id.toString(),
     from: doc.from,

--- a/app/client/src/components/e2ee/api.ts
+++ b/app/client/src/components/e2ee/api.ts
@@ -107,10 +107,17 @@ export const sendEncryptedMessage = async (
 export const fetchEncryptedMessages = async (
   user: string,
   partner?: string,
+  params?: { limit?: number; before?: string; after?: string },
 ): Promise<EncryptedMessage[]> => {
   try {
+    const search = new URLSearchParams();
+    if (partner) search.set("with", partner);
+    if (params?.limit) search.set("limit", String(params.limit));
+    if (params?.before) search.set("before", params.before);
+    if (params?.after) search.set("after", params.after);
+    const query = search.toString();
     const url = `/api/users/${encodeURIComponent(user)}/messages${
-      partner ? `?with=${encodeURIComponent(partner)}` : ""
+      query ? `?${query}` : ""
     }`;
     const res = await apiFetch(url);
     if (!res.ok) {
@@ -162,10 +169,17 @@ export const sendPublicMessage = async (
 export const fetchPublicMessages = async (
   user: string,
   partner?: string,
+  params?: { limit?: number; before?: string; after?: string },
 ): Promise<PublicMessage[]> => {
   try {
+    const search = new URLSearchParams();
+    if (partner) search.set("with", partner);
+    if (params?.limit) search.set("limit", String(params.limit));
+    if (params?.before) search.set("before", params.before);
+    if (params?.after) search.set("after", params.after);
+    const query = search.toString();
     const url = `/api/users/${encodeURIComponent(user)}/publicMessages${
-      partner ? `?with=${encodeURIComponent(partner)}` : ""
+      query ? `?${query}` : ""
     }`;
     const res = await apiFetch(url);
     if (!res.ok) {


### PR DESCRIPTION
## Summary
- add limit/before/after query support to message APIs
- update client API helpers for new parameters
- implement infinite scroll and latest message polling in chat

## Testing
- `deno fmt app/api/e2ee.ts app/client/src/components/Chat.tsx app/client/src/components/e2ee/api.ts`
- `deno lint app/api/e2ee.ts app/client/src/components/Chat.tsx app/client/src/components/e2ee/api.ts`


------
https://chatgpt.com/codex/tasks/task_e_687201af74348328872af3db27bfc19a