### PR TITLE
リンクプレビュー自動挿入機能

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,12 @@ deno task dev
 - `POST /api/microblog/:id/like` – いいねを追加
 - `POST /api/microblog/:id/retweet` – リツイートを追加
 
+### リンクプレビュー
+
+投稿内にURLを含めると、最初に出現したリンクを基にOGP情報を取得し、タイムラインでカード形式のプレビューを表示します。
+この処理はクライアント側で自動挿入される `<div data-og="URL"></div>` と
+`/api/ogp` エンドポイントによって実現されています。
+
 ## 動画 API
 
 ActivityPub の `Video` オブジェクトを利用して動画を投稿できます。

--- a/app/client/src/components/Microblog.tsx
+++ b/app/client/src/components/Microblog.tsx
@@ -24,7 +24,13 @@ import {
   updatePost,
   viewStory,
 } from "./microblog/api.ts";
-import type { Community, MicroblogPost, Story, Note } from "./microblog/types.ts";
+import type {
+  Community,
+  MicroblogPost,
+  Note,
+  Story,
+} from "./microblog/types.ts";
+import LinkifyIt from "linkify-it";
 
 export function Microblog() {
   // タブ切り替え: "recommend" | "following" | "community"
@@ -233,6 +239,14 @@ export function Microblog() {
     const content = newPostContent().trim();
     if (!content) return;
 
+    const linkify = new LinkifyIt();
+    const match = linkify.match(content)?.[0];
+    let finalContent = content;
+    if (match) {
+      const safe = match.url.replace(/"/g, "&quot;");
+      finalContent += `\n<div data-og="${safe}"></div>`;
+    }
+
     const user = account();
     if (!user) {
       alert("アカウントが選択されていません");
@@ -240,7 +254,7 @@ export function Microblog() {
     }
 
     const success = await createPost(
-      content,
+      finalContent,
       user.userName,
       newPostAttachments(),
       _replyingTo() ?? undefined,


### PR DESCRIPTION
## Summary
- 投稿送信時に本文から URL を抽出し `<div data-og>` を自動付与
- OGP 取得 API の説明を README に追記

## Testing
- `deno fmt app/client/src/components/Microblog.tsx`
- `deno lint app/client/src/components/Microblog.tsx`
- `deno fmt README.md`


------
https://chatgpt.com/codex/tasks/task_e_687260d6149483288fc45b43e0ecf3a6