### PR TITLE
fix oauth client for host instances

### DIFF
--- a/app/takos_host/README.md
+++ b/app/takos_host/README.md
@@ -76,8 +76,9 @@ $ deno task dev
 各インスタンスでは基本的に OAuth を利用してログインします。まず
 `/oauth/authorize` と `/oauth/token` を経由してアクセストークンを取得し、
 インスタンスの `/api/oauth/login`
-へ送信することでダッシュボードへアクセスできます。OAuth クライアントの登録は
-`/user/oauth/clients` から行ってください。
+へ送信することでダッシュボードへアクセスできます。インスタンス作成時に 必要な
+OAuth クライアントは自動登録されますが、追加で登録したい場合は
+`/user/oauth/clients` を利用してください。
 
 パスワードを設定した場合は `/login` へパスワードを POST
 してログインできます。`POST /user/instances` で指定したパスワードは

--- a/app/takos_host/consumer.ts
+++ b/app/takos_host/consumer.ts
@@ -58,6 +58,23 @@ export function createConsumerApp(
         return c.json({ error: "already exists" }, 400);
       }
       const env: Record<string, string> = {};
+      if (rootDomain) {
+        env.OAUTH_HOST = rootDomain;
+        const redirect = `https://${fullHost}`;
+        const clientId = redirect;
+        const clientSecret = crypto.randomUUID();
+        const existsCli = await OAuthClient.findOne({ clientId });
+        if (!existsCli) {
+          const client = new OAuthClient({
+            clientId,
+            clientSecret,
+            redirectUri: redirect,
+          });
+          await client.save();
+        }
+        env.OAUTH_CLIENT_ID = clientId;
+        env.OAUTH_CLIENT_SECRET = clientSecret;
+      }
       if (password) {
         const salt = crypto.randomUUID();
         const hashedPassword = await hash(password + salt);


### PR DESCRIPTION
## Summary
- takos hostがインスタンスを作成する際にOAuthクライアントを自動登録し、環境変数に設定
- README更新: OAuthクライアントは自動登録される旨を追記

## Testing
- `deno fmt app/takos_host/consumer.ts app/takos_host/README.md`
- `deno lint app/takos_host/consumer.ts app/takos_host/README.md`


------
https://chatgpt.com/codex/tasks/task_e_6878bf07951483288146f1194e9630e8