### PR TITLE
Add real retweet delivery for ActivityPub

### DIFF
--- a/app/client/src/components/Microblog.tsx
+++ b/app/client/src/components/Microblog.tsx
@@ -24,7 +24,12 @@ import {
   updatePost,
   viewStory,
 } from "./microblog/api.ts";
-import type { Community, MicroblogPost, Story, Note } from "./microblog/types.ts";
+import type {
+  Community,
+  MicroblogPost,
+  Note,
+  Story,
+} from "./microblog/types.ts";
 
 export function Microblog() {
   // タブ切り替え: "recommend" | "following" | "community"
@@ -270,7 +275,9 @@ export function Microblog() {
   };
 
   const handleRetweet = async (id: string) => {
-    const retweets = await retweetPost(id);
+    const user = account();
+    if (!user) return;
+    const retweets = await retweetPost(id, user.userName);
     if (retweets !== null) {
       setPosts((prev) =>
         prev.map((p) => p.id === id ? { ...p, retweets, isRetweeted: true } : p)

--- a/app/client/src/components/microblog/api.ts
+++ b/app/client/src/components/microblog/api.ts
@@ -334,10 +334,15 @@ export const likePost = async (
   }
 };
 
-export const retweetPost = async (id: string): Promise<number | null> => {
+export const retweetPost = async (
+  id: string,
+  username: string,
+): Promise<number | null> => {
   try {
     const response = await apiFetch(`/api/microblog/${id}/retweet`, {
       method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ username }),
     });
     if (!response.ok) return null;
     const data = await response.json();


### PR DESCRIPTION
## Summary
- ActivityPubにリツイート(Announce)を送信する機能を追加
- 返信時に元投稿作者へ通知・配信を行うよう改善
- フロントエンドからユーザー名を送信するよう修正

## Testing
- `deno fmt`
- `deno lint`


------
https://chatgpt.com/codex/tasks/task_e_6872624f65b08328adfec5ad891c937c