### PR TITLE
Add API server selection for Tauri build

### DIFF
--- a/app/client/src/components/LoginForm.tsx
+++ b/app/client/src/components/LoginForm.tsx
@@ -1,5 +1,5 @@
-import { createSignal, Show } from "solid-js";
-import { apiFetch } from "../utils/config.ts";
+import { createSignal, onMount, Show } from "solid-js";
+import { apiFetch, getApiBase, setApiBase } from "../utils/config.ts";
 
 interface LoginFormProps {
   onLoginSuccess: () => void;
@@ -9,10 +9,22 @@ export function LoginForm(props: LoginFormProps) {
   const [loginPassword, setLoginPassword] = createSignal("");
   const [error, setError] = createSignal("");
   const [isLoading, setIsLoading] = createSignal(false);
+  const [serverUrl, setServerUrl] = createSignal("");
+
+  onMount(() => {
+    setServerUrl(getApiBase());
+  });
 
   const handleLogin = async (e: Event) => {
     e.preventDefault();
     setError("");
+
+    if (!serverUrl()) {
+      setError("サーバーURLを入力してください");
+      return;
+    }
+
+    setApiBase(serverUrl());
 
     if (!loginPassword()) {
       setError("ログイン用パスワードを入力してください");
@@ -62,6 +74,22 @@ export function LoginForm(props: LoginFormProps) {
           </div>
 
           <form onSubmit={handleLogin} class="space-y-6">
+            <div>
+              <label
+                for="serverUrl"
+                class="block text-sm font-medium text-gray-300 mb-2"
+              >
+                サーバーURL
+              </label>
+              <input
+                type="text"
+                id="serverUrl"
+                value={serverUrl()}
+                onInput={(e) => setServerUrl(e.currentTarget.value)}
+                class="w-full px-4 py-3 bg-gray-700 border border-gray-600 rounded-md text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 placeholder-gray-500 transition-colors"
+                placeholder="http://localhost:8000"
+              />
+            </div>
             <div>
               <label
                 for="loginPassword"

--- a/app/client/src/utils/config.ts
+++ b/app/client/src/utils/config.ts
@@ -1,24 +1,29 @@
-export const API_BASE = import.meta.env.VITE_API_BASE || "";
+let apiBase = import.meta.env.VITE_API_BASE ||
+  localStorage.getItem("takos-api-base") ||
+  "";
 
-export const ORIGIN = API_BASE
-  ? new URL(API_BASE).origin
-  : globalThis.location.origin;
+export function setApiBase(url: string) {
+  apiBase = url;
+  localStorage.setItem("takos-api-base", url);
+}
 
-export const DOMAIN = import.meta.env.VITE_ACTIVITYPUB_DOMAIN ||
-  new URL(ORIGIN).hostname;
+export function getApiBase(): string {
+  return apiBase;
+}
 
 export function apiUrl(path: string): string {
-  return API_BASE ? `${API_BASE}${path}` : path;
+  return apiBase ? `${apiBase}${path}` : path;
 }
 
 export function apiFetch(path: string, init?: RequestInit) {
   return fetch(apiUrl(path), init);
 }
 
-export function getDomain(): string {
-  return DOMAIN;
+export function getOrigin(): string {
+  return apiBase ? new URL(apiBase).origin : globalThis.location.origin;
 }
 
-export function getOrigin(): string {
-  return ORIGIN;
+export function getDomain(): string {
+  return import.meta.env.VITE_ACTIVITYPUB_DOMAIN ||
+    new URL(getOrigin()).hostname;
 }


### PR DESCRIPTION
## Summary
- allow selecting API server URL at login
- persist selected server URL in localStorage
- update config utilities to use the stored API base URL

## Testing
- `deno fmt ./app/client/src/utils/config.ts ./app/client/src/components/LoginForm.tsx`
- `deno lint ./app/client/src/utils/config.ts ./app/client/src/components/LoginForm.tsx`


------
https://chatgpt.com/codex/tasks/task_e_6872ae3e7b0c8328acb48389de355681