### PR TITLE
インスタンス一覧のリンク追加

### DIFF
--- a/app/takos_host/client/src/pages/UserPage.tsx
+++ b/app/takos_host/client/src/pages/UserPage.tsx
@@ -161,7 +161,14 @@ const UserPage: Component = () => {
                 {(inst) => (
                   <li class="bg-[#212121] p-4 rounded-lg shadow">
                     <div class="flex justify-between items-center">
-                      <span class="font-semibold">{inst.host}</span>
+                      <a
+                        href={`${globalThis.location.protocol}//${inst.host}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        class="font-semibold hover:underline"
+                      >
+                        {inst.host}
+                      </a>
                       <div class="space-x-2">
                         <button
                           type="button"


### PR DESCRIPTION
## 変更内容
- takos host のユーザーダッシュボードで表示するインスタンス名をリンク化し、クリックで対象インスタンスへ移動できるようにしました。

## テスト
- `deno fmt --check app/takos_host/client/src/pages/UserPage.tsx`
- `deno lint app/takos_host/client/src/pages/UserPage.tsx`


------
https://chatgpt.com/codex/tasks/task_e_687844271b688328a4af01f84eeb4ebb