### PR TITLE
Add OAuth2 authentication via takos host

### DIFF
--- a/app/api/.env.example
+++ b/app/api/.env.example
@@ -3,6 +3,7 @@ hashedPassword=dda47e55945d0a9b8a81cdb2abac13b18698a3a1b19252013f5a9fe3fa0fb340
 salt=88fffa6cabe7f4ae67fb0d1ba8eab619
 ACTIVITYPUB_DOMAIN=dev.takos.jp
 REGISTRY_URL=http://localhost:8080/_takopack
+OAUTH_HOST=http://localhost:8001
 
 # オブジェクトストレージの設定
 # どのプロバイダを使用するか選択します: "local", "s3", "r2", "minio", "gridfs"

--- a/app/api/oauth_login.ts
+++ b/app/api/oauth_login.ts
@@ -1,0 +1,37 @@
+import { Hono } from "hono";
+import { setCookie } from "hono/cookie";
+import { getEnv } from "./utils/env_store.ts";
+import Session from "./models/session.ts";
+
+const app = new Hono();
+
+app.post("/oauth/login", async (c) => {
+  const { accessToken } = await c.req.json();
+  const env = getEnv();
+  const host = env["OAUTH_HOST"];
+  if (!host) {
+    return c.json({ error: "Server configuration error" }, 500);
+  }
+  const res = await fetch(`${host}/oauth/verify`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ token: accessToken }),
+  });
+  if (!res.ok) return c.json({ error: "Invalid token" }, 401);
+  const data = await res.json();
+  if (!data.active) return c.json({ error: "Invalid token" }, 401);
+  const sessionId = crypto.randomUUID();
+  const expiresAt = new Date(Date.now() + 24 * 60 * 60 * 1000);
+  const session = new Session({ sessionId, expiresAt });
+  await session.save();
+  setCookie(c, "sessionId", sessionId, {
+    path: "/",
+    httpOnly: true,
+    secure: c.req.url.startsWith("https://"),
+    expires: expiresAt,
+    sameSite: "Lax",
+  });
+  return c.json({ success: true, message: "Login successful" });
+});
+
+export default app;

--- a/app/api/server.ts
+++ b/app/api/server.ts
@@ -4,6 +4,7 @@ import { connectDatabase } from "./db.ts";
 import { initEnv } from "./utils/env_store.ts";
 import login from "./login.ts";
 import logout from "./logout.ts";
+import oauthLogin from "./oauth_login.ts";
 import session from "./session.ts";
 import accounts from "./accounts.ts";
 import notifications from "./notifications.ts";
@@ -29,6 +30,9 @@ export async function createTakosApp(env?: Record<string, string>) {
   const app = new Hono();
   app.route("/api", login);
   app.route("/api", logout);
+  if (e["OAUTH_HOST"]) {
+    app.route("/api", oauthLogin);
+  }
   app.route("/api", session);
   app.route("/api", accounts);
   app.route("/api", notifications);

--- a/app/takos_host/main.ts
+++ b/app/takos_host/main.ts
@@ -5,6 +5,7 @@ import { connectDatabase } from "../api/db.ts";
 import Instance from "./models/instance.ts";
 import { createAdminApp } from "./admin.ts";
 import { authApp } from "./auth.ts";
+import oauthApp from "./oauth.ts";
 import { serveStatic } from "hono/deno";
 import type { Context } from "hono";
 
@@ -84,6 +85,7 @@ if (!isDev && rootDomain) {
 }
 
 root.route("/auth", authApp);
+root.route("/oauth", oauthApp);
 root.route("/user", adminApp);
 
 root.all("/*", async (c) => {

--- a/app/takos_host/models/oauth_client.ts
+++ b/app/takos_host/models/oauth_client.ts
@@ -1,0 +1,13 @@
+import mongoose from "mongoose";
+
+const oauthClientSchema = new mongoose.Schema({
+  clientId: { type: String, required: true, unique: true },
+  clientSecret: { type: String, required: true },
+  redirectUri: { type: String, required: true },
+  createdAt: { type: Date, default: Date.now },
+});
+
+const OAuthClient = mongoose.model("OAuthClient", oauthClientSchema);
+
+export default OAuthClient;
+export { oauthClientSchema };

--- a/app/takos_host/models/oauth_code.ts
+++ b/app/takos_host/models/oauth_code.ts
@@ -1,0 +1,22 @@
+import mongoose from "mongoose";
+
+const oauthCodeSchema = new mongoose.Schema({
+  code: { type: String, required: true, unique: true },
+  client: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: "OAuthClient",
+    required: true,
+  },
+  user: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: "HostUser",
+    required: true,
+  },
+  expiresAt: { type: Date, required: true },
+  createdAt: { type: Date, default: Date.now },
+});
+
+const OAuthCode = mongoose.model("OAuthCode", oauthCodeSchema);
+
+export default OAuthCode;
+export { oauthCodeSchema };

--- a/app/takos_host/models/oauth_token.ts
+++ b/app/takos_host/models/oauth_token.ts
@@ -1,0 +1,22 @@
+import mongoose from "mongoose";
+
+const oauthTokenSchema = new mongoose.Schema({
+  token: { type: String, required: true, unique: true },
+  client: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: "OAuthClient",
+    required: true,
+  },
+  user: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: "HostUser",
+    required: true,
+  },
+  expiresAt: { type: Date, required: true },
+  createdAt: { type: Date, default: Date.now },
+});
+
+const OAuthToken = mongoose.model("OAuthToken", oauthTokenSchema);
+
+export default OAuthToken;
+export { oauthTokenSchema };

--- a/app/takos_host/oauth.ts
+++ b/app/takos_host/oauth.ts
@@ -1,0 +1,99 @@
+import { Hono } from "hono";
+import { getCookie } from "hono/cookie";
+import OAuthClient from "./models/oauth_client.ts";
+import OAuthCode from "./models/oauth_code.ts";
+import OAuthToken from "./models/oauth_token.ts";
+import HostSession from "./models/session.ts";
+
+export const oauthApp = new Hono();
+
+// Authorization Endpoint
+oauthApp.get("/authorize", async (c) => {
+  const clientId = c.req.query("client_id");
+  const redirectUri = c.req.query("redirect_uri");
+  const state = c.req.query("state") ?? "";
+  if (!clientId || !redirectUri) {
+    return c.text("invalid_request", 400);
+  }
+  const client = await OAuthClient.findOne({ clientId });
+  if (!client || client.redirectUri !== redirectUri) {
+    return c.text("invalid_client", 400);
+  }
+  const sid = getCookie(c, "hostSessionId");
+  if (!sid) return c.text("login required", 401);
+  const session = await HostSession.findOne({ sessionId: sid });
+  if (!session || session.expiresAt <= new Date()) {
+    return c.text("login required", 401);
+  }
+  const code = crypto.randomUUID();
+  const expiresAt = new Date(Date.now() + 10 * 60 * 1000);
+  const oauthCode = new OAuthCode({
+    code,
+    client: client._id,
+    user: session.user,
+    expiresAt,
+  });
+  await oauthCode.save();
+  const url = new URL(redirectUri);
+  url.searchParams.set("code", code);
+  if (state) url.searchParams.set("state", state);
+  return c.redirect(url.toString());
+});
+
+// Token Endpoint
+oauthApp.post("/token", async (c) => {
+  const body = await c.req.formData();
+  const grantType = body.get("grant_type");
+  const code = body.get("code");
+  const clientId = body.get("client_id");
+  const clientSecret = body.get("client_secret");
+  const redirectUri = body.get("redirect_uri");
+  if (
+    grantType !== "authorization_code" ||
+    typeof code !== "string" ||
+    typeof clientId !== "string" ||
+    typeof clientSecret !== "string" ||
+    typeof redirectUri !== "string"
+  ) {
+    return c.json({ error: "invalid_request" }, 400);
+  }
+  const client = await OAuthClient.findOne({ clientId });
+  if (
+    !client || client.clientSecret !== clientSecret ||
+    client.redirectUri !== redirectUri
+  ) {
+    return c.json({ error: "invalid_client" }, 400);
+  }
+  const authCode = await OAuthCode.findOne({ code, client: client._id });
+  if (!authCode || authCode.expiresAt <= new Date()) {
+    return c.json({ error: "invalid_grant" }, 400);
+  }
+  await OAuthCode.deleteOne({ code });
+  const tokenStr = crypto.randomUUID();
+  const expiresAt = new Date(Date.now() + 24 * 60 * 60 * 1000);
+  const token = new OAuthToken({
+    token: tokenStr,
+    client: client._id,
+    user: authCode.user,
+    expiresAt,
+  });
+  await token.save();
+  return c.json({
+    access_token: tokenStr,
+    token_type: "Bearer",
+    expires_in: 86400,
+  });
+});
+
+// Token verification
+oauthApp.post("/verify", async (c) => {
+  const { token } = await c.req.json();
+  if (typeof token !== "string") return c.json({ active: false }, 400);
+  const t = await OAuthToken.findOne({ token }).populate("user");
+  if (!t || t.expiresAt <= new Date()) {
+    return c.json({ active: false }, 401);
+  }
+  return c.json({ active: true, userName: t.user.userName });
+});
+
+export default oauthApp;


### PR DESCRIPTION
## Summary
- implement OAuth2 authorization server in takos_host
- add OAuth login endpoint for takos instance
- expose endpoints for client registration
- document `OAUTH_HOST` in env example
- disable OAuth login in takos when `OAUTH_HOST` is unset
- tweak OAuth login response

## Testing
- `deno fmt app/api/oauth_login.ts app/takos_host/oauth.ts app/takos_host/models/oauth_client.ts app/takos_host/models/oauth_code.ts app/takos_host/models/oauth_token.ts app/takos_host/admin.ts app/takos_host/main.ts app/api/server.ts app/api/.env.example`
- `deno lint app/api/oauth_login.ts app/takos_host/oauth.ts app/takos_host/models/oauth_client.ts app/takos_host/models/oauth_code.ts app/takos_host/models/oauth_token.ts app/takos_host/admin.ts app/takos_host/main.ts app/api/server.ts`


------
https://chatgpt.com/codex/tasks/task_e_6874b2d48b6c8328b79a40ae6c8a52d7