### PR TITLE
env.ts 廃止と DB 接続の分離

### DIFF
--- a/app/api/activitypub.ts
+++ b/app/api/activitypub.ts
@@ -15,7 +15,7 @@ import {
   jsonResponse,
   verifyHttpSignature,
 } from "./utils/activitypub.ts";
-import { env } from "./utils/env.ts";
+import { getEnv } from "./utils/env_store.ts";
 
 const app = new Hono();
 import { logger } from "hono/logger";
@@ -27,7 +27,7 @@ app.get("/.well-known/webfinger", async (c) => {
     return jsonResponse(c, { error: "Bad Request" }, 400);
   }
   const [username, host] = resource.slice(5).split("@");
-  const expected = env["ACTIVITYPUB_DOMAIN"];
+  const expected = getEnv()["ACTIVITYPUB_DOMAIN"];
   if (expected && host !== expected) {
     return jsonResponse(c, { error: "Not found" }, 404);
   }

--- a/app/api/db.ts
+++ b/app/api/db.ts
@@ -1,0 +1,8 @@
+import mongoose from "mongoose";
+
+export async function connectDatabase(env: Record<string, string>) {
+  const uri = env["MONGO_URI"];
+  await mongoose.connect(uri)
+    .then(() => console.log("Connected to MongoDB"))
+    .catch((err: Error) => console.error("MongoDB connection error:", err));
+}

--- a/app/api/login.ts
+++ b/app/api/login.ts
@@ -1,12 +1,13 @@
 import { Hono } from "hono";
 import { setCookie } from "hono/cookie";
-import { env } from "./utils/env.ts";
+import { getEnv } from "./utils/env_store.ts";
 import Session from "./models/session.ts";
 
 const app = new Hono();
 
 app.post("/login", async (c) => {
   const { password } = await c.req.json();
+  const env = getEnv();
   const hashedPassword = env["hashedPassword"];
   const salt = env["salt"];
   if (!hashedPassword || !salt) {

--- a/app/api/nodeinfo.ts
+++ b/app/api/nodeinfo.ts
@@ -2,7 +2,7 @@ import { Hono } from "hono";
 import Account from "./models/account.ts";
 import ActivityPubObject from "./models/activitypub_object.ts";
 import { getDomain } from "./utils/activitypub.ts";
-import { env } from "./utils/env.ts";
+import { getEnv } from "./utils/env_store.ts";
 // NodeInfo は外部からの参照を想定しているため認証は不要
 
 const app = new Hono();
@@ -21,7 +21,7 @@ app.get("/.well-known/nodeinfo", (c) => {
 });
 
 app.get("/nodeinfo/2.0", async (c) => {
-  const version = env["TAKOS_VERSION"] ?? "1.0.0";
+  const version = getEnv()["TAKOS_VERSION"] ?? "1.0.0";
   const users = await Account.countDocuments();
   const posts = await ActivityPubObject.countDocuments();
 
@@ -44,7 +44,7 @@ app.get("/nodeinfo/2.0", async (c) => {
 
 app.get("/api/v1/instance", async (c) => {
   const domain = getDomain(c);
-  const version = env["TAKOS_VERSION"] ?? "1.0.0";
+  const version = getEnv()["TAKOS_VERSION"] ?? "1.0.0";
   const userCount = await Account.countDocuments();
   const statusCount = await ActivityPubObject.countDocuments();
 
@@ -70,7 +70,7 @@ app.get("/api/v1/instance", async (c) => {
 });
 
 app.get("/.well-known/x-nodeinfo2", async (c) => {
-  const version = env["TAKOS_VERSION"] ?? "1.0.0";
+  const version = getEnv()["TAKOS_VERSION"] ?? "1.0.0";
   const users = await Account.countDocuments();
   const posts = await ActivityPubObject.countDocuments();
 

--- a/app/api/server.ts
+++ b/app/api/server.ts
@@ -1,6 +1,7 @@
-import mongoose from "mongoose";
 import { load } from "jsr:@std/dotenv";
 import { Hono } from "hono";
+import { connectDatabase } from "./db.ts";
+import { initEnv } from "./utils/env_store.ts";
 import login from "./login.ts";
 import logout from "./logout.ts";
 import session from "./session.ts";
@@ -22,9 +23,8 @@ import { fetchOgpData } from "./services/ogp.ts";
 
 export async function createTakosApp(env?: Record<string, string>) {
   const e = env ?? await load();
-  await mongoose.connect(e["MONGO_URI"])
-    .then(() => console.log("Connected to MongoDB"))
-    .catch((err: Error) => console.error("MongoDB connection error:", err));
+  initEnv(e);
+  await connectDatabase(e);
 
   const app = new Hono();
   app.route("/api", login);

--- a/app/api/services/object-storage.ts
+++ b/app/api/services/object-storage.ts
@@ -18,7 +18,7 @@ import { once } from "node:events";
 import { Buffer } from "node:buffer";
 
 // 内部ユーティリティ
-import { env } from "../utils/env.ts";
+import { getEnv } from "../utils/env_store.ts";
 
 export interface ObjectStorage {
   put(key: string, data: Uint8Array): Promise<string>;
@@ -161,15 +161,15 @@ export class GridFSStorage implements ObjectStorage {
 /* ==========================
    ストレージファクトリ関数
    ========================== */
-export function createStorage(): ObjectStorage {
-  const provider = env["OBJECT_STORAGE_PROVIDER"] || "local";
+export function createStorage(e = getEnv()): ObjectStorage {
+  const provider = e["OBJECT_STORAGE_PROVIDER"] || "local";
   if (provider === "s3" || provider === "r2" || provider === "minio") {
-    const bucket = env["S3_BUCKET"] || "";
-    const region = env["S3_REGION"] || "us-east-1";
-    const accessKey = env["S3_ACCESS_KEY"] || "";
-    const secretKey = env["S3_SECRET_KEY"] || "";
-    const endpoint = env["S3_ENDPOINT"] || undefined;
-    const forcePathStyle = env["S3_FORCE_PATH_STYLE"] === "true";
+    const bucket = e["S3_BUCKET"] || "";
+    const region = e["S3_REGION"] || "us-east-1";
+    const accessKey = e["S3_ACCESS_KEY"] || "";
+    const secretKey = e["S3_SECRET_KEY"] || "";
+    const endpoint = e["S3_ENDPOINT"] || undefined;
+    const forcePathStyle = e["S3_FORCE_PATH_STYLE"] === "true";
     return new S3Storage(
       bucket,
       region,
@@ -180,9 +180,9 @@ export function createStorage(): ObjectStorage {
     );
   }
   if (provider === "gridfs") {
-    const bucketName = env["GRIDFS_BUCKET"] || "uploads";
+    const bucketName = e["GRIDFS_BUCKET"] || "uploads";
     return new GridFSStorage(bucketName);
   }
-  const dir = env["LOCAL_STORAGE_DIR"] || "uploads";
+  const dir = e["LOCAL_STORAGE_DIR"] || "uploads";
   return new LocalStorage(dir);
 }

--- a/app/api/utils/activitypub.ts
+++ b/app/api/utils/activitypub.ts
@@ -1,6 +1,6 @@
 import Account from "../models/account.ts";
 import Relay from "../models/relay.ts";
-import { env } from "./env.ts";
+import { getEnv } from "./env_store.ts";
 
 function base64ToArrayBuffer(base64: string): ArrayBuffer {
   const binary = atob(base64);
@@ -59,7 +59,7 @@ async function signAndSend(
   );
 
   const signatureB64 = arrayBufferToBase64(signature);
-  const domain = env["ACTIVITYPUB_DOMAIN"] || "localhost";
+  const domain = getEnv()["ACTIVITYPUB_DOMAIN"] || "localhost";
   const keyId = `https://${domain}/users/${account.userName}#main-key`;
 
   const headers = new Headers({
@@ -522,7 +522,7 @@ export function resolveActor(
 export function getDomain(
   c: { req: { url: string } },
 ): string {
-  return env["ACTIVITYPUB_DOMAIN"] ?? new URL(c.req.url).host;
+  return getEnv()["ACTIVITYPUB_DOMAIN"] ?? new URL(c.req.url).host;
 }
 
 export function jsonResponse(
@@ -762,7 +762,7 @@ export async function fetchJson<T = unknown>(
   signer?: { id: string; privateKey: string },
 ): Promise<T> {
   if (!signer) {
-    const domain = env["ACTIVITYPUB_DOMAIN"] || "localhost";
+    const domain = getEnv()["ACTIVITYPUB_DOMAIN"] || "localhost";
     const sys = await Account.findOne({ userName: "system" }).lean();
     if (sys) {
       signer = {
@@ -942,4 +942,4 @@ export function extractAttachments(
     attachments.push({ url: obj.image, type: "image" });
   }
   return attachments;
-};
+}

--- a/app/api/utils/env.ts
+++ b/app/api/utils/env.ts
@@ -1,3 +1,0 @@
-import { load } from "@std/dotenv";
-
-export const env = await load();

--- a/app/api/utils/env_store.ts
+++ b/app/api/utils/env_store.ts
@@ -1,0 +1,12 @@
+// createTakosApp から渡された環境変数を保持する
+let currentEnv: Record<string, string> = {};
+
+// 環境変数を初期化する
+export function initEnv(env: Record<string, string>) {
+  currentEnv = env;
+}
+
+// 保持している環境変数を取得する
+export function getEnv(): Record<string, string> {
+  return currentEnv;
+}


### PR DESCRIPTION
## Summary
- `createTakosApp` から渡された環境変数を保持する `env_store.ts` を追加
- DB 接続用モジュール `db.ts` を作成
- `server.ts` から MongoDB 接続処理を削除して上記モジュールへ委譲
- 各 API で `env.ts` の代わりに `env_store.ts` を利用
- 不要となった `env.ts` を削除

## Testing
- `deno fmt app/api/db.ts app/api/server.ts app/api/login.ts app/api/nodeinfo.ts app/api/activitypub.ts app/api/services/object-storage.ts app/api/utils/activitypub.ts app/api/utils/env_store.ts`
- `deno lint app/api/db.ts app/api/server.ts app/api/login.ts app/api/nodeinfo.ts app/api/activitypub.ts app/api/services/object-storage.ts app/api/utils/activitypub.ts app/api/utils/env_store.ts`


------
https://chatgpt.com/codex/tasks/task_e_68730b7823988328a34dbacc9e2704cd