### PR TITLE
ハッシュベースルーターの追加

### DIFF
--- a/app/client/src/App.tsx
+++ b/app/client/src/App.tsx
@@ -7,6 +7,7 @@ import { EncryptionKeyForm } from "./components/EncryptionKeyForm.tsx";
 import { Application } from "./components/Application.tsx";
 import { apiFetch } from "./utils/config.ts";
 import { useInitialLoad } from "./utils/initialLoad.ts";
+import { useHashRouter } from "./utils/router.ts";
 import "./App.css";
 import "./stylesheet.css";
 
@@ -19,6 +20,8 @@ function App() {
 
   // 共通の初期データ取得
   useInitialLoad();
+  // URLハッシュと状態を同期
+  useHashRouter();
 
   // アプリケーション初期化時にログイン状態を確認
   onMount(async () => {

--- a/app/client/src/components/Chat.tsx
+++ b/app/client/src/components/Chat.tsx
@@ -586,6 +586,17 @@ export function Chat(props: ChatProps) {
     }
   });
 
+  // URLから直接チャットを開いた場合、モバイルでは自動的にルーム表示を切り替える
+  createEffect(() => {
+    if (!isMobile()) return;
+    const roomId = selectedRoom();
+    if (roomId && showRoomList()) {
+      setShowRoomList(false);
+    } else if (!roomId && !showRoomList()) {
+      setShowRoomList(true);
+    }
+  });
+
   createEffect(() => {
     account();
     loadGroupStates();

--- a/app/client/src/components/Chat.tsx
+++ b/app/client/src/components/Chat.tsx
@@ -10,7 +10,7 @@ import {
 import { useAtom } from "solid-jotai";
 import { selectedRoomState } from "../states/chat.ts";
 import { activeAccount } from "../states/account.ts";
-import { fetchUserInfoBatch } from "./microblog/api.ts";
+import { fetchUserInfo, fetchUserInfoBatch } from "./microblog/api.ts";
 import {
   addKeyPackage,
   fetchEncryptedKeyPair,
@@ -563,7 +563,25 @@ export function Chat(props: ChatProps) {
     const room = rooms.find((r) => r.id === roomId);
     if (room) {
       loadMessages(room, true);
-    } else if (roomId === null) {
+    } else if (roomId) {
+      fetchUserInfo(roomId).then((info) => {
+        if (!info) return;
+        const newRoom: ChatRoom = {
+          id: roomId,
+          name: info.displayName || info.userName,
+          userName: info.userName,
+          domain: info.domain,
+          avatar: info.authorAvatar || info.userName.charAt(0).toUpperCase(),
+          unreadCount: 0,
+          type: "dm",
+          members: [roomId],
+          lastMessage: "...",
+          lastMessageTime: undefined,
+        };
+        setChatRooms((prev) => [...prev, newRoom]);
+        loadMessages(newRoom, true);
+      });
+    } else {
       setMessages([]);
     }
   });

--- a/app/client/src/components/Microblog.tsx
+++ b/app/client/src/components/Microblog.tsx
@@ -74,7 +74,7 @@ export function Microblog() {
   };
 
   const loadMorePosts = async () => {
-    if (loadingMore()) return;
+    if (loadingMore() || targetPostId()) return;
     setLoadingMore(true);
     const data = await fetchPosts({
       limit: limit(),
@@ -96,7 +96,7 @@ export function Microblog() {
   let observer: IntersectionObserver | undefined;
 
   const setupObserver = () => {
-    if (observer || !sentinel) return;
+    if (observer || !sentinel || targetPostId()) return;
     observer = new IntersectionObserver((entries) => {
       for (const entry of entries) {
         if (entry.isIntersecting) {
@@ -116,7 +116,12 @@ export function Microblog() {
   });
 
   createEffect(() => {
-    if (sentinel) setupObserver();
+    if (sentinel && !targetPostId()) {
+      setupObserver();
+    } else {
+      observer?.disconnect();
+      observer = undefined;
+    }
   });
 
   createEffect(() => {
@@ -239,17 +244,21 @@ export function Microblog() {
     const query = searchQuery().toLowerCase();
     let postsToFilter: MicroblogPost[] = [];
 
-    // タブに応じて投稿を選択
-    if (tab() === "recommend") {
+    if (targetPostId()) {
       postsToFilter = posts() || [];
-    } else if (tab() === "following") {
-      postsToFilter = followingTimelinePosts() || [];
-    } else if (tab() === "community") {
-      // コミュニティタブの場合は選択中コミュニティの投稿を取得する設計にする
-      // ここでは空配列を返す（詳細はCommunityView側で取得・表示）
-      postsToFilter = [];
     } else {
-      postsToFilter = [];
+      // タブに応じて投稿を選択
+      if (tab() === "recommend") {
+        postsToFilter = posts() || [];
+      } else if (tab() === "following") {
+        postsToFilter = followingTimelinePosts() || [];
+      } else if (tab() === "community") {
+        // コミュニティタブの場合は選択中コミュニティの投稿を取得する設計にする
+        // ここでは空配列を返す（詳細はCommunityView側で取得・表示）
+        postsToFilter = [];
+      } else {
+        postsToFilter = [];
+      }
     }
 
     if (!query) return postsToFilter;
@@ -536,10 +545,12 @@ export function Microblog() {
               handleDelete={handleDelete}
             />
           )}
-          <div ref={(el) => (sentinel = el)} class="h-4"></div>
-          {loadingMore() && (
-            <div class="text-center py-4 text-gray-400">読み込み中...</div>
-          )}
+          <Show when={!targetPostId()}>
+            <div ref={(el) => (sentinel = el)} class="h-4"></div>
+            {loadingMore() && (
+              <div class="text-center py-4 text-gray-400">読み込み中...</div>
+            )}
+          </Show>
         </div>
 
         <StoryViewer

--- a/app/client/src/components/home/UnifiedToolsContent.tsx
+++ b/app/client/src/components/home/UnifiedToolsContent.tsx
@@ -226,13 +226,13 @@ export default function UnifiedToolsContent() {
   const placeholder = () => {
     switch (activeTab()) {
       case "users":
-        return "ユーザー検索... (外部ユーザーは username@example.com 形式)";
+        return "ユーザー検索... (外部ユーザーは userName@example.com 形式)";
       case "posts":
         return "投稿内容、ハッシュタグで検索...";
       case "communities":
         return "コミュニティ名、説明、タグで検索...";
       default:
-        return "検索... (外部ユーザーは username@example.com 形式で入力)";
+        return "検索... (外部ユーザーは userName@example.com 形式で入力)";
     }
   };
 

--- a/app/client/src/components/microblog/Post.tsx
+++ b/app/client/src/components/microblog/Post.tsx
@@ -206,8 +206,17 @@ function PostItem(props: PostItemProps) {
     };
   };
 
+  const openPost = (e: MouseEvent) => {
+    const target = e.target as HTMLElement;
+    if (target.closest("button, a")) return;
+    globalThis.location.hash = `#/post/${post.id}`;
+  };
+
   return (
-    <div class="p-4 hover:bg-gray-950/50 transition-colors cursor-pointer">
+    <div
+      class="p-4 hover:bg-gray-950/50 transition-colors cursor-pointer"
+      onClick={openPost}
+    >
       <div class="flex space-x-3">
         <div class="flex-shrink-0">
           <UserAvatar

--- a/app/client/src/components/microblog/Post.tsx
+++ b/app/client/src/components/microblog/Post.tsx
@@ -226,9 +226,12 @@ function PostItem(props: PostItemProps) {
               @{finalUserInfo().userName}
             </span>
             <span class="text-gray-500">·</span>
-            <span class="text-gray-500 text-sm whitespace-nowrap">
+            <a
+              href={`#/post/${post.id}`}
+              class="text-gray-500 text-sm whitespace-nowrap hover:underline"
+            >
               {formatDate(post.createdAt)}
-            </span>
+            </a>
           </div>
           <div
             class="text-white mb-3 leading-relaxed break-words overflow-hidden"

--- a/app/client/src/components/microblog/Post.tsx
+++ b/app/client/src/components/microblog/Post.tsx
@@ -147,6 +147,7 @@ type PostItemProps = {
   handleEdit: (id: string, current: string) => void;
   handleDelete: (id: string) => void;
   formatDate: (dateString: string) => string;
+  isReply?: boolean;
 };
 
 function PostItem(props: PostItemProps) {
@@ -214,7 +215,9 @@ function PostItem(props: PostItemProps) {
 
   return (
     <div
-      class="p-4 hover:bg-gray-950/50 transition-colors cursor-pointer"
+      class={`p-4 hover:bg-gray-950/50 transition-colors cursor-pointer ${
+        props.isReply ? "border-l-2 border-gray-700 pl-6" : ""
+      }`}
       onClick={openPost}
     >
       <div class="flex space-x-3">
@@ -446,11 +449,12 @@ export function PostList(props: {
   handleEdit: (id: string, current: string) => void;
   handleDelete: (id: string) => void;
   formatDate: (dateString: string) => string;
+  isThread?: boolean;
 }) {
   return (
     <div class="divide-y divide-gray-800">
       <For each={props.posts}>
-        {(post) => (
+        {(post, i) => (
           <PostItem
             post={post}
             tab={props.tab}
@@ -461,6 +465,7 @@ export function PostList(props: {
             handleEdit={props.handleEdit}
             handleDelete={props.handleDelete}
             formatDate={props.formatDate}
+            isReply={props.isThread && i() > 0}
           />
         )}
       </For>

--- a/app/client/src/components/microblog/api.ts
+++ b/app/client/src/components/microblog/api.ts
@@ -73,6 +73,19 @@ export const fetchPostById = async (
   }
 };
 
+export const fetchPostReplies = async (
+  id: string,
+): Promise<MicroblogPost[]> => {
+  try {
+    const res = await apiFetch(`/api/microblog/${id}/replies`);
+    if (!res.ok) return [];
+    return await res.json();
+  } catch (error) {
+    console.error("Error fetching replies:", error);
+    return [];
+  }
+};
+
 export const fetchFollowingPosts = async (
   username: string,
 ): Promise<MicroblogPost[]> => {

--- a/app/client/src/states/router.ts
+++ b/app/client/src/states/router.ts
@@ -1,0 +1,4 @@
+import { atom } from "solid-jotai";
+
+export const selectedPostIdState = atom<string | null>(null);
+export const profileUserState = atom<string | null>(null);

--- a/app/client/src/utils/router.ts
+++ b/app/client/src/utils/router.ts
@@ -1,0 +1,80 @@
+import { createEffect, onMount } from "solid-js";
+import { useAtom } from "solid-jotai";
+import { AppPage, selectedAppState } from "../states/app.ts";
+import { selectedRoomState } from "../states/chat.ts";
+import { profileUserState, selectedPostIdState } from "../states/router.ts";
+
+export function useHashRouter() {
+  const [app, setApp] = useAtom(selectedAppState);
+  const [room, setRoom] = useAtom(selectedRoomState);
+  const [postId, setPostId] = useAtom(selectedPostIdState);
+  const [profile, setProfile] = useAtom(profileUserState);
+
+  let fromHash = false;
+
+  const parseHash = () => {
+    fromHash = true;
+    const hash = globalThis.location.hash.slice(1);
+    const [seg, param] = hash.split("/").filter(Boolean);
+    switch (seg) {
+      case "chat":
+        setApp("chat");
+        setRoom(param ?? null);
+        setPostId(null);
+        setProfile(null);
+        break;
+      case "post":
+        setApp("microblog");
+        setPostId(param ?? null);
+        setRoom(null);
+        setProfile(null);
+        break;
+      case "user":
+        setApp("home");
+        setProfile(param ?? null);
+        setRoom(null);
+        setPostId(null);
+        break;
+      case "home":
+      case "microblog":
+      case "tools":
+      case "videos":
+        setApp(seg as AppPage);
+        setRoom(null);
+        setPostId(null);
+        setProfile(null);
+        break;
+      default:
+        setApp("chat");
+        setRoom(null);
+        setPostId(null);
+        setProfile(null);
+    }
+    fromHash = false;
+  };
+
+  const updateHash = () => {
+    if (fromHash) return;
+    let newHash = "";
+    if (app() === "chat") {
+      newHash = room() ? `#/chat/${room()}` : "#/chat";
+    } else if (app() === "microblog") {
+      newHash = postId() ? `#/post/${postId()}` : "#/microblog";
+    } else if (app() === "home") {
+      newHash = profile() ? `#/user/${profile()}` : "#/home";
+    } else {
+      newHash = `#/${app()}`;
+    }
+    if (globalThis.location.hash !== newHash) {
+      globalThis.location.hash = newHash;
+    }
+  };
+
+  onMount(() => {
+    parseHash();
+    globalThis.addEventListener("hashchange", parseHash);
+    return () => globalThis.removeEventListener("hashchange", parseHash);
+  });
+
+  createEffect(updateHash);
+}


### PR DESCRIPTION
## 概要
URL のハッシュ部分を利用してアプリケーション状態と同期する簡易ルーターを実装しました。これにより投稿やチャットルームなどを直接 URL で開けるようになります。

## 主な変更点
- `src/utils/router.ts` を新規追加し、ハッシュ値からページ・ルーム・投稿を選択する仕組みを実装
- `src/states/router.ts` を追加し、選択中の投稿 ID やプロフィールユーザー名を管理
- `App.tsx` で `useHashRouter` を呼び出して初期化
- `Microblog.tsx` で `selectedPostIdState` を監視し、特定の投稿のみを読み込む処理を追加

## テスト
- `deno fmt` と `deno lint` を実行してエラーがないことを確認

------
https://chatgpt.com/codex/tasks/task_e_687295abb5408328b9ff93353c233e9a