### PR TITLE
auth.ts にログインフォーム追加

### DIFF
--- a/app/takos_host/.env.example
+++ b/app/takos_host/.env.example
@@ -1,0 +1,2 @@
+MONGO_URI=mongodb://localhost:27017/takos-host
+ROOT_DOMAIN=takos.jp

--- a/app/takos_host/README.md
+++ b/app/takos_host/README.md
@@ -23,3 +23,39 @@ takos を運用できるようにすることが目的です。
 ホスト側ではドメイン名を基にインスタンスを識別し、takos の API
 を共通モジュールとして読み込んで処理します。これにより複数の takos
 サーバーを一元管理できます。
+
+## ログインと管理 API
+
+`ROOT_DOMAIN` で指定したドメインは takos host
+自身のログインページとして機能します。 `/auth`
+でアカウント登録やログインを行い、セッション Cookie を得た状態で `/admin` 以下の
+API を利用できます。
+
+- `POST /auth/register` 新規ユーザー登録
+- `POST /auth/login` ログイン
+- `GET /auth/status` セッション状態確認
+- `DELETE /auth/logout` ログアウト
+
+管理 API では以下のエンドポイントが利用できます。
+
+- `GET /admin/instances` 登録済みインスタンス一覧を取得
+- `POST /admin/instances` 新しいインスタンスを追加 (パスワードを設定)
+- `DELETE /admin/instances/:host` インスタンスを削除
+- `GET /admin/instances/:host` インスタンスの詳細を取得
+- `PUT /admin/instances/:host/env` インスタンスの環境変数を更新
+- `PUT /admin/instances/:host/password` インスタンスのログインパスワードを変更
+- `POST /admin/instances/:host/restart` インスタンスを再起動
+
+環境変数やパスワードを更新すると、キャッシュされたアプリが破棄され、次のアクセス時に再起動されます。
+
+### インスタンスへのログイン
+
+各インスタンスでは `/login` へパスワードを POST
+すると管理画面にアクセスできます。 `POST /admin/instances`
+で登録したパスワードは `hashedPassword` と `salt` として
+インスタンスの環境変数に保存され、ログイン時に照合されます。
+
+## 起動方法
+
+1. `.env.example` を参考に `.env` を作成します。
+2. `deno run -A app/takos_host/main.ts` でサーバーを起動します。

--- a/app/takos_host/admin.ts
+++ b/app/takos_host/admin.ts
@@ -1,0 +1,96 @@
+import { Hono } from "hono";
+import { z } from "zod";
+import { zValidator } from "@hono/zod-validator";
+import Instance from "./models/instance.ts";
+import { authRequired, hash } from "./auth.ts";
+
+export function createAdminApp(invalidate?: (host: string) => void) {
+  const app = new Hono();
+
+  app.use("/*", authRequired);
+
+  app.get("/admin/instances", async (c) => {
+    const list = await Instance.find().lean();
+    return c.json(list.map((i) => ({ host: i.host })));
+  });
+
+  app.post(
+    "/admin/instances",
+    zValidator(
+      "json",
+      z.object({ host: z.string(), password: z.string() }),
+    ),
+    async (c) => {
+      const { host, password } = c.req.valid("json");
+      const exists = await Instance.findOne({ host });
+      if (exists) {
+        return c.json({ error: "already exists" }, 400);
+      }
+      const salt = crypto.randomUUID();
+      const hashedPassword = await hash(password + salt);
+      const inst = new Instance({
+        host,
+        env: { hashedPassword, salt },
+      });
+      await inst.save();
+      invalidate?.(host);
+      return c.json({ success: true });
+    },
+  );
+
+  app.delete("/admin/instances/:host", async (c) => {
+    const host = c.req.param("host");
+    await Instance.deleteOne({ host });
+    invalidate?.(host);
+    return c.json({ success: true });
+  });
+
+  app.get("/admin/instances/:host", async (c) => {
+    const host = c.req.param("host");
+    const inst = await Instance.findOne({ host }).lean();
+    if (!inst) return c.json({ error: "not found" }, 404);
+    return c.json({ host: inst.host, env: inst.env });
+  });
+
+  app.put(
+    "/admin/instances/:host/env",
+    zValidator("json", z.record(z.string(), z.string())),
+    async (c) => {
+      const host = c.req.param("host");
+      const env = c.req.valid("json");
+      const inst = await Instance.findOne({ host });
+      if (!inst) return c.json({ error: "not found" }, 404);
+      inst.env = { ...(inst.env ?? {}), ...env };
+      await inst.save();
+      invalidate?.(host);
+      return c.json({ success: true });
+    },
+  );
+
+  app.put(
+    "/admin/instances/:host/password",
+    zValidator("json", z.object({ password: z.string() })),
+    async (c) => {
+      const host = c.req.param("host");
+      const { password } = c.req.valid("json");
+      const inst = await Instance.findOne({ host });
+      if (!inst) return c.json({ error: "not found" }, 404);
+      const salt = crypto.randomUUID();
+      const hashedPassword = await hash(password + salt);
+      inst.env = { ...(inst.env ?? {}), hashedPassword, salt };
+      await inst.save();
+      invalidate?.(host);
+      return c.json({ success: true });
+    },
+  );
+
+  app.post("/admin/instances/:host/restart", async (c) => {
+    const host = c.req.param("host");
+    const inst = await Instance.findOne({ host });
+    if (!inst) return c.json({ error: "not found" }, 404);
+    invalidate?.(host);
+    return c.json({ success: true });
+  });
+
+  return app;
+}

--- a/app/takos_host/auth.ts
+++ b/app/takos_host/auth.ts
@@ -1,0 +1,108 @@
+import { Hono, type MiddlewareHandler } from "hono";
+import { deleteCookie, getCookie, setCookie } from "hono/cookie";
+import HostUser from "./models/user.ts";
+import HostSession from "./models/session.ts";
+
+export async function hash(text: string): Promise<string> {
+  const buf = new TextEncoder().encode(text);
+  const hashBuf = await crypto.subtle.digest("SHA-256", buf);
+  return Array.from(new Uint8Array(hashBuf)).map((b) =>
+    b.toString(16).padStart(2, "0")
+  ).join("");
+}
+
+export const authApp = new Hono();
+
+authApp.get("/", (c) => {
+  const html = `<!DOCTYPE html>
+  <html lang="ja">
+    <head><meta charset="UTF-8"><title>takos host</title></head>
+    <body>
+      <h1>takos host ログイン</h1>
+      <form id="login">
+        <input name="userName" placeholder="ユーザー名" />
+        <input name="password" type="password" placeholder="パスワード" />
+        <button type="submit">ログイン</button>
+      </form>
+      <script>
+        document.getElementById('login').onsubmit = async (e) => {
+          e.preventDefault();
+          const fd = new FormData(e.target);
+          const res = await fetch('/auth/login', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(Object.fromEntries(fd)),
+          });
+          if (res.ok) location.href = '/admin/';
+          else alert('login failed');
+        };
+      </script>
+    </body>
+  </html>`;
+  return c.html(html);
+});
+
+authApp.post("/register", async (c) => {
+  const { userName, password } = await c.req.json();
+  if (typeof userName !== "string" || typeof password !== "string") {
+    return c.json({ error: "invalid" }, 400);
+  }
+  const exists = await HostUser.findOne({ userName });
+  if (exists) return c.json({ error: "exists" }, 400);
+  const salt = crypto.randomUUID();
+  const hashedPassword = await hash(password + salt);
+  const user = new HostUser({ userName, hashedPassword, salt });
+  await user.save();
+  return c.json({ success: true });
+});
+
+authApp.post("/login", async (c) => {
+  const { userName, password } = await c.req.json();
+  const user = await HostUser.findOne({ userName });
+  if (!user) return c.json({ error: "invalid" }, 401);
+  const hashed = await hash(password + user.salt);
+  if (hashed !== user.hashedPassword) return c.json({ error: "invalid" }, 401);
+  const sessionId = crypto.randomUUID();
+  const expiresAt = new Date(Date.now() + 24 * 60 * 60 * 1000);
+  const session = new HostSession({ sessionId, user: user._id, expiresAt });
+  await session.save();
+  setCookie(c, "hostSessionId", sessionId, {
+    httpOnly: true,
+    secure: c.req.url.startsWith("https://"),
+    expires: expiresAt,
+    sameSite: "Lax",
+    path: "/",
+  });
+  return c.json({ success: true });
+});
+
+authApp.get("/status", async (c) => {
+  const sid = getCookie(c, "hostSessionId");
+  if (!sid) return c.json({ login: false });
+  const session = await HostSession.findOne({ sessionId: sid });
+  if (session && session.expiresAt > new Date()) {
+    return c.json({ login: true, user: session.user });
+  }
+  if (session) await HostSession.deleteOne({ sessionId: sid });
+  return c.json({ login: false });
+});
+
+authApp.delete("/logout", async (c) => {
+  const sid = getCookie(c, "hostSessionId");
+  if (sid) {
+    await HostSession.deleteOne({ sessionId: sid });
+    deleteCookie(c, "hostSessionId", { path: "/" });
+  }
+  return c.json({ success: true });
+});
+
+export const authRequired: MiddlewareHandler = async (c, next) => {
+  const sid = getCookie(c, "hostSessionId");
+  if (!sid) return c.json({ error: "unauthorized" }, 401);
+  const session = await HostSession.findOne({ sessionId: sid });
+  if (!session || session.expiresAt <= new Date()) {
+    if (session) await HostSession.deleteOne({ sessionId: sid });
+    return c.json({ error: "unauthorized" }, 401);
+  }
+  await next();
+};

--- a/app/takos_host/main.ts
+++ b/app/takos_host/main.ts
@@ -1,21 +1,50 @@
 import { Hono } from "hono";
 import { load } from "jsr:@std/dotenv";
 import { createTakosApp } from "../api/server.ts";
+import { connectDatabase } from "../api/db.ts";
+import Instance from "./models/instance.ts";
+import { createAdminApp } from "./admin.ts";
+import { authApp } from "./auth.ts";
 
 const env = await load();
-const apps = new Map<string, Hono>();
+await connectDatabase(env);
 
-async function getAppForHost(host: string): Promise<Hono> {
+const apps = new Map<string, Hono>();
+const adminApp = createAdminApp((host) => {
+  apps.delete(host);
+});
+const rootDomain = env["ROOT_DOMAIN"] ?? "";
+
+async function getEnvForHost(
+  host: string,
+): Promise<Record<string, string> | null> {
+  const inst = await Instance.findOne({ host }).lean();
+  if (!inst) return null;
+  return { ...env, ...inst.env, ACTIVITYPUB_DOMAIN: host };
+}
+
+async function getAppForHost(host: string): Promise<Hono | null> {
   let app = apps.get(host);
-  if (!app) {
-    app = await createTakosApp(env);
-    apps.set(host, app);
-  }
+  if (app) return app;
+  const hostEnv = await getEnvForHost(host);
+  if (!hostEnv) return null;
+  app = await createTakosApp(hostEnv);
+  apps.set(host, app);
   return app;
 }
 
-Deno.serve(async (req) => {
-  const host = req.headers.get("host") ?? "localhost";
+const root = new Hono();
+root.route("/auth", authApp);
+root.route("/admin", adminApp);
+
+root.all("/*", async (c) => {
+  const host = c.req.header("host") ?? "";
+  if (rootDomain && host === rootDomain) {
+    return authApp.fetch(c.req.raw);
+  }
   const app = await getAppForHost(host);
-  return app.fetch(req);
+  if (!app) return c.text("not found", 404);
+  return app.fetch(c.req.raw);
 });
+
+Deno.serve(root.fetch);

--- a/app/takos_host/models/instance.ts
+++ b/app/takos_host/models/instance.ts
@@ -1,0 +1,12 @@
+import mongoose from "mongoose";
+
+const instanceSchema = new mongoose.Schema({
+  host: { type: String, required: true, unique: true },
+  env: { type: mongoose.Schema.Types.Mixed, default: {} },
+  createdAt: { type: Date, default: Date.now },
+});
+
+const Instance = mongoose.model("Instance", instanceSchema);
+
+export default Instance;
+export { instanceSchema };

--- a/app/takos_host/models/session.ts
+++ b/app/takos_host/models/session.ts
@@ -1,0 +1,17 @@
+import mongoose from "mongoose";
+
+const sessionSchema = new mongoose.Schema({
+  sessionId: { type: String, required: true, unique: true },
+  user: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: "HostUser",
+    required: true,
+  },
+  expiresAt: { type: Date, required: true },
+  createdAt: { type: Date, default: Date.now },
+});
+
+const HostSession = mongoose.model("HostSession", sessionSchema);
+
+export default HostSession;
+export { sessionSchema };

--- a/app/takos_host/models/user.ts
+++ b/app/takos_host/models/user.ts
@@ -1,0 +1,13 @@
+import mongoose from "mongoose";
+
+const userSchema = new mongoose.Schema({
+  userName: { type: String, required: true, unique: true },
+  hashedPassword: { type: String, required: true },
+  salt: { type: String, required: true },
+  createdAt: { type: Date, default: Date.now },
+});
+
+const HostUser = mongoose.model("HostUser", userSchema);
+
+export default HostUser;
+export { userSchema };


### PR DESCRIPTION
## Summary
- ルート `/auth/` で簡易ログインフォームを返すよう追加
- README に起動方法を記載

## Testing
- `deno fmt app/takos_host/auth.ts app/takos_host/README.md`
- `deno lint app/takos_host/auth.ts`


------
https://chatgpt.com/codex/tasks/task_e_68730f663c74832895c58821b20a91b3