### PR TITLE
Add routing for URL based navigation

### DIFF
--- a/app/client/deno.json
+++ b/app/client/deno.json
@@ -38,7 +38,8 @@
     "vite": "npm:vite@^5.4.19",
     "vite-plugin-solid": "npm:vite-plugin-solid@^2.11.6",
     "vite-plugin-pwa": "npm:vite-plugin-pwa@^1.0.1",
-    "zod": "npm:zod@^3.24.4"
+    "zod": "npm:zod@^3.24.4",
+    "@solidjs/router": "npm:@solidjs/router@^0.15.3"
   },
   "nodeModulesDir": "auto"
 }

--- a/app/client/src/App.tsx
+++ b/app/client/src/App.tsx
@@ -5,16 +5,25 @@ import { darkModeState, languageState } from "./states/settings.ts";
 import { LoginForm } from "./components/LoginForm.tsx";
 import { EncryptionKeyForm } from "./components/EncryptionKeyForm.tsx";
 import { Application } from "./components/Application.tsx";
+import { AppPage, selectedAppState } from "./states/app.ts";
+import { selectedRoomState } from "./states/chat.ts";
 import { apiFetch } from "./utils/config.ts";
 import { useInitialLoad } from "./utils/initialLoad.ts";
 import "./App.css";
 import "./stylesheet.css";
 
-function App() {
+interface AppProps {
+  initialPage?: AppPage;
+  initialRoomId?: string | null;
+}
+
+function App(props: AppProps) {
   const [isLoggedIn, setIsLoggedIn] = useAtom(loginState);
   const [encryptionKey, setEncryptionKey] = useAtom(encryptionKeyState);
   const [darkMode, setDarkMode] = useAtom(darkModeState);
   const [language, setLanguage] = useAtom(languageState);
+  const [_selectedApp, setSelectedApp] = useAtom(selectedAppState);
+  const [_selectedRoom, setSelectedRoom] = useAtom(selectedRoomState);
   const [skippedEncryptionKey, setSkippedEncryptionKey] = createSignal(false);
 
   // 共通の初期データ取得
@@ -22,6 +31,9 @@ function App() {
 
   // アプリケーション初期化時にログイン状態を確認
   onMount(async () => {
+    if (props.initialPage) setSelectedApp(props.initialPage);
+    if (props.initialRoomId) setSelectedRoom(props.initialRoomId);
+
     const storedKey = localStorage.getItem("encryptionKey");
     if (storedKey) {
       setEncryptionKey(storedKey);

--- a/app/client/src/main.tsx
+++ b/app/client/src/main.tsx
@@ -1,9 +1,35 @@
 /* @refresh reload */
 import { render } from "solid-js/web";
+import { Route, Router, Routes } from "@solidjs/router";
 import { registerSW } from "virtual:pwa-register";
 
 import App from "./App.tsx";
+import PostView from "./routes/PostView.tsx";
+import UserProfilePage from "./routes/UserProfilePage.tsx";
 
-render(() => <App />, document.getElementById("root")!);
+render(
+  () => (
+    <Router>
+      <Routes>
+        <Route path="/post/:id" component={PostView} />
+        <Route path="/profile/:username" component={UserProfilePage} />
+        <Route
+          path="/chat/:roomId"
+          element={(props) => (
+            <App initialPage="chat" initialRoomId={props.params.roomId} />
+          )}
+        />
+        <Route path="/chat" element={() => <App initialPage="chat" />} />
+        <Route
+          path="/microblog"
+          element={() => <App initialPage="microblog" />}
+        />
+        <Route path="/home" element={() => <App initialPage="home" />} />
+        <Route path="/*" component={App} />
+      </Routes>
+    </Router>
+  ),
+  document.getElementById("root")!,
+);
 // サービスワーカーを登録してPWAを有効化
 registerSW({ immediate: true });

--- a/app/client/src/routes/PostView.tsx
+++ b/app/client/src/routes/PostView.tsx
@@ -1,0 +1,18 @@
+import { createResource, Show } from "solid-js";
+import { useParams } from "@solidjs/router";
+import { fetchPostById } from "../components/microblog/api.ts";
+import { renderNoteContent } from "../utils/render.ts";
+
+export default function PostView() {
+  const params = useParams();
+  const [post] = createResource(() => fetchPostById(params.id));
+  return (
+    <Show when={post()}>
+      {(p) => (
+        <div class="p-4 text-gray-100">
+          <div innerHTML={renderNoteContent({ content: p.content })} />
+        </div>
+      )}
+    </Show>
+  );
+}

--- a/app/client/src/routes/UserProfilePage.tsx
+++ b/app/client/src/routes/UserProfilePage.tsx
@@ -1,0 +1,34 @@
+import { createResource, For, Show } from "solid-js";
+import { useParams } from "@solidjs/router";
+import {
+  fetchActivityPubObjects,
+  fetchUserProfile,
+} from "../components/microblog/api.ts";
+import { renderNoteContent } from "../utils/render.ts";
+
+export default function UserProfilePage() {
+  const params = useParams();
+  const [profile] = createResource(() => fetchUserProfile(params.username));
+  const [posts] = createResource(() =>
+    fetchActivityPubObjects(params.username, "Note")
+  );
+  return (
+    <div class="p-4 text-gray-100 space-y-4">
+      <Show when={profile()}>
+        {(p) => (
+          <div class="border-b border-gray-700 pb-4">
+            <h2 class="text-xl font-bold">{p.displayName}</h2>
+            <p class="text-gray-400">@{p.userName}</p>
+          </div>
+        )}
+      </Show>
+      <For each={posts() || []}>
+        {(post) => (
+          <div class="border-b border-gray-700 pb-3 mb-3">
+            <div innerHTML={renderNoteContent({ content: post.content })} />
+          </div>
+        )}
+      </For>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `@solidjs/router` to frontend
- enable routing via `/post/:id`, `/profile/:username`, `/chat/:roomId`
- allow `App` to accept initial page and room id
- add simple post and profile pages

## Testing
- `deno fmt app/client/src/main.tsx app/client/src/App.tsx app/client/src/routes/PostView.tsx app/client/src/routes/UserProfilePage.tsx app/client/deno.json`
- `deno lint app/client/src/main.tsx app/client/src/App.tsx app/client/src/routes/PostView.tsx app/client/src/routes/UserProfilePage.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68726633bbcc8328bbcbbd2c4cac9486