### PR TITLE
管理機能を廃止しユーザーダッシュボードへ統一

### DIFF
--- a/app/takos_host/README.md
+++ b/app/takos_host/README.md
@@ -27,9 +27,9 @@ takos を運用できるようにすることが目的です。
 ## ログインと管理 API
 
 `ROOT_DOMAIN` で指定したドメインへアクセスすると、ウェルカムページが
-表示されます。ログインは `/auth`、管理画面は `/admin` から利用します。 `/auth`
-では登録やログインなど API も提供され、取得したセッション Cookie
-を送信することで `/admin` 以下の API を利用できます。
+表示されます。ログインは `/auth`、ダッシュボードは `/user` から利用します。
+`/auth` では登録やログインなど API も提供され、取得したセッション Cookie
+を送信することで `/user` 以下の API を利用できます。
 
 - `POST /auth/register` 新規ユーザー登録
 - `POST /auth/login` ログイン
@@ -38,13 +38,13 @@ takos を運用できるようにすることが目的です。
 
 管理 API では以下のエンドポイントが利用できます。
 
-- `GET /admin/instances` 登録済みインスタンス一覧を取得
-- `POST /admin/instances` 新しいインスタンスを追加 (パスワードを設定)
-- `DELETE /admin/instances/:host` インスタンスを削除
-- `GET /admin/instances/:host` インスタンスの詳細を取得
-- `PUT /admin/instances/:host/env` インスタンスの環境変数を更新
-- `PUT /admin/instances/:host/password` インスタンスのログインパスワードを変更
-- `POST /admin/instances/:host/restart` インスタンスを再起動
+- `GET /user/instances` 登録済みインスタンス一覧を取得
+- `POST /user/instances` 新しいインスタンスを追加 (パスワードを設定)
+- `DELETE /user/instances/:host` インスタンスを削除
+- `GET /user/instances/:host` インスタンスの詳細を取得
+- `PUT /user/instances/:host/env` インスタンスの環境変数を更新
+- `PUT /user/instances/:host/password` インスタンスのログインパスワードを変更
+- `POST /user/instances/:host/restart` インスタンスを再起動
 
 環境変数やパスワードを更新すると、キャッシュされたアプリが破棄され、次のアクセス時に再起動されます。
 
@@ -64,7 +64,7 @@ $ deno task dev
 ### インスタンスへのログイン
 
 各インスタンスでは `/login` へパスワードを POST
-すると管理画面にアクセスできます。 `POST /admin/instances`
+するとダッシュボードにアクセスできます。 `POST /user/instances`
 で登録したパスワードは `hashedPassword` と `salt` として
 インスタンスの環境変数に保存され、ログイン時に照合されます。
 

--- a/app/takos_host/admin.ts
+++ b/app/takos_host/admin.ts
@@ -9,13 +9,13 @@ export function createAdminApp(invalidate?: (host: string) => void) {
 
   app.use("/*", authRequired);
 
-  app.get("/admin/instances", async (c) => {
+  app.get("/instances", async (c) => {
     const list = await Instance.find().lean();
     return c.json(list.map((i) => ({ host: i.host })));
   });
 
   app.post(
-    "/admin/instances",
+    "/instances",
     zValidator(
       "json",
       z.object({ host: z.string(), password: z.string() }),
@@ -38,14 +38,14 @@ export function createAdminApp(invalidate?: (host: string) => void) {
     },
   );
 
-  app.delete("/admin/instances/:host", async (c) => {
+  app.delete("/instances/:host", async (c) => {
     const host = c.req.param("host");
     await Instance.deleteOne({ host });
     invalidate?.(host);
     return c.json({ success: true });
   });
 
-  app.get("/admin/instances/:host", async (c) => {
+  app.get("/instances/:host", async (c) => {
     const host = c.req.param("host");
     const inst = await Instance.findOne({ host }).lean();
     if (!inst) return c.json({ error: "not found" }, 404);
@@ -53,7 +53,7 @@ export function createAdminApp(invalidate?: (host: string) => void) {
   });
 
   app.put(
-    "/admin/instances/:host/env",
+    "/instances/:host/env",
     zValidator("json", z.record(z.string(), z.string())),
     async (c) => {
       const host = c.req.param("host");
@@ -68,7 +68,7 @@ export function createAdminApp(invalidate?: (host: string) => void) {
   );
 
   app.put(
-    "/admin/instances/:host/password",
+    "/instances/:host/password",
     zValidator("json", z.object({ password: z.string() })),
     async (c) => {
       const host = c.req.param("host");
@@ -84,7 +84,7 @@ export function createAdminApp(invalidate?: (host: string) => void) {
     },
   );
 
-  app.post("/admin/instances/:host/restart", async (c) => {
+  app.post("/instances/:host/restart", async (c) => {
     const host = c.req.param("host");
     const inst = await Instance.findOne({ host });
     if (!inst) return c.json({ error: "not found" }, 404);

--- a/app/takos_host/client/src/App.tsx
+++ b/app/takos_host/client/src/App.tsx
@@ -2,7 +2,6 @@ import { Match, onMount, Switch } from "solid-js";
 import { useAtom } from "solid-jotai";
 import LoginPage from "./pages/LoginPage.tsx";
 import RegisterPage from "./pages/RegisterPage.tsx";
-import AdminPage from "./pages/AdminPage.tsx";
 import UserPage from "./pages/UserPage.tsx";
 import WelcomePage from "./pages/WelcomePage.tsx";
 import { fetchInstances, fetchStatus } from "./api.ts";
@@ -25,7 +24,7 @@ export default function App() {
 
   onMount(async () => {
     await loadStatus();
-    if ((path === "/admin" || path === "/user") && loggedIn()) {
+    if (path === "/user" && loggedIn()) {
       await loadInstances();
     }
   });
@@ -37,9 +36,6 @@ export default function App() {
       </Match>
       <Match when={path === "/signup"}>
         <RegisterPage />
-      </Match>
-      <Match when={path === "/admin"}>
-        <AdminPage />
       </Match>
       <Match when={path === "/user"}>
         <UserPage />

--- a/app/takos_host/client/src/api.ts
+++ b/app/takos_host/client/src/api.ts
@@ -38,7 +38,7 @@ export async function logout(): Promise<void> {
 }
 
 export async function fetchInstances(): Promise<Instance[]> {
-  const res = await fetch("/admin/instances");
+  const res = await fetch("/user/instances");
   if (!res.ok) return [];
   return await res.json();
 }
@@ -47,7 +47,7 @@ export async function addInstance(
   host: string,
   password: string,
 ): Promise<boolean> {
-  const res = await fetch("/admin/instances", {
+  const res = await fetch("/user/instances", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ host, password }),
@@ -56,7 +56,7 @@ export async function addInstance(
 }
 
 export async function deleteInstance(host: string): Promise<boolean> {
-  const res = await fetch(`/admin/instances/${host}`, { method: "DELETE" });
+  const res = await fetch(`/user/instances/${host}`, { method: "DELETE" });
   return res.ok;
 }
 
@@ -68,7 +68,7 @@ export interface InstanceDetail {
 export async function fetchInstance(
   host: string,
 ): Promise<InstanceDetail | null> {
-  const res = await fetch(`/admin/instances/${host}`);
+  const res = await fetch(`/user/instances/${host}`);
   if (!res.ok) return null;
   return await res.json();
 }
@@ -77,7 +77,7 @@ export async function updateEnv(
   host: string,
   env: Record<string, string>,
 ): Promise<boolean> {
-  const res = await fetch(`/admin/instances/${host}/env`, {
+  const res = await fetch(`/user/instances/${host}/env`, {
     method: "PUT",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(env),
@@ -89,7 +89,7 @@ export async function updateInstancePassword(
   host: string,
   password: string,
 ): Promise<boolean> {
-  const res = await fetch(`/admin/instances/${host}/password`, {
+  const res = await fetch(`/user/instances/${host}/password`, {
     method: "PUT",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ password }),
@@ -98,7 +98,7 @@ export async function updateInstancePassword(
 }
 
 export async function restartInstance(host: string): Promise<boolean> {
-  const res = await fetch(`/admin/instances/${host}/restart`, {
+  const res = await fetch(`/user/instances/${host}/restart`, {
     method: "POST",
   });
   return res.ok;

--- a/app/takos_host/client/src/pages/LoginPage.tsx
+++ b/app/takos_host/client/src/pages/LoginPage.tsx
@@ -13,7 +13,7 @@ const LoginPage: Component = () => {
     e.preventDefault();
     if (await apiLogin(userName(), password())) {
       setLoggedIn(true);
-      globalThis.location.href = "/admin";
+      globalThis.location.href = "/user";
     } else {
       setError("ログインに失敗しました");
     }

--- a/app/takos_host/client/src/pages/RegisterPage.tsx
+++ b/app/takos_host/client/src/pages/RegisterPage.tsx
@@ -13,7 +13,7 @@ const RegisterPage: Component = () => {
     e.preventDefault();
     if (await apiRegister(userName(), password())) {
       setLoggedIn(true);
-      globalThis.location.href = "/admin";
+      globalThis.location.href = "/user";
     } else {
       setError("登録に失敗しました");
     }

--- a/app/takos_host/client/src/pages/WelcomePage.tsx
+++ b/app/takos_host/client/src/pages/WelcomePage.tsx
@@ -153,7 +153,7 @@ const LandingPage: Component = () => {
               </a>
             }
           >
-            <a href="/admin" class="rounded-xl bg-gradient-to-r from-emerald-600 to-emerald-500 px-5 py-2.5 text-sm font-semibold shadow-lg hover:shadow-xl hover:from-emerald-500 hover:to-emerald-400 transition-all duration-200 transform hover:scale-105">
+            <a href="/user" class="rounded-xl bg-gradient-to-r from-emerald-600 to-emerald-500 px-5 py-2.5 text-sm font-semibold shadow-lg hover:shadow-xl hover:from-emerald-500 hover:to-emerald-400 transition-all duration-200 transform hover:scale-105">
               ダッシュボード
             </a>
           </Show>

--- a/app/takos_host/client/vite.config.mts
+++ b/app/takos_host/client/vite.config.mts
@@ -1,10 +1,10 @@
 import { defineConfig } from "vite";
 import solid from "vite-plugin-solid";
-import tailwindcss from '@tailwindcss/vite';
+import tailwindcss from "@tailwindcss/vite";
 
 export default defineConfig({
   base: "/",
-  plugins: [solid(),tailwindcss()],
+  plugins: [solid(), tailwindcss()],
   server: {
     host: "0.0.0.0",
     port: 1421,
@@ -14,7 +14,7 @@ export default defineConfig({
         target: "http://localhost:8001",
         changeOrigin: true,
       },
-      "/admin": {
+      "/user": {
         target: "http://localhost:8001",
         changeOrigin: true,
       },

--- a/app/takos_host/main.ts
+++ b/app/takos_host/main.ts
@@ -54,21 +54,13 @@ const root = new Hono();
 
 if (isDev) {
   root.use("/auth/*", proxy("/auth"));
-  root.use("/admin/*", proxy("/admin"));
-  root.use("/user/*", proxy("/admin"));
+  root.use("/user/*", proxy("/user"));
 } else {
   root.use(
     "/auth/*",
     serveStatic({
       root: "./client/dist",
       rewriteRequestPath: (path) => path.replace(/^\/auth/, ""),
-    }),
-  );
-  root.use(
-    "/admin/*",
-    serveStatic({
-      root: "./client/dist",
-      rewriteRequestPath: (path) => path.replace(/^\/admin/, ""),
     }),
   );
   root.use(
@@ -92,7 +84,6 @@ if (!isDev && rootDomain) {
 }
 
 root.route("/auth", authApp);
-root.route("/admin", adminApp);
 root.route("/user", adminApp);
 
 root.all("/*", async (c) => {


### PR DESCRIPTION
## Summary
- takos host の管理画面 `/admin` を廃止し `/user` に統一
- API ルートを `/user/instances` へ変更
- README などドキュメントの表記を更新
- ログイン・登録後の遷移先を `/user` に変更

## Testing
- `deno fmt app/takos_host/main.ts app/takos_host/admin.ts app/takos_host/client/vite.config.mts app/takos_host/client/src/App.tsx app/takos_host/client/src/api.ts app/takos_host/client/src/pages/LoginPage.tsx app/takos_host/client/src/pages/RegisterPage.tsx app/takos_host/README.md`
- `deno lint app/takos_host`

------
https://chatgpt.com/codex/tasks/task_e_6874a2a38768832882db0d1a6aec944e