### PR TITLE
Fix TypeScript errors in API

### DIFF
--- a/app/api/activity_handlers.ts
+++ b/app/api/activity_handlers.ts
@@ -1,3 +1,4 @@
+import type { Context } from "hono";
 import Account from "./models/account.ts";
 import {
   addFollowEdge,
@@ -97,7 +98,7 @@ export const activityHandlers: Record<string, ActivityHandler> = {
       string
     >;
     await addFollowEdge(env["ACTIVITYPUB_DOMAIN"] ?? "", activity.actor);
-    const domain = getDomain(c as { req: { url: string } });
+    const domain = getDomain(c as Context);
     const accept = createAcceptActivity(
       domain,
       `https://${domain}/users/${username}`,

--- a/app/api/communities.ts
+++ b/app/api/communities.ts
@@ -111,6 +111,8 @@ app.get("/communities", async (c) => {
 app.post("/communities", async (c) => {
   try {
     const domain = getDomain(c);
+    const env = getEnv(c);
+    const tenantId = env["ACTIVITYPUB_DOMAIN"] ?? "";
     const { name, description, isPrivate, tags, avatar, banner } = await c.req
       .json();
 
@@ -354,7 +356,7 @@ app.post("/communities/:id/posts", async (c) => {
     const account = await Account.findOne({ userName: author }).lean();
 
     return c.json({
-      id: post._id.toString(),
+      id: String(post._id),
       communityId,
       content: post.content,
       userName: post.attributedTo,

--- a/app/api/group.ts
+++ b/app/api/group.ts
@@ -171,7 +171,17 @@ app.get("/communities/:name/outbox", async (c) => {
         type: "OrderedCollectionPage",
         partOf: baseId,
         orderedItems: items.map((n) =>
-          buildGroupActivity({ ...n, content: n.content ?? "" }, domain, name)
+          buildGroupActivity(
+            {
+              _id: n._id,
+              type: n.type ?? "Note",
+              content: n.content ?? "",
+              published: n.published,
+              extra: n.extra ?? {},
+            },
+            domain,
+            name,
+          )
         ),
         next,
         prev,


### PR DESCRIPTION
## Summary
- fix undefined variables when creating communities
- cast to `Context` in activity handler
- ensure object fields when building group activities
- avoid `_id` nullable issue when creating community posts

## Testing
- `deno fmt app/api/communities.ts app/api/group.ts app/api/activity_handlers.ts`
- `deno lint app/api/communities.ts app/api/group.ts app/api/activity_handlers.ts`

------
https://chatgpt.com/codex/tasks/task_e_6879764b990c8328a4d671448a3dcd61