### PR TITLE
Add support for ActivityPub attachment images

### DIFF
--- a/app/api/activity_handlers.ts
+++ b/app/api/activity_handlers.ts
@@ -3,6 +3,7 @@ import ActivityPubObject from "./models/activitypub_object.ts";
 import {
   createAcceptActivity,
   deliverActivityPubObject,
+  extractAttachments,
   getDomain,
 } from "./utils/activitypub.ts";
 
@@ -33,6 +34,13 @@ async function saveObject(
     }
   }
 
+  const attachments = extractAttachments(obj);
+  const extra: Record<string, unknown> = {
+    ...(obj.extra ?? {}),
+    actorInfo: Object.keys(actorInfo).length > 0 ? actorInfo : undefined,
+  };
+  if (attachments.length > 0) extra.attachments = attachments;
+
   await ActivityPubObject.create({
     type: obj.type ?? "Note",
     attributedTo: typeof obj.attributedTo === "string"
@@ -45,10 +53,7 @@ async function saveObject(
       ? new Date(obj.published)
       : new Date(),
     raw: obj,
-    extra: {
-      ...(obj.extra ?? {}),
-      actorInfo: Object.keys(actorInfo).length > 0 ? actorInfo : undefined,
-    },
+    extra,
   });
 }
 

--- a/app/api/group.ts
+++ b/app/api/group.ts
@@ -6,6 +6,7 @@ import {
   createAnnounceActivity,
   createGroupActor,
   deliverActivityPubObjectFromUrl,
+  extractAttachments,
   getDomain,
   jsonResponse,
   verifyHttpSignature,
@@ -97,6 +98,9 @@ app.post("/communities/:name/inbox", async (c) => {
       return jsonResponse(c, { error: "Forbidden" }, 403);
     }
     const obj = activity.object as Record<string, unknown>;
+    const attachments = extractAttachments(obj);
+    const extra: Record<string, unknown> = {};
+    if (attachments.length > 0) extra.attachments = attachments;
     const stored = await ActivityPubObject.create({
       type: (obj.type as string) ?? "Note",
       attributedTo: `!${name}`,
@@ -107,7 +111,7 @@ app.post("/communities/:name/inbox", async (c) => {
         ? new Date(obj.published)
         : new Date(),
       raw: obj,
-      extra: {},
+      extra,
     });
     const announce = createAnnounceActivity(
       domain,

--- a/app/api/root_inbox.ts
+++ b/app/api/root_inbox.ts
@@ -3,6 +3,7 @@ import {
   createAcceptActivity,
   createAnnounceActivity,
   deliverActivityPubObjectFromUrl,
+  extractAttachments,
   getDomain,
   jsonResponse,
   verifyHttpSignature,
@@ -90,6 +91,9 @@ app.post("/inbox", async (c) => {
             !group.followers.includes(actor) || group.banned.includes(actor)
           ) continue;
           const obj = activity.object as Record<string, unknown>;
+          const attachments = extractAttachments(obj);
+          const extra: Record<string, unknown> = {};
+          if (attachments.length > 0) extra.attachments = attachments;
           const stored = await ActivityPubObject.create({
             type: (obj.type as string) ?? "Note",
             attributedTo: `!${name}`,
@@ -100,7 +104,7 @@ app.post("/inbox", async (c) => {
               ? new Date(obj.published)
               : new Date(),
             raw: obj,
-            extra: {},
+            extra,
           });
           const announce = createAnnounceActivity(
             domain,

--- a/app/client/src/components/microblog/Post.tsx
+++ b/app/client/src/components/microblog/Post.tsx
@@ -182,7 +182,7 @@ function PostItem(props: PostItemProps) {
             innerHTML={renderHtml(linkifyText(post.content))}
           />
           {post.attachments && post.attachments.length > 0 && (
-            <div class="mb-3 space-y-2">
+            <div class="mb-3 grid gap-2 sm:grid-cols-2">
               <For each={post.attachments}>
                 {(att) => (
                   <Show
@@ -199,7 +199,11 @@ function PostItem(props: PostItemProps) {
                       ? <audio src={att.url} controls class="w-full" />
                       : null}
                   >
-                    <img src={att.url} class="max-w-full rounded" />
+                    <img
+                      src={att.url}
+                      alt="attachment"
+                      class="max-w-full rounded"
+                    />
                   </Show>
                 )}
               </For>
@@ -496,7 +500,7 @@ export function PostForm(props: {
                     rows={4}
                   />
                   {props.attachments.length > 0 && (
-                    <div class="mt-2 space-y-2">
+                    <div class="mt-2 grid gap-2 sm:grid-cols-2">
                       <For each={props.attachments}>
                         {(att, i) => (
                           <div class="relative">
@@ -520,7 +524,11 @@ export function PostForm(props: {
                                 )
                                 : null}
                             >
-                              <img src={att.url} class="max-w-full rounded" />
+                              <img
+                                src={att.url}
+                                alt="attachment"
+                                class="max-w-full rounded"
+                              />
                             </Show>
                             <button
                               type="button"


### PR DESCRIPTION
## Summary
- ActivityPub オブジェクト保存時に添付ファイルを抽出
- 受信オブジェクトやグループ投稿で添付情報を保存
- 添付画像取得用ユーティリティを追加

## Testing
- `deno fmt`
- `deno lint`


------
https://chatgpt.com/codex/tasks/task_e_68720b2bde8883289aa5897351515c12