### PR TITLE
Add multi-server login support for Tauri

### DIFF
--- a/app/client/src/utils/config.ts
+++ b/app/client/src/utils/config.ts
@@ -1,4 +1,4 @@
-import { fetch as tauriFetch } from '@tauri-apps/plugin-http';
+import { fetch as tauriFetch } from "@tauri-apps/plugin-http";
 
 let apiBase = import.meta.env.VITE_API_BASE ||
   localStorage.getItem("takos-api-base") ||
@@ -18,17 +18,17 @@ export function apiUrl(path: string): string {
 }
 
 export function isTauri(): boolean {
-  if (typeof window === "undefined") return false;           // SSR/Node 対策
+  if (typeof window === "undefined") return false; // SSR/Node 対策
   return (
-    "__TAURI__" in window ||        // Tauri v1 〜 v2 β
+    "__TAURI__" in window || // Tauri v1 〜 v2 β
     "__TAURI_INTERNALS__" in window // v2 α〜β 一部で採用
   );
 }
 
 export function apiFetch(path: string, init?: RequestInit) {
   // Tauri環境判定
-  const is = isTauri() 
-  console.log("isTauri:" + is)
+  const is = isTauri();
+  console.log("isTauri:" + is);
   if (is) {
     return tauriFetch(apiUrl(path), init);
   }
@@ -42,4 +42,34 @@ export function getOrigin(): string {
 export function getDomain(): string {
   return import.meta.env.VITE_ACTIVITYPUB_DOMAIN ||
     new URL(getOrigin()).hostname;
+}
+
+// --- 複数サーバー管理 ---
+
+const SERVERS_KEY = "takos-servers";
+const ACTIVE_SERVER_KEY = "takos-active-server";
+
+export function getServers(): string[] {
+  const raw = localStorage.getItem(SERVERS_KEY);
+  try {
+    return raw ? JSON.parse(raw) as string[] : [];
+  } catch {
+    return [];
+  }
+}
+
+export function addServer(url: string) {
+  const list = getServers();
+  if (!list.includes(url)) {
+    list.push(url);
+    localStorage.setItem(SERVERS_KEY, JSON.stringify(list));
+  }
+}
+
+export function getActiveServer(): string | null {
+  return localStorage.getItem(ACTIVE_SERVER_KEY);
+}
+
+export function setActiveServer(url: string) {
+  localStorage.setItem(ACTIVE_SERVER_KEY, url);
 }


### PR DESCRIPTION
## Summary
- support multiple server configuration via new helpers
- enhance login form to pick or add servers when running under Tauri

## Testing
- `deno fmt app/client/src/utils/config.ts app/client/src/components/LoginForm.tsx`
- `deno lint app/client/src/utils/config.ts app/client/src/components/LoginForm.tsx`


------
https://chatgpt.com/codex/tasks/task_e_6872d6e5b35083289073bd8c8c27c42c