### PR TITLE
takos host ドメイン管理機能追加

### DIFF
--- a/app/takos_host/.env.example
+++ b/app/takos_host/.env.example
@@ -1,2 +1,3 @@
 MONGO_URI=mongodb://localhost:27017/takos-host
 ROOT_DOMAIN=takos.jp
+FREE_PLAN_LIMIT=1

--- a/app/takos_host/README.md
+++ b/app/takos_host/README.md
@@ -24,6 +24,12 @@ takos を運用できるようにすることが目的です。
 を共通モジュールとして読み込んで処理します。これにより複数の takos
 サーバーを一元管理できます。
 
+環境変数 `ROOT_DOMAIN` を設定すると、インスタンスのホスト名は
+`<サブドメイン>.<ROOT_DOMAIN>` の形式で自動補完されます。`FREE_PLAN_LIMIT`
+で1ユーザーが作成できる無料インスタンス数を制限できます。`ROOT_DOMAIN`
+に含まれない独自ドメインを利用する場合は、事前にドメイン登録と
+所有確認を行ってください。
+
 ## ログインと管理 API
 
 `ROOT_DOMAIN` で指定したドメインへアクセスすると、ウェルカムページが
@@ -43,6 +49,9 @@ takos を運用できるようにすることが目的です。
 - `DELETE /user/instances/:host` インスタンスを削除
 - `GET /user/instances/:host` インスタンスの詳細を取得
 - `PUT /user/instances/:host/password` インスタンスのログインパスワードを変更
+- `GET /user/domains` 登録済みドメイン一覧を取得
+- `POST /user/domains` ドメインを登録 (検証トークンを返す)
+- `POST /user/domains/:domain/verify` ドメインの所有確認
 
 環境変数やパスワードを更新すると、キャッシュされたアプリが破棄され、次のアクセス時に再起動されます。
 
@@ -69,4 +78,6 @@ $ deno task dev
 ## 起動方法
 
 1. `.env.example` を参考に `.env` を作成します。
+   - `ROOT_DOMAIN` にホストの基本ドメインを設定します。
+   - `FREE_PLAN_LIMIT` で無料プランのインスタンス数上限を指定します。
 2. `deno run -A app/takos_host/main.ts` でサーバーを起動します。

--- a/app/takos_host/auth.ts
+++ b/app/takos_host/auth.ts
@@ -70,10 +70,13 @@ authApp.delete("/logout", async (c) => {
 export const authRequired: MiddlewareHandler = async (c, next) => {
   const sid = getCookie(c, "hostSessionId");
   if (!sid) return c.json({ error: "unauthorized" }, 401);
-  const session = await HostSession.findOne({ sessionId: sid });
+  const session = await HostSession.findOne({ sessionId: sid }).populate(
+    "user",
+  );
   if (!session || session.expiresAt <= new Date()) {
     if (session) await HostSession.deleteOne({ sessionId: sid });
     return c.json({ error: "unauthorized" }, 401);
   }
+  c.set("user", session.user);
   await next();
 };

--- a/app/takos_host/client/src/pages/AdminPage.tsx
+++ b/app/takos_host/client/src/pages/AdminPage.tsx
@@ -130,7 +130,7 @@ const AdminPage: Component = () => {
               class="grid gap-4 sm:grid-cols-[1fr_1fr_auto]"
             >
               <input
-                placeholder="ホスト名"
+                placeholder="ホスト名(サブドメイン)"
                 value={host()}
                 onInput={(e) => setHost(e.currentTarget.value)}
                 class="px-3 py-2 bg-gray-700 border border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"

--- a/app/takos_host/main.ts
+++ b/app/takos_host/main.ts
@@ -13,10 +13,14 @@ const env = await load();
 await connectDatabase(env);
 
 const apps = new Map<string, Hono>();
-const adminApp = createAdminApp((host) => {
-  apps.delete(host);
-});
 const rootDomain = env["ROOT_DOMAIN"] ?? "";
+const freeLimit = Number(env["FREE_PLAN_LIMIT"] ?? "1");
+const adminApp = createAdminApp(
+  (host) => {
+    apps.delete(host);
+  },
+  { rootDomain, freeLimit },
+);
 const isDev = Deno.env.get("DEV") === "1";
 
 function proxy(prefix: string) {
@@ -56,7 +60,6 @@ const root = new Hono();
 root.route("/auth", authApp);
 root.route("/oauth", oauthApp);
 root.route("/user", adminApp);
-
 
 if (isDev) {
   root.use("/auth/*", proxy("/auth"));

--- a/app/takos_host/models/domain.ts
+++ b/app/takos_host/models/domain.ts
@@ -1,0 +1,18 @@
+import mongoose from "mongoose";
+
+const domainSchema = new mongoose.Schema({
+  domain: { type: String, required: true, unique: true },
+  user: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: "HostUser",
+    required: true,
+  },
+  token: { type: String, required: true },
+  verified: { type: Boolean, default: false },
+  createdAt: { type: Date, default: Date.now },
+});
+
+const HostDomain = mongoose.model("HostDomain", domainSchema);
+
+export default HostDomain;
+export { domainSchema };

--- a/app/takos_host/models/instance.ts
+++ b/app/takos_host/models/instance.ts
@@ -2,6 +2,11 @@ import mongoose from "mongoose";
 
 const instanceSchema = new mongoose.Schema({
   host: { type: String, required: true, unique: true },
+  owner: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: "HostUser",
+    required: true,
+  },
   env: { type: mongoose.Schema.Types.Mixed, default: {} },
   createdAt: { type: Date, default: Date.now },
 });


### PR DESCRIPTION
## Summary
- takos host に独自ドメイン登録・認証機能を追加
- インスタンスモデルに所有者情報を追加
- ルートドメインを環境変数 `ROOT_DOMAIN` から自動補完
- `FREE_PLAN_LIMIT` で無料インスタンス数を制限
- 管理画面のホスト名入力をサブドメイン表示に変更
- ドキュメント更新

## Testing
- `deno fmt app/takos_host/models/domain.ts app/takos_host/models/instance.ts app/takos_host/auth.ts app/takos_host/admin.ts app/takos_host/main.ts app/takos_host/client/src/pages/AdminPage.tsx app/takos_host/README.md app/takos_host/.env.example`
- `deno lint app/takos_host/models/domain.ts app/takos_host/models/instance.ts app/takos_host/auth.ts app/takos_host/admin.ts app/takos_host/main.ts app/takos_host/client/src/pages/AdminPage.tsx`

------
https://chatgpt.com/codex/tasks/task_e_6874c0a872d0832889286716f58dfc2f