### PR TITLE
fix oauth client for host instances

### DIFF
--- a/app/api/oauth_login.ts
+++ b/app/api/oauth_login.ts
@@ -6,17 +6,43 @@ import Session from "./models/session.ts";
 const app = new Hono();
 
 app.post("/oauth/login", async (c) => {
-  const { accessToken } = await c.req.json();
+  const { accessToken, code } = await c.req.json();
   const env = getEnv(c);
   const host = env["OAUTH_HOST"] ?? env["ROOT_DOMAIN"];
   if (!host) {
     return c.json({ error: "Server configuration error" }, 500);
   }
   const url = host.startsWith("http") ? host : `https://${host}`;
+  let token = accessToken as string | undefined;
+  if (!token && code) {
+    const clientId = env["OAUTH_CLIENT_ID"];
+    const clientSecret = env["OAUTH_CLIENT_SECRET"];
+    if (!clientId || !clientSecret) {
+      return c.json({ error: "Server configuration error" }, 500);
+    }
+    const params = new URLSearchParams({
+      grant_type: "authorization_code",
+      code,
+      client_id: clientId,
+      client_secret: clientSecret,
+      redirect_uri: clientId,
+    });
+    const resp = await fetch(`${url}/oauth/token`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      body: params.toString(),
+    });
+    if (!resp.ok) return c.json({ error: "invalid_code" }, 400);
+    const data = await resp.json();
+    token = data.access_token as string;
+  }
+  if (!token) return c.json({ error: "invalid_request" }, 400);
   const res = await fetch(`${url}/oauth/verify`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ token: accessToken }),
+    body: JSON.stringify({ token }),
   });
   if (!res.ok) return c.json({ error: "Invalid token" }, 401);
   const data = await res.json();

--- a/app/client/src/components/LoginForm.tsx
+++ b/app/client/src/components/LoginForm.tsx
@@ -30,6 +30,31 @@ export function LoginForm(props: LoginFormProps) {
     } catch {
       // ignore
     }
+
+    const params = new URLSearchParams(globalThis.location.search);
+    const code = params.get("code");
+    if (code) {
+      setIsLoading(true);
+      try {
+        const res = await apiFetch("/api/oauth/login", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ code }),
+        });
+        const data = await res.json();
+        if (data.success) {
+          props.onLoginSuccess();
+          history.replaceState(null, "", globalThis.location.pathname);
+          return;
+        }
+        setError(data.error || "OAuth ログインに失敗しました");
+      } catch (err) {
+        console.error("OAuth login failed:", err);
+        setError("通信エラーが発生しました");
+      } finally {
+        setIsLoading(false);
+      }
+    }
   });
 
   onMount(() => {

--- a/app/takos_host/README.md
+++ b/app/takos_host/README.md
@@ -73,11 +73,12 @@ $ deno task dev
 
 ### インスタンスへのログイン
 
-各インスタンスでは基本的に OAuth を利用してログインします。まず
-`/oauth/authorize` と `/oauth/token` を経由してアクセストークンを取得し、
-インスタンスの `/api/oauth/login`
-へ送信することでダッシュボードへアクセスできます。OAuth クライアントの登録は
-`/user/oauth/clients` から行ってください。
+各インスタンスでは基本的に OAuth を利用してログインします。ログイン画面から
+takos host の `/oauth/authorize` へ遷移し、認可後に返される `code` を
+インスタンスの `/api/oauth/login` へ送信すると、サーバー側でアクセストークンを
+取得してセッションを開始します。インスタンス作成時に必要な OAuth クライアントは
+自動登録されますが、追加で登録したい場合は `/user/oauth/clients` を利用してくだ
+さい。
 
 パスワードを設定した場合は `/login` へパスワードを POST
 してログインできます。`POST /user/instances` で指定したパスワードは

--- a/app/takos_host/consumer.ts
+++ b/app/takos_host/consumer.ts
@@ -58,6 +58,23 @@ export function createConsumerApp(
         return c.json({ error: "already exists" }, 400);
       }
       const env: Record<string, string> = {};
+      if (rootDomain) {
+        env.OAUTH_HOST = rootDomain;
+        const redirect = `https://${fullHost}`;
+        const clientId = redirect;
+        const clientSecret = crypto.randomUUID();
+        const existsCli = await OAuthClient.findOne({ clientId });
+        if (!existsCli) {
+          const client = new OAuthClient({
+            clientId,
+            clientSecret,
+            redirectUri: redirect,
+          });
+          await client.save();
+        }
+        env.OAUTH_CLIENT_ID = clientId;
+        env.OAUTH_CLIENT_SECRET = clientSecret;
+      }
       if (password) {
         const salt = crypto.randomUUID();
         const hashedPassword = await hash(password + salt);


### PR DESCRIPTION
## Summary
- takos hostがインスタンスを作成する際にOAuthクライアントを自動登録し、環境変数に設定
- README更新: OAuthクライアントは自動登録される旨を追記
- OAuthログイン時に `code` を用いてサーバーがトークン取得するよう修正
- フロントエンドのログイン画面で `code` を検出して自動ログイン処理

## Testing
- `deno fmt app/api/oauth_login.ts app/client/src/components/LoginForm.tsx app/takos_host/README.md app/takos_host/consumer.ts`
- `deno lint app/api/oauth_login.ts app/client/src/components/LoginForm.tsx app/takos_host/README.md app/takos_host/consumer.ts`


------
https://chatgpt.com/codex/tasks/task_e_6878bf07951483288146f1194e9630e8