### PR TITLE
統合オブジェクトストアの基礎実装

### DIFF
--- a/app/takos_host/models/follow_edge.ts
+++ b/app/takos_host/models/follow_edge.ts
@@ -1,0 +1,16 @@
+import mongoose from "mongoose";
+
+const followEdgeSchema = new mongoose.Schema({
+  _id: { type: String },
+  tenant_id: { type: String, required: true },
+  actor_id: { type: String, required: true },
+  since: { type: Date, default: Date.now },
+  relay: { type: String, default: null },
+});
+
+followEdgeSchema.index({ actor_id: 1, tenant_id: 1 });
+
+const FollowEdge = mongoose.model("FollowEdge", followEdgeSchema);
+
+export default FollowEdge;
+export { followEdgeSchema };

--- a/app/takos_host/models/object_store.ts
+++ b/app/takos_host/models/object_store.ts
@@ -1,0 +1,23 @@
+import mongoose from "mongoose";
+
+const objectStoreSchema = new mongoose.Schema({
+  _id: { type: String },
+  raw: { type: mongoose.Schema.Types.Mixed, required: true },
+  type: { type: String, required: true },
+  actor_id: { type: String, required: true },
+  created_at: { type: Date, default: Date.now },
+  updated_at: { type: Date, default: Date.now },
+  deleted_at: { type: Date, default: null },
+  aud: {
+    to: { type: [String], default: [] },
+    cc: { type: [String], default: [] },
+  },
+});
+
+objectStoreSchema.index({ deleted_at: 1 }, { expireAfterSeconds: 0 });
+objectStoreSchema.index({ actor_id: "hashed" });
+
+const ObjectStore = mongoose.model("ObjectStore", objectStoreSchema);
+
+export default ObjectStore;
+export { objectStoreSchema };

--- a/app/takos_host/models/relay_edge.ts
+++ b/app/takos_host/models/relay_edge.ts
@@ -1,0 +1,15 @@
+import mongoose from "mongoose";
+
+const relayEdgeSchema = new mongoose.Schema({
+  tenant_id: { type: String, required: true },
+  relay: { type: String, required: true },
+  mode: { type: String, enum: ["pull", "push"], default: "pull" },
+  since: { type: Date, default: Date.now },
+});
+
+relayEdgeSchema.index({ relay: 1, tenant_id: 1 });
+
+const RelayEdge = mongoose.model("RelayEdge", relayEdgeSchema);
+
+export default RelayEdge;
+export { relayEdgeSchema };

--- a/app/takos_host/models/tenant.ts
+++ b/app/takos_host/models/tenant.ts
@@ -1,0 +1,11 @@
+import mongoose from "mongoose";
+
+const tenantSchema = new mongoose.Schema({
+  _id: { type: String, required: true },
+  domain: { type: String, required: true },
+});
+
+const Tenant = mongoose.model("Tenant", tenantSchema);
+
+export default Tenant;
+export { tenantSchema };

--- a/app/takos_host/models/timeline_event.ts
+++ b/app/takos_host/models/timeline_event.ts
@@ -1,0 +1,14 @@
+import mongoose from "mongoose";
+
+const timelineEventSchema = new mongoose.Schema({
+  tenant_id: { type: String, required: true },
+  object_id: { type: String, required: true },
+  inserted_at: { type: Date, default: Date.now },
+});
+
+timelineEventSchema.index({ tenant_id: 1, inserted_at: -1 });
+
+const TimelineEvent = mongoose.model("TimelineEvent", timelineEventSchema);
+
+export default TimelineEvent;
+export { timelineEventSchema };

--- a/app/takos_host/services/timeline.ts
+++ b/app/takos_host/services/timeline.ts
@@ -1,0 +1,34 @@
+import FollowEdge from "../models/follow_edge.ts";
+import type { PipelineStage } from "mongoose";
+
+export async function getTimeline(
+  tenantId: string,
+  actorUri: string,
+  limit = 40,
+) {
+  const pipeline: PipelineStage[] = [
+    { $match: { tenant_id: tenantId } },
+    {
+      $lookup: {
+        from: "objectstores",
+        localField: "actor_id",
+        foreignField: "actor_id",
+        as: "objs",
+      },
+    },
+    { $unwind: "$objs" },
+    {
+      $match: {
+        $or: [
+          { "objs.aud.to": actorUri },
+          { "objs.aud.cc": actorUri },
+          { "objs.aud.to": "https://www.w3.org/ns/activitystreams#Public" },
+        ],
+      },
+    },
+    { $sort: { "objs.created_at": -1 } },
+    { $limit: limit },
+  ];
+  const result = await FollowEdge.aggregate(pipeline);
+  return result.map((doc) => doc.objs);
+}


### PR DESCRIPTION
## Summary
- takos host 側に統合オブジェクトストアのモデル群を追加
- フォローエッジからオブジェクトを検索するタイムライン取得関数を実装

## Testing
- `deno fmt app/takos_host/models/object_store.ts app/takos_host/models/tenant.ts app/takos_host/models/follow_edge.ts app/takos_host/models/relay_edge.ts app/takos_host/models/timeline_event.ts app/takos_host/services/timeline.ts`
- `deno lint app/takos_host/models/object_store.ts app/takos_host/models/tenant.ts app/takos_host/models/follow_edge.ts app/takos_host/models/relay_edge.ts app/takos_host/models/timeline_event.ts app/takos_host/services/timeline.ts`

------
https://chatgpt.com/codex/tasks/task_e_687510be94c0832886ca72ccafa36f34