### PR TITLE
Add SPA routing

### DIFF
--- a/app/api/index.ts
+++ b/app/api/index.ts
@@ -18,6 +18,8 @@ import e2ee from "./e2ee.ts";
 import relays from "./relays.ts";
 import videos from "./videos.ts";
 import { fetchOgpData } from "./services/ogp.ts";
+import { serveDir, serveFile } from "@std/http/file_server";
+import { join } from "@std/path";
 
 const env = await load();
 
@@ -58,6 +60,16 @@ app.get("/api/ogp", async (c) => {
   } else {
     return c.json({ error: "Failed to fetch OGP data" }, 500);
   }
+});
+
+const distDir = join(new URL("./", import.meta.url).pathname, "../client/dist");
+
+app.get("*", async (c) => {
+  const res = await serveDir(c.req.raw, { fsRoot: distDir, urlRoot: "" });
+  if (res.status === 404 && c.req.method === "GET") {
+    return serveFile(c.req.raw, join(distDir, "index.html"));
+  }
+  return res;
 });
 
 Deno.serve(app.fetch);

--- a/app/client/deno.json
+++ b/app/client/deno.json
@@ -33,6 +33,7 @@
     "solid-jotai": "npm:solid-jotai@^0.3.1",
     "solid-js": "npm:solid-js@^1.9.6",
     "solid-qr-code": "npm:solid-qr-code@^0.1.11",
+    "@solidjs/router": "npm:@solidjs/router@^0.6.2",
     "tailwindcss": "npm:tailwindcss@^4.1.7",
     "tlds": "npm:tlds@^1.259.0",
     "vite": "npm:vite@^5.4.19",

--- a/app/client/src/components/Application.tsx
+++ b/app/client/src/components/Application.tsx
@@ -1,4 +1,4 @@
-import { createSignal, onMount, Show } from "solid-js";
+import { createEffect, createSignal, onMount } from "solid-js";
 import { useAtom } from "solid-jotai";
 import { selectedAppState } from "../states/app.ts";
 import { selectedRoomState } from "../states/chat.ts";
@@ -8,15 +8,19 @@ import { Chat } from "./Chat.tsx";
 import { Videos } from "./Videos.tsx";
 import UnifiedToolsContent from "./home/UnifiedToolsContent.tsx";
 import Header from "./header/header.tsx";
+import { Route, Routes, useLocation } from "@solidjs/router";
+import PostView from "./microblog/PostView.tsx";
+import UserProfile from "./UserProfile.tsx";
 
 interface ApplicationProps {
   onShowEncryptionKeyForm?: () => void;
 }
 
 export function Application(props: ApplicationProps) {
-  const [selectedApp] = useAtom(selectedAppState);
+  const [selectedApp, setSelectedApp] = useAtom(selectedAppState);
   const [selectedRoom] = useAtom(selectedRoomState);
   const [isMobile, setIsMobile] = createSignal(false);
+  const location = useLocation();
 
   // モバイルかどうかを判定
   onMount(() => {
@@ -38,29 +42,54 @@ export function Application(props: ApplicationProps) {
     return isHeaderHidden ? `${baseClass} no-header` : baseClass;
   };
 
+  createEffect(() => {
+    const path = location.pathname;
+    if (path.startsWith("/chat")) setSelectedApp("chat");
+    else if (path.startsWith("/microblog")) setSelectedApp("microblog");
+    else if (path.startsWith("/videos")) setSelectedApp("videos");
+    else if (path.startsWith("/tools")) setSelectedApp("tools");
+    else setSelectedApp("home");
+  });
+
   return (
     <>
       <Header />
       <main class={wrapperClass()}>
-        <Show when={selectedApp() === "home"}>
-          <Home onShowEncryptionKeyForm={props.onShowEncryptionKeyForm} />
-        </Show>
-        <Show when={selectedApp() === "microblog"}>
-          <Microblog />
-        </Show>
-        <Show when={selectedApp() === "chat"}>
-          <Chat onShowEncryptionKeyForm={props.onShowEncryptionKeyForm} />
-        </Show>
-        <Show when={selectedApp() === "tools"}>
-          <div class="text-gray-100">
-            <div class="p-6">
-              <UnifiedToolsContent />
-            </div>
-          </div>
-        </Show>
-        <Show when={selectedApp() === "videos"}>
-          <Videos />
-        </Show>
+        <Routes>
+          <Route
+            path="/"
+            element={
+              <Home onShowEncryptionKeyForm={props.onShowEncryptionKeyForm} />
+            }
+          />
+          <Route path="/microblog" component={Microblog} />
+          <Route path="/microblog/:id" component={PostView} />
+          <Route
+            path="/chat"
+            element={
+              <Chat onShowEncryptionKeyForm={props.onShowEncryptionKeyForm} />
+            }
+          />
+          <Route
+            path="/chat/:roomId"
+            element={
+              <Chat onShowEncryptionKeyForm={props.onShowEncryptionKeyForm} />
+            }
+          />
+          <Route
+            path="/tools"
+            element={
+              <div class="text-gray-100">
+                <div class="p-6">
+                  <UnifiedToolsContent />
+                </div>
+              </div>
+            }
+          />
+          <Route path="/videos" component={Videos} />
+          <Route path="/user/:username" component={UserProfile} />
+          <Route path="*" element={<Home />} />
+        </Routes>
       </main>
     </>
   );

--- a/app/client/src/components/Chat.tsx
+++ b/app/client/src/components/Chat.tsx
@@ -8,6 +8,7 @@ import {
   Show,
 } from "solid-js";
 import { useAtom } from "solid-jotai";
+import { useNavigate, useParams } from "@solidjs/router";
 import { selectedRoomState } from "../states/chat.ts";
 import { activeAccount } from "../states/account.ts";
 import { fetchUserInfoBatch } from "./microblog/api.ts";
@@ -78,6 +79,8 @@ interface ChatProps {
 }
 
 export function Chat(props: ChatProps) {
+  const navigate = useNavigate();
+  const params = useParams();
   const [selectedRoom, setSelectedRoom] = useAtom(selectedRoomState); // グローバル状態を使用
   const [account] = useAtom(activeAccount);
   const [encryptionKey, setEncryptionKey] = useAtom(encryptionKeyState);
@@ -509,6 +512,7 @@ export function Chat(props: ChatProps) {
     console.log("selected room:", roomId); // for debug
     setPartnerHasKey(true);
     setSelectedRoom(roomId);
+    navigate(`/chat/${roomId}`);
     if (isMobile()) {
       setShowRoomList(false); // モバイルではチャット画面に切り替え
     }
@@ -532,6 +536,7 @@ export function Chat(props: ChatProps) {
   const backToRoomList = () => {
     setShowRoomList(true);
     setSelectedRoom(null); // チャンネル選択状態をリセット
+    navigate("/chat");
     if (poller) clearInterval(poller);
   };
 
@@ -542,6 +547,9 @@ export function Chat(props: ChatProps) {
     loadRooms();
     loadGroupStates();
     ensureKeyPair();
+    if (params.roomId) {
+      setSelectedRoom(params.roomId);
+    }
     const room = chatRooms().find((r) => r.id === selectedRoom());
     if (room) {
       loadMessages(room, true);

--- a/app/client/src/components/UserProfile.tsx
+++ b/app/client/src/components/UserProfile.tsx
@@ -1,0 +1,52 @@
+import { createResource, Show } from "solid-js";
+import { useParams } from "@solidjs/router";
+import { fetchUserProfile } from "./microblog/api.ts";
+import { fetchActivityPubObjects } from "./microblog/api.ts";
+import { PostList } from "./microblog/Post.tsx";
+import { UserAvatar } from "./microblog/UserAvatar.tsx";
+
+export default function UserProfile() {
+  const params = useParams();
+  const [profile] = createResource(() => fetchUserProfile(params.username));
+  const [posts] = createResource(() =>
+    fetchActivityPubObjects(params.username, "Note")
+  );
+
+  const noop = () => {};
+  const formatDate = (d: string) => new Date(d).toLocaleString("ja-JP");
+
+  return (
+    <div class="max-w-2xl mx-auto p-4 space-y-6">
+      <Show when={profile()}>
+        {(info) => (
+          <div class="flex items-center space-x-4">
+            <UserAvatar
+              avatarUrl={info.avatarInitial}
+              username={info.userName}
+              size="w-16 h-16"
+            />
+            <div>
+              <div class="text-lg font-bold text-white">{info.displayName}</div>
+              <div class="text-sm text-gray-400">@{info.userName}</div>
+            </div>
+          </div>
+        )}
+      </Show>
+      <Show when={posts()}>
+        {(list) => (
+          <PostList
+            posts={list}
+            tab="recommend"
+            handleReply={noop}
+            handleRetweet={noop}
+            handleQuote={noop}
+            handleLike={noop}
+            handleEdit={noop}
+            handleDelete={noop}
+            formatDate={formatDate}
+          />
+        )}
+      </Show>
+    </div>
+  );
+}

--- a/app/client/src/components/header/header.tsx
+++ b/app/client/src/components/header/header.tsx
@@ -4,6 +4,15 @@ import { createSignal, onMount, Show } from "solid-js";
 import { useAtom } from "solid-jotai";
 import { AppPage, selectedAppState } from "../../states/app.ts";
 import { selectedRoomState } from "../../states/chat.ts";
+import { A } from "@solidjs/router";
+
+const pathMap: Record<AppPage, string> = {
+  home: "/",
+  chat: "/chat",
+  tools: "/tools",
+  microblog: "/microblog",
+  videos: "/videos",
+};
 
 const HeaderButton = (props: { page: AppPage; children: JSX.Element }) => {
   const [selectedApp, setSelectedApp] = useAtom(selectedAppState);
@@ -15,7 +24,7 @@ const HeaderButton = (props: { page: AppPage; children: JSX.Element }) => {
       }`}
       onClick={() => setSelectedApp(props.page)}
     >
-      {props.children}
+      <A href={pathMap[props.page]}>{props.children}</A>
     </li>
   );
 };

--- a/app/client/src/components/microblog/PostView.tsx
+++ b/app/client/src/components/microblog/PostView.tsx
@@ -1,0 +1,33 @@
+import { createResource, Show } from "solid-js";
+import { useParams } from "@solidjs/router";
+import { fetchPostById } from "./api.ts";
+import { renderNoteContent } from "../../utils/render.ts";
+import { UserAvatar } from "./UserAvatar.tsx";
+
+export default function PostView() {
+  const params = useParams();
+  const [post] = createResource(() => fetchPostById(params.id));
+
+  return (
+    <div class="p-4 text-white">
+      <Show when={post()}>
+        {(p) => (
+          <div class="space-y-4">
+            <div class="flex items-center space-x-3">
+              <UserAvatar
+                avatarUrl={p.authorAvatar}
+                username={p.userName}
+                size="w-10 h-10"
+              />
+              <div>
+                <div class="font-bold">{p.displayName}</div>
+                <div class="text-sm text-gray-400">@{p.userName}</div>
+              </div>
+            </div>
+            <div innerHTML={renderNoteContent({ content: p.content })} />
+          </div>
+        )}
+      </Show>
+    </div>
+  );
+}

--- a/app/client/src/main.tsx
+++ b/app/client/src/main.tsx
@@ -2,8 +2,16 @@
 import { render } from "solid-js/web";
 import { registerSW } from "virtual:pwa-register";
 
+import { Router } from "@solidjs/router";
 import App from "./App.tsx";
 
-render(() => <App />, document.getElementById("root")!);
+render(
+  () => (
+    <Router>
+      <App />
+    </Router>
+  ),
+  document.getElementById("root")!,
+);
 // サービスワーカーを登録してPWAを有効化
 registerSW({ immediate: true });


### PR DESCRIPTION
## Summary
- support URL routing with `@solidjs/router`
- link header buttons to routes
- sync URL with selected state and chat room
- add simple post and profile views
- serve client build from API server

## Testing
- `deno fmt`
- `deno lint`

------
https://chatgpt.com/codex/tasks/task_e_68726e85739c8328a70814314110b867