### PR TITLE
OAuthログイン処理を追加

### DIFF
--- a/app/api/config.ts
+++ b/app/api/config.ts
@@ -6,7 +6,13 @@ const app = new Hono();
 app.get("/config", (c) => {
   const env = getEnv(c);
   const host = env["OAUTH_HOST"] ?? env["ROOT_DOMAIN"] ?? null;
-  return c.json({ oauthHost: host });
+  const clientId = env["OAUTH_CLIENT_ID"] ?? null;
+  const clientSecret = env["OAUTH_CLIENT_SECRET"] ?? null;
+  return c.json({
+    oauthHost: host,
+    oauthClientId: clientId,
+    oauthClientSecret: clientSecret,
+  });
 });
 
 export default app;


### PR DESCRIPTION
## Summary
- `/api/config` が OAuth クライアント情報を返すよう修正
- ログインフォームで OAuth 認証コードを処理しトークンを取得
- 取得したアクセストークンで `/api/oauth/login` へログイン

## Testing
- `deno fmt app/api/config.ts app/client/src/components/LoginForm.tsx`
- `deno lint app/api/config.ts app/client/src/components/LoginForm.tsx`


------
https://chatgpt.com/codex/tasks/task_e_6878e4f470a083288b9162903e4ada42