### PR TITLE
Fix empty account settings on first login

### DIFF
--- a/app/client/src/components/home/AccountSettingsContent.tsx
+++ b/app/client/src/components/home/AccountSettingsContent.tsx
@@ -229,7 +229,21 @@ const AccountSettingsContent: Component<{
 
   return (
     <div class="min-h-screen">
-      <Show when={selectedAccount()}>
+      <Show
+        when={selectedAccount()}
+        fallback={
+          <div class="py-10 text-center space-y-4">
+            <p class="text-gray-300">アカウントがありません。</p>
+            <button
+              type="button"
+              onClick={() => setShowNewAccountModal(true)}
+              class="px-4 py-2 bg-blue-500 text-white rounded-lg hover:bg-blue-600 transition-colors"
+            >
+              新規アカウント作成
+            </button>
+          </div>
+        }
+      >
         {/* SNS風のプロフィールレイアウト */}
         <div>
           {/* カバー画像エリア */}


### PR DESCRIPTION
## Summary
- 新規ログイン後にアカウントが存在しない場合，作成案内を表示

## Testing
- `deno fmt`
- `deno lint app/client/src/components/home/AccountSettingsContent.tsx`

------
https://chatgpt.com/codex/tasks/task_e_6878ecb8f0ac83288fefe68e5b0276b5