### PR TITLE
Apply zod validation to API

### DIFF
--- a/app/api/login.ts
+++ b/app/api/login.ts
@@ -1,56 +1,63 @@
 import { Hono } from "hono";
 import { setCookie } from "hono/cookie";
+import { z } from "zod";
+import { zValidator } from "@hono/zod-validator";
 import { getEnv } from "./utils/env_store.ts";
 import Session from "./models/session.ts";
 
 const app = new Hono();
 
-app.post("/login", async (c) => {
-  const { password } = await c.req.json();
-  const env = getEnv(c);
-  const hashedPassword = env["hashedPassword"];
-  const salt = env["salt"];
-  if (!hashedPassword || !salt) {
-    return c.json({ error: "not_configured" }, 400);
-  }
-  try {
-    const encoder = new TextEncoder();
-    const data = encoder.encode(password + salt);
-    const hashBuffer = await crypto.subtle.digest("SHA-256", data);
-    const hashArray = Array.from(new Uint8Array(hashBuffer));
-    const hashHex = hashArray.map((b) => b.toString(16).padStart(2, "0")).join(
-      "",
-    );
-
-    if (hashHex === hashedPassword) {
-      const sessionId = crypto.randomUUID();
-      const expiresAt = new Date(Date.now() + 24 * 60 * 60 * 1000); // 24 hours from now
-
-      const session = new Session({
-        sessionId,
-        expiresAt,
-      });
-      (session as unknown as { $locals?: { env?: Record<string, string> } })
-        .$locals = { env };
-
-      await session.save();
-
-      setCookie(c, "sessionId", sessionId, {
-        path: "/",
-        httpOnly: true,
-        secure: c.req.url.startsWith("https://"),
-        expires: expiresAt,
-        sameSite: "Lax",
-      });
-
-      return c.json({ success: true, message: "Login successful" });
-    } else {
-      return c.json({ error: "Invalid password" }, 401);
+app.post(
+  "/login",
+  zValidator("json", z.object({ password: z.string() })),
+  async (c) => {
+    const { password } = c.req.valid("json") as { password: string };
+    const env = getEnv(c);
+    const hashedPassword = env["hashedPassword"];
+    const salt = env["salt"];
+    if (!hashedPassword || !salt) {
+      return c.json({ error: "not_configured" }, 400);
     }
-  } catch (error) {
-    console.error("Login error:", error);
-    return c.json({ error: "Authentication failed" }, 500);
-  }
-});
+    try {
+      const encoder = new TextEncoder();
+      const data = encoder.encode(password + salt);
+      const hashBuffer = await crypto.subtle.digest("SHA-256", data);
+      const hashArray = Array.from(new Uint8Array(hashBuffer));
+      const hashHex = hashArray.map((b) => b.toString(16).padStart(2, "0"))
+        .join(
+          "",
+        );
+
+      if (hashHex === hashedPassword) {
+        const sessionId = crypto.randomUUID();
+        const expiresAt = new Date(Date.now() + 24 * 60 * 60 * 1000); // 24 hours from now
+
+        const session = new Session({
+          sessionId,
+          expiresAt,
+        });
+        (session as unknown as { $locals?: { env?: Record<string, string> } })
+          .$locals = { env };
+
+        await session.save();
+
+        setCookie(c, "sessionId", sessionId, {
+          path: "/",
+          httpOnly: true,
+          secure: c.req.url.startsWith("https://"),
+          expires: expiresAt,
+          sameSite: "Lax",
+        });
+
+        return c.json({ success: true, message: "Login successful" });
+      } else {
+        return c.json({ error: "Invalid password" }, 401);
+      }
+    } catch (error) {
+      console.error("Login error:", error);
+      return c.json({ error: "Authentication failed" }, 500);
+    }
+  },
+);
 
 export default app;

--- a/app/api/microblog.ts
+++ b/app/api/microblog.ts
@@ -1,4 +1,6 @@
 import { Hono } from "hono";
+import { z } from "zod";
+import { zValidator } from "@hono/zod-validator";
 import {
   deleteObject,
   findObjects,
@@ -178,52 +180,67 @@ app.get("/microblog", async (c) => {
   return c.json(formatted);
 });
 
-app.post("/microblog", async (c) => {
-  const domain = getDomain(c);
-  const {
-    author,
-    content,
-    attachments,
-    parentId,
-    quoteId,
-  } = await c.req.json();
+app.post(
+  "/microblog",
+  zValidator(
+    "json",
+    z.object({
+      author: z.string(),
+      content: z.string(),
+      attachments: z.array(z.unknown()).optional(),
+      parentId: z.string().optional(),
+      quoteId: z.string().optional(),
+    }),
+  ),
+  async (c) => {
+    const domain = getDomain(c);
+    const {
+      author,
+      content,
+      attachments,
+      parentId,
+      quoteId,
+    } = c.req.valid("json") as {
+      author: string;
+      content: string;
+      attachments?: unknown[];
+      parentId?: string;
+      quoteId?: string;
+    };
 
-  if (typeof author !== "string" || typeof content !== "string") {
-    return c.json({ error: "Invalid body" }, 400);
-  }
+    const extra: Record<string, unknown> = { likes: 0, retweets: 0 };
+    if (Array.isArray(attachments)) extra.attachments = attachments;
+    if (typeof parentId === "string") extra.inReplyTo = parentId;
+    if (typeof quoteId === "string") extra.quoteId = quoteId;
+    if (typeof parentId === "string") extra.replies = 0;
 
-  const extra: Record<string, unknown> = { likes: 0, retweets: 0 };
-  if (Array.isArray(attachments)) extra.attachments = attachments;
-  if (typeof parentId === "string") extra.inReplyTo = parentId;
-  if (typeof quoteId === "string") extra.quoteId = quoteId;
-  if (typeof parentId === "string") extra.replies = 0;
+    const env = getEnv(c);
+    const post = await saveNote(env, domain, author, content, extra);
 
-  const env = getEnv(c);
-  const post = await saveNote(env, domain, author, content, extra);
+    if (typeof parentId === "string") {
+      await updateObject(env, parentId, { $inc: { "extra.replies": 1 } }).catch(
+        () => {},
+      );
+    }
 
-  if (typeof parentId === "string") {
-    await updateObject(env, parentId, { $inc: { "extra.replies": 1 } }).catch(
-      () => {},
+    deliverPostToFollowers(
+      env,
+      post,
+      author,
+      domain,
+      typeof parentId === "string" ? parentId : undefined,
     );
-  }
 
-  deliverPostToFollowers(
-    env,
-    post,
-    author,
-    domain,
-    typeof parentId === "string" ? parentId : undefined,
-  );
-
-  const userInfo = await getUserInfo(post.attributedTo as string, domain);
-  return c.json(
-    formatUserInfoForPost(
-      userInfo,
-      post.toObject() as unknown as Record<string, unknown>,
-    ),
-    201,
-  );
-});
+    const userInfo = await getUserInfo(post.attributedTo as string, domain);
+    return c.json(
+      formatUserInfoForPost(
+        userInfo,
+        post.toObject() as unknown as Record<string, unknown>,
+      ),
+      201,
+    );
+  },
+);
 
 app.get("/microblog/:id", async (c) => {
   const domain = getDomain(c);
@@ -252,180 +269,186 @@ app.get("/microblog/:id/replies", async (c) => {
   return c.json(formatted);
 });
 
-app.put("/microblog/:id", async (c) => {
-  const domain = getDomain(c);
-  const id = c.req.param("id");
-  const { content } = await c.req.json();
-  if (typeof content !== "string") {
-    return c.json({ error: "Invalid body" }, 400);
-  }
-  const env = getEnv(c);
-  const post = await updateObject(env, id, { content });
-  if (!post) return c.json({ error: "Not found" }, 404);
-
-  // 共通ユーザー情報取得サービスを使用
-  const userInfo = await getUserInfo(post.attributedTo as string, domain);
-
-  return c.json(
-    formatUserInfoForPost(
-      userInfo,
-      post.toObject() as unknown as Record<string, unknown>,
-    ),
-  );
-});
-
-app.post("/microblog/:id/like", async (c) => {
-  const domain = getDomain(c);
-  const id = c.req.param("id");
-  const { username } = await c.req.json();
-  if (typeof username !== "string") {
-    return c.json({ error: "Invalid body" }, 400);
-  }
-  const env = getEnv(c);
-  const post = await getObject(env, id);
-  if (!post) return c.json({ error: "Not found" }, 404);
-
-  const extra = post.extra as Record<string, unknown> ?? {};
-  const likedBy: string[] = Array.isArray(extra.likedBy)
-    ? extra.likedBy as string[]
-    : [];
-  if (!likedBy.includes(username)) {
-    likedBy.push(username);
-    extra.likedBy = likedBy;
-    extra.likes = likedBy.length;
+app.put(
+  "/microblog/:id",
+  zValidator("json", z.object({ content: z.string() })),
+  async (c) => {
+    const domain = getDomain(c);
+    const id = c.req.param("id");
+    const { content } = c.req.valid("json") as { content: string };
     const env = getEnv(c);
-    await updateObject(env, id, { extra });
+    const post = await updateObject(env, id, { content });
+    if (!post) return c.json({ error: "Not found" }, 404);
 
-    const actorId = `https://${domain}/users/${username}`;
-    const objectUrl = typeof post.raw?.id === "string"
-      ? post.raw.id as string
-      : `https://${domain}/objects/${post._id}`;
-    let inboxes: string[] = [];
-    if (
-      typeof post.attributedTo === "string" &&
-      post.attributedTo.startsWith("http")
-    ) {
-      const inbox = await fetchActorInbox(post.attributedTo as string, env);
-      if (inbox) inboxes.push(inbox);
-    } else {
-      const account = await Account.findOne({ userName: post.attributedTo })
-        .lean();
+    // 共通ユーザー情報取得サービスを使用
+    const userInfo = await getUserInfo(post.attributedTo as string, domain);
+
+    return c.json(
+      formatUserInfoForPost(
+        userInfo,
+        post.toObject() as unknown as Record<string, unknown>,
+      ),
+    );
+  },
+);
+
+app.post(
+  "/microblog/:id/like",
+  zValidator("json", z.object({ username: z.string() })),
+  async (c) => {
+    const domain = getDomain(c);
+    const id = c.req.param("id");
+    const { username } = c.req.valid("json") as { username: string };
+    const env = getEnv(c);
+    const post = await getObject(env, id);
+    if (!post) return c.json({ error: "Not found" }, 404);
+
+    const extra = post.extra as Record<string, unknown> ?? {};
+    const likedBy: string[] = Array.isArray(extra.likedBy)
+      ? extra.likedBy as string[]
+      : [];
+    if (!likedBy.includes(username)) {
+      likedBy.push(username);
+      extra.likedBy = likedBy;
+      extra.likes = likedBy.length;
+      const env = getEnv(c);
+      await updateObject(env, id, { extra });
+
+      const actorId = `https://${domain}/users/${username}`;
+      const objectUrl = typeof post.raw?.id === "string"
+        ? post.raw.id as string
+        : `https://${domain}/objects/${post._id}`;
+      let inboxes: string[] = [];
+      if (
+        typeof post.attributedTo === "string" &&
+        post.attributedTo.startsWith("http")
+      ) {
+        const inbox = await fetchActorInbox(post.attributedTo as string, env);
+        if (inbox) inboxes.push(inbox);
+      } else {
+        const account = await Account.findOne({ userName: post.attributedTo })
+          .lean();
+        inboxes = account?.followers ?? [];
+      }
+      if (inboxes.length > 0) {
+        const like = createLikeActivity(domain, actorId, objectUrl);
+        deliverActivityPubObject(inboxes, like, username, domain, env).catch(
+          (err) => {
+            console.error("Delivery failed:", err);
+          },
+        );
+      }
+
+      let localAuthor: string | null = null;
+      if (typeof post.attributedTo === "string") {
+        if (post.attributedTo.startsWith("http")) {
+          try {
+            const url = new URL(post.attributedTo);
+            if (url.hostname === domain && url.pathname.startsWith("/users/")) {
+              localAuthor = url.pathname.split("/")[2];
+            }
+          } catch {
+            /* ignore */
+          }
+        } else {
+          localAuthor = post.attributedTo;
+        }
+      }
+      if (localAuthor) {
+        await addNotification(
+          "新しいいいね",
+          `${username}さんが${localAuthor}さんの投稿をいいねしました`,
+          "info",
+          env,
+        );
+      }
+    }
+
+    return c.json({
+      likes: (post.extra as Record<string, unknown>)?.likes ?? 0,
+    });
+  },
+);
+
+app.post(
+  "/microblog/:id/retweet",
+  zValidator("json", z.object({ username: z.string() })),
+  async (c) => {
+    const domain = getDomain(c);
+    const id = c.req.param("id");
+    const { username } = c.req.valid("json") as { username: string };
+    const env = getEnv(c);
+    const post = await getObject(env, id);
+    if (!post) return c.json({ error: "Not found" }, 404);
+
+    const extra = post.extra as Record<string, unknown>;
+    const retweetedBy: string[] = Array.isArray(extra.retweetedBy)
+      ? extra.retweetedBy as string[]
+      : [];
+    if (!retweetedBy.includes(username)) {
+      retweetedBy.push(username);
+      extra.retweetedBy = retweetedBy;
+      extra.retweets = retweetedBy.length;
+      const env = getEnv(c);
+      await updateObject(env, id, { extra });
+
+      const actorId = `https://${domain}/users/${username}`;
+      const objectUrl = typeof post.raw?.id === "string"
+        ? post.raw.id as string
+        : `https://${domain}/objects/${post._id}`;
+
+      let inboxes: string[] = [];
+      const account = await Account.findOne({ userName: username }).lean();
       inboxes = account?.followers ?? [];
-    }
-    if (inboxes.length > 0) {
-      const like = createLikeActivity(domain, actorId, objectUrl);
-      deliverActivityPubObject(inboxes, like, username, domain, env).catch(
-        (err) => {
-          console.error("Delivery failed:", err);
-        },
-      );
-    }
 
-    let localAuthor: string | null = null;
-    if (typeof post.attributedTo === "string") {
-      if (post.attributedTo.startsWith("http")) {
-        try {
-          const url = new URL(post.attributedTo);
-          if (url.hostname === domain && url.pathname.startsWith("/users/")) {
-            localAuthor = url.pathname.split("/")[2];
+      if (
+        typeof post.attributedTo === "string" &&
+        post.attributedTo.startsWith("http")
+      ) {
+        const inbox = await fetchActorInbox(post.attributedTo as string, env);
+        if (inbox) inboxes.push(inbox);
+      }
+
+      if (inboxes.length > 0) {
+        const announce = createAnnounceActivity(domain, actorId, objectUrl);
+        deliverActivityPubObject(inboxes, announce, username, domain, env)
+          .catch(
+            (err) => {
+              console.error("Delivery failed:", err);
+            },
+          );
+      }
+
+      let localAuthor: string | null = null;
+      if (typeof post.attributedTo === "string") {
+        if (post.attributedTo.startsWith("http")) {
+          try {
+            const url = new URL(post.attributedTo);
+            if (url.hostname === domain && url.pathname.startsWith("/users/")) {
+              localAuthor = url.pathname.split("/")[2];
+            }
+          } catch {
+            /* ignore */
           }
-        } catch {
-          /* ignore */
+        } else {
+          localAuthor = post.attributedTo;
         }
-      } else {
-        localAuthor = post.attributedTo;
+      }
+      if (localAuthor) {
+        await addNotification(
+          "新しいリツイート",
+          `${username}さんが${localAuthor}さんの投稿をリツイートしました`,
+          "info",
+          env,
+        );
       }
     }
-    if (localAuthor) {
-      await addNotification(
-        "新しいいいね",
-        `${username}さんが${localAuthor}さんの投稿をいいねしました`,
-        "info",
-        env,
-      );
-    }
-  }
 
-  return c.json({ likes: (post.extra as Record<string, unknown>)?.likes ?? 0 });
-});
-
-app.post("/microblog/:id/retweet", async (c) => {
-  const domain = getDomain(c);
-  const id = c.req.param("id");
-  const { username } = await c.req.json();
-  if (typeof username !== "string") {
-    return c.json({ error: "Invalid body" }, 400);
-  }
-  const env = getEnv(c);
-  const post = await getObject(env, id);
-  if (!post) return c.json({ error: "Not found" }, 404);
-
-  const extra = post.extra as Record<string, unknown>;
-  const retweetedBy: string[] = Array.isArray(extra.retweetedBy)
-    ? extra.retweetedBy as string[]
-    : [];
-  if (!retweetedBy.includes(username)) {
-    retweetedBy.push(username);
-    extra.retweetedBy = retweetedBy;
-    extra.retweets = retweetedBy.length;
-    const env = getEnv(c);
-    await updateObject(env, id, { extra });
-
-    const actorId = `https://${domain}/users/${username}`;
-    const objectUrl = typeof post.raw?.id === "string"
-      ? post.raw.id as string
-      : `https://${domain}/objects/${post._id}`;
-
-    let inboxes: string[] = [];
-    const account = await Account.findOne({ userName: username }).lean();
-    inboxes = account?.followers ?? [];
-
-    if (
-      typeof post.attributedTo === "string" &&
-      post.attributedTo.startsWith("http")
-    ) {
-      const inbox = await fetchActorInbox(post.attributedTo as string, env);
-      if (inbox) inboxes.push(inbox);
-    }
-
-    if (inboxes.length > 0) {
-      const announce = createAnnounceActivity(domain, actorId, objectUrl);
-      deliverActivityPubObject(inboxes, announce, username, domain, env).catch(
-        (err) => {
-          console.error("Delivery failed:", err);
-        },
-      );
-    }
-
-    let localAuthor: string | null = null;
-    if (typeof post.attributedTo === "string") {
-      if (post.attributedTo.startsWith("http")) {
-        try {
-          const url = new URL(post.attributedTo);
-          if (url.hostname === domain && url.pathname.startsWith("/users/")) {
-            localAuthor = url.pathname.split("/")[2];
-          }
-        } catch {
-          /* ignore */
-        }
-      } else {
-        localAuthor = post.attributedTo;
-      }
-    }
-    if (localAuthor) {
-      await addNotification(
-        "新しいリツイート",
-        `${username}さんが${localAuthor}さんの投稿をリツイートしました`,
-        "info",
-        env,
-      );
-    }
-  }
-
-  return c.json({
-    retweets: (post.extra as Record<string, unknown>)?.retweets ?? 0,
-  });
-});
+    return c.json({
+      retweets: (post.extra as Record<string, unknown>)?.retweets ?? 0,
+    });
+  },
+);
 
 app.delete("/microblog/:id", async (c) => {
   const env = getEnv(c);

--- a/app/api/oauth_login.ts
+++ b/app/api/oauth_login.ts
@@ -1,40 +1,46 @@
 import { Hono } from "hono";
 import { setCookie } from "hono/cookie";
+import { z } from "zod";
+import { zValidator } from "@hono/zod-validator";
 import { getEnv } from "./utils/env_store.ts";
 import Session from "./models/session.ts";
 
 const app = new Hono();
 
-app.post("/oauth/login", async (c) => {
-  const { accessToken } = await c.req.json();
-  const env = getEnv(c);
-  const host = env["OAUTH_HOST"] ?? env["ROOT_DOMAIN"];
-  if (!host) {
-    return c.json({ error: "Server configuration error" }, 500);
-  }
-  const url = host.startsWith("http") ? host : `https://${host}`;
-  const res = await fetch(`${url}/oauth/verify`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ token: accessToken }),
-  });
-  if (!res.ok) return c.json({ error: "Invalid token" }, 401);
-  const data = await res.json();
-  if (!data.active) return c.json({ error: "Invalid token" }, 401);
-  const sessionId = crypto.randomUUID();
-  const expiresAt = new Date(Date.now() + 24 * 60 * 60 * 1000);
-  const session = new Session({ sessionId, expiresAt });
-  (session as unknown as { $locals?: { env?: Record<string, string> } })
-    .$locals = { env };
-  await session.save();
-  setCookie(c, "sessionId", sessionId, {
-    path: "/",
-    httpOnly: true,
-    secure: c.req.url.startsWith("https://"),
-    expires: expiresAt,
-    sameSite: "Lax",
-  });
-  return c.json({ success: true, message: "Login successful" });
-});
+app.post(
+  "/oauth/login",
+  zValidator("json", z.object({ accessToken: z.string() })),
+  async (c) => {
+    const { accessToken } = c.req.valid("json") as { accessToken: string };
+    const env = getEnv(c);
+    const host = env["OAUTH_HOST"] ?? env["ROOT_DOMAIN"];
+    if (!host) {
+      return c.json({ error: "Server configuration error" }, 500);
+    }
+    const url = host.startsWith("http") ? host : `https://${host}`;
+    const res = await fetch(`${url}/oauth/verify`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ token: accessToken }),
+    });
+    if (!res.ok) return c.json({ error: "Invalid token" }, 401);
+    const data = await res.json();
+    if (!data.active) return c.json({ error: "Invalid token" }, 401);
+    const sessionId = crypto.randomUUID();
+    const expiresAt = new Date(Date.now() + 24 * 60 * 60 * 1000);
+    const session = new Session({ sessionId, expiresAt });
+    (session as unknown as { $locals?: { env?: Record<string, string> } })
+      .$locals = { env };
+    await session.save();
+    setCookie(c, "sessionId", sessionId, {
+      path: "/",
+      httpOnly: true,
+      secure: c.req.url.startsWith("https://"),
+      expires: expiresAt,
+      sameSite: "Lax",
+    });
+    return c.json({ success: true, message: "Login successful" });
+  },
+);
 
 export default app;

--- a/app/api/relays.ts
+++ b/app/api/relays.ts
@@ -1,4 +1,6 @@
 import { Hono } from "hono";
+import { z } from "zod";
+import { zValidator } from "@hono/zod-validator";
 import Relay from "./models/relay.ts";
 import authRequired from "./utils/auth.ts";
 import { getEnv } from "./utils/env_store.ts";
@@ -20,36 +22,37 @@ app.get("/relays", async (c) => {
   return jsonResponse(c, { relays });
 });
 
-app.post("/relays", async (c) => {
-  const { inboxUrl } = await c.req.json();
-  if (!inboxUrl || typeof inboxUrl !== "string") {
-    return jsonResponse(c, { error: "Invalid body" }, 400);
-  }
-  const exists = await Relay.findOne({ inboxUrl });
-  if (exists) return jsonResponse(c, { error: "Already exists" }, 409);
-  const relay = new Relay({ inboxUrl });
-  await relay.save();
-  const env = getEnv(c);
-  const tenant = env["ACTIVITYPUB_DOMAIN"] ?? getDomain(c);
-  try {
-    const host = new URL(inboxUrl).hostname;
-    await addRelayEdge(tenant, host, "pull");
-    await addRelayEdge(tenant, host, "push");
-  } catch {
-    // URL パース失敗時は無視
-  }
-  try {
-    const domain = getDomain(c);
-    await getSystemKey(domain);
-    const actorId = `https://${domain}/users/system`;
-    const target = "https://www.w3.org/ns/activitystreams#Public";
-    const follow = createFollowActivity(domain, actorId, target);
-    await sendActivityPubObject(inboxUrl, follow, "system", domain);
-  } catch (err) {
-    console.error("Failed to follow relay:", err);
-  }
-  return jsonResponse(c, { id: String(relay._id), inboxUrl: relay.inboxUrl });
-});
+app.post(
+  "/relays",
+  zValidator("json", z.object({ inboxUrl: z.string() })),
+  async (c) => {
+    const { inboxUrl } = c.req.valid("json") as { inboxUrl: string };
+    const exists = await Relay.findOne({ inboxUrl });
+    if (exists) return jsonResponse(c, { error: "Already exists" }, 409);
+    const relay = new Relay({ inboxUrl });
+    await relay.save();
+    const env = getEnv(c);
+    const tenant = env["ACTIVITYPUB_DOMAIN"] ?? getDomain(c);
+    try {
+      const host = new URL(inboxUrl).hostname;
+      await addRelayEdge(tenant, host, "pull");
+      await addRelayEdge(tenant, host, "push");
+    } catch {
+      // URL パース失敗時は無視
+    }
+    try {
+      const domain = getDomain(c);
+      await getSystemKey(domain);
+      const actorId = `https://${domain}/users/system`;
+      const target = "https://www.w3.org/ns/activitystreams#Public";
+      const follow = createFollowActivity(domain, actorId, target);
+      await sendActivityPubObject(inboxUrl, follow, "system", domain);
+    } catch (err) {
+      console.error("Failed to follow relay:", err);
+    }
+    return jsonResponse(c, { id: String(relay._id), inboxUrl: relay.inboxUrl });
+  },
+);
 
 app.delete("/relays/:id", async (c) => {
   const id = c.req.param("id");


### PR DESCRIPTION
## Summary
- `/login` を `zValidator` でラップし、`password` を明示
- その他の API でも `zValidator` を導入し、型検証を統一
- 不正な入力時は 400 を返すよう整理

## Testing
- `deno fmt`
- `deno lint`

------
https://chatgpt.com/codex/tasks/task_e_6879886734ac83289a461463c9b9d2da