### PR TITLE
ログアウト機能の追加

### DIFF
--- a/app/api/index.ts
+++ b/app/api/index.ts
@@ -2,6 +2,7 @@ import mongoose from "mongoose";
 import { load } from "jsr:@std/dotenv";
 import { Hono } from "hono";
 import login from "./login.ts";
+import logout from "./logout.ts";
 import session from "./session.ts";
 import accounts from "./accounts.ts";
 import notifications from "./notifications.ts";
@@ -27,6 +28,7 @@ await mongoose.connect(env["MONGO_URI"])
 
 const app = new Hono();
 app.route("/api", login);
+app.route("/api", logout);
 app.route("/api", session);
 app.route("/api", accounts);
 app.route("/api", notifications);

--- a/app/api/logout.ts
+++ b/app/api/logout.ts
@@ -1,0 +1,18 @@
+import { Hono } from "hono";
+import { deleteCookie, getCookie } from "hono/cookie";
+import Session from "./models/session.ts";
+import authRequired from "./utils/auth.ts";
+
+const app = new Hono();
+app.use("*", authRequired);
+
+app.post("/logout", async (c) => {
+  const sessionId = getCookie(c, "sessionId");
+  if (sessionId) {
+    await Session.deleteOne({ sessionId });
+    deleteCookie(c, "sessionId", { path: "/" });
+  }
+  return c.json({ success: true });
+});
+
+export default app;

--- a/app/client/src/components/Setting/index.tsx
+++ b/app/client/src/components/Setting/index.tsx
@@ -1,6 +1,8 @@
 import { useAtom } from "solid-jotai";
 import { darkModeState, languageState } from "../../states/settings.ts";
+import { encryptionKeyState, loginState } from "../../states/session.ts";
 import RelaySettings from "./RelaySettings.tsx";
+import { apiFetch } from "../../utils/config.ts";
 
 export interface SettingProps {
   onShowEncryptionKeyForm?: () => void;
@@ -8,8 +10,23 @@ export interface SettingProps {
 export function Setting(props: SettingProps) {
   const [darkMode, setDarkMode] = useAtom(darkModeState);
   const [language, setLanguage] = useAtom(languageState);
+  const [, setIsLoggedIn] = useAtom(loginState);
+  const [, setEncryptionKey] = useAtom(encryptionKeyState);
 
   const toggleDark = () => setDarkMode(!darkMode());
+
+  const handleLogout = async () => {
+    try {
+      await apiFetch("/api/logout", { method: "POST" });
+    } catch (err) {
+      console.error("logout failed", err);
+    } finally {
+      setIsLoggedIn(false);
+      setEncryptionKey(null);
+      localStorage.removeItem("encryptionKey");
+      sessionStorage.removeItem("skippedEncryptionKey");
+    }
+  };
 
   return (
     <div class="space-y-6">
@@ -34,13 +51,20 @@ export function Setting(props: SettingProps) {
         </select>
       </div>
       <RelaySettings />
-      <div class="flex justify-end">
+      <div class="flex justify-end space-x-2">
         <button
           type="button"
           class="bg-blue-700 text-white px-4 py-2 rounded hover:bg-blue-800 transition"
           onClick={() => props.onShowEncryptionKeyForm?.()}
         >
           暗号化キー再入力
+        </button>
+        <button
+          type="button"
+          class="bg-red-700 text-white px-4 py-2 rounded hover:bg-red-800 transition"
+          onClick={handleLogout}
+        >
+          ログアウト
         </button>
       </div>
     </div>

--- a/app/takos_host/main.ts
+++ b/app/takos_host/main.ts
@@ -1,4 +1,3 @@
-import { Hono } from "hono"
+import { Hono } from "hono";
 
-const app = new Hono()
-
+const _app = new Hono();


### PR DESCRIPTION
## 変更内容
- API に `/api/logout` エンドポイントを実装
- `index.ts` で `logout` ルートを登録
- 設定画面にログアウトボタンを追加
- lint エラー解消のため `takos_host/main.ts` を修正

## テスト
- `deno fmt` 実行済み
- `deno lint` 実行済み

------
https://chatgpt.com/codex/tasks/task_e_6872c561a6408328a4b83edb2c4e2562