### PR TITLE
Fix type mismatch when building activities

### DIFF
--- a/app/api/activitypub.ts
+++ b/app/api/activitypub.ts
@@ -214,8 +214,15 @@ app.post("/users/:username/outbox", async (c) => {
     aud: { to: body.to ?? [], cc: body.cc ?? [] },
   });
   // contentをstringに変換して渡す
+  const stored = object.toObject();
   const activity = buildActivityFromStored(
-    { ...object.toObject(), content: object.content ?? "" },
+    {
+      _id: stored._id,
+      type: stored.type ?? "Note",
+      content: stored.content ?? "",
+      published: stored.published,
+      extra: stored.extra ?? {},
+    },
     domain,
     username,
     true,


### PR DESCRIPTION
## Summary
- buildActivityFromStored() へ渡すオブジェクトのフィールドを明示的に指定し、型エラーを解消

## Testing
- `deno fmt app/api/activitypub.ts`
- `deno lint app/api/activitypub.ts`


------
https://chatgpt.com/codex/tasks/task_e_68779197a8fc8328a97556986a39452b