### PR TITLE
OAuth用ホスト設定をOAUTH_HOSTに変更

### DIFF
--- a/app/api/.env.example
+++ b/app/api/.env.example
@@ -3,10 +3,13 @@ hashedPassword=dda47e55945d0a9b8a81cdb2abac13b18698a3a1b19252013f5a9fe3fa0fb340
 salt=88fffa6cabe7f4ae67fb0d1ba8eab619
 ACTIVITYPUB_DOMAIN=dev.takos.jp
 REGISTRY_URL=http://localhost:8080/_takopack
-# OAuth 認証用ホストを指定します。省略時は ROOT_DOMAIN を用います
-# ROOT_DOMAIN=takos.jp の場合 `https://takos.jp` へ接続します
-# ROOT_DOMAIN を設定していない場合は OAuth 認証を利用できません
-# OAUTH_HOST は廃止されました
+# OAuth 認証を提供する takos host のドメインを指定します
+# 例: OAUTH_HOST=takos.jp または https://takos.jp
+# 未設定の場合は OAuth 認証を利用できません
+OAUTH_HOST=
+# OAuth クライアントIDとシークレットを設定します
+OAUTH_CLIENT_ID=
+OAUTH_CLIENT_SECRET=
 
 # オブジェクトストレージの設定
 # どのプロバイダを使用するか選択します: "local", "s3", "r2", "minio", "gridfs"

--- a/app/api/config.ts
+++ b/app/api/config.ts
@@ -1,0 +1,12 @@
+import { Hono } from "hono";
+import { getEnv } from "./utils/env_store.ts";
+
+const app = new Hono();
+
+app.get("/config", (c) => {
+  const env = getEnv(c);
+  const host = env["OAUTH_HOST"] ?? env["ROOT_DOMAIN"] ?? null;
+  return c.json({ oauthHost: host });
+});
+
+export default app;

--- a/app/api/oauth_login.ts
+++ b/app/api/oauth_login.ts
@@ -8,7 +8,7 @@ const app = new Hono();
 app.post("/oauth/login", async (c) => {
   const { accessToken } = await c.req.json();
   const env = getEnv(c);
-  const host = env["ROOT_DOMAIN"];
+  const host = env["OAUTH_HOST"] ?? env["ROOT_DOMAIN"];
   if (!host) {
     return c.json({ error: "Server configuration error" }, 500);
   }

--- a/app/api/server.ts
+++ b/app/api/server.ts
@@ -21,6 +21,7 @@ import nodeinfo from "./nodeinfo.ts";
 import e2ee from "./e2ee.ts";
 import relays from "./relays.ts";
 import videos, { initVideoModule } from "./videos.ts";
+import config from "./config.ts";
 import { fetchOgpData } from "./services/ogp.ts";
 import { serveStatic } from "hono/deno";
 import type { Context } from "hono";
@@ -33,13 +34,14 @@ export async function createTakosApp(env?: Record<string, string>) {
   initVideoModule(e);
   app.route("/api", login);
   app.route("/api", logout);
-  if (e["ROOT_DOMAIN"]) {
+  if (e["OAUTH_HOST"] || e["ROOT_DOMAIN"]) {
     app.route("/api", oauthLogin);
   }
   app.route("/api", session);
   app.route("/api", accounts);
   app.route("/api", notifications);
   app.route("/api", microblog);
+  app.route("/api", config);
   app.route("/api", videos);
   app.route("/api", search);
   app.route("/api", communities);

--- a/app/takos_host/README.md
+++ b/app/takos_host/README.md
@@ -82,7 +82,9 @@ $ deno task dev
 パスワードを設定した場合は `/login` へパスワードを POST
 してログインできます。`POST /user/instances` で指定したパスワードは
 `hashedPassword` と `salt` としてインスタンスの環境変数に保存されます。 OAuth
-認証は常にホストの `ROOT_DOMAIN` を利用します。
+認証は常にホストの `ROOT_DOMAIN` を利用します。 インスタンスでは `/api/config`
+にアクセスすることで `OAUTH_HOST` を取得でき、 ログイン画面は値が存在する場合に
+OAuth ボタンを表示します。
 
 ## 起動方法
 


### PR DESCRIPTION
## Summary
- OAuth設定の環境変数を`OAUTH_HOST`に変更
- `/api/config` も `oauthHost` を返すよう更新
- ログイン画面は `oauthHost` があるときに OAuth ボタンを表示
- ドキュメントとサンプル環境変数を修正

## Testing
- `deno fmt app/api/config.ts app/api/oauth_login.ts app/api/server.ts app/client/src/components/LoginForm.tsx app/api/.env.example app/takos_host/README.md`
- `deno lint app/api/config.ts app/api/oauth_login.ts app/api/server.ts app/client/src/components/LoginForm.tsx`

------
https://chatgpt.com/codex/tasks/task_e_6878ae88c9148328adee22bdba3c8f62