### PR TITLE
Implement route-level rate limits

### DIFF
--- a/app/api/microblog.ts
+++ b/app/api/microblog.ts
@@ -34,6 +34,7 @@ import {
   getUserInfoBatch,
 } from "./services/user-info.ts";
 import { addNotification } from "./services/notification.ts";
+import { rateLimit } from "./utils/rate_limit.ts";
 
 // --- Helper Functions ---
 
@@ -182,6 +183,7 @@ app.get("/microblog", async (c) => {
 
 app.post(
   "/microblog",
+  rateLimit({ windowMs: 60_000, limit: 10 }),
   zValidator(
     "json",
     z.object({

--- a/app/api/server.ts
+++ b/app/api/server.ts
@@ -26,12 +26,14 @@ import config from "./config.ts";
 import { fetchOgpData } from "./services/ogp.ts";
 import { serveStatic } from "hono/deno";
 import type { Context } from "hono";
+import { rateLimit } from "./utils/rate_limit.ts";
 
 export async function createTakosApp(env?: Record<string, string>) {
   const e = env ?? await load();
 
   const app = new Hono();
   initEnv(app, e);
+  app.use("/api/*", rateLimit({ windowMs: 60_000, limit: 100 }));
   initVideoModule(e);
   app.route("/api", login);
   app.route("/api", logout);

--- a/app/api/utils/rate_limit.ts
+++ b/app/api/utils/rate_limit.ts
@@ -1,0 +1,42 @@
+import type { MiddlewareHandler } from "hono";
+
+export interface RateLimitOptions {
+  windowMs?: number;
+  limit?: number;
+  keyGenerator?: (c: Parameters<MiddlewareHandler>[0]) => string;
+}
+
+const counters = new Map<string, { count: number; expires: number }>();
+
+export function rateLimit(options: RateLimitOptions = {}): MiddlewareHandler {
+  const windowMs = options.windowMs ?? 60_000;
+  const limit = options.limit ?? 100;
+  const keyGenerator = options.keyGenerator ??
+    ((c) =>
+      c.req.header("x-forwarded-for") ?? c.req.raw.headers.get("x-real-ip") ??
+        "unknown");
+  return async (c, next) => {
+    const key = keyGenerator(c);
+    const now = Date.now();
+    const entry = counters.get(key) ?? { count: 0, expires: now + windowMs };
+    if (now > entry.expires) {
+      entry.count = 0;
+      entry.expires = now + windowMs;
+    }
+    entry.count++;
+    counters.set(key, entry);
+    if (entry.count > limit) {
+      c.res.headers.set(
+        "Retry-After",
+        String(Math.ceil((entry.expires - now) / 1000)),
+      );
+      return c.json({ error: "アクセスが多すぎます" }, 429);
+    }
+    c.res.headers.set("X-RateLimit-Limit", String(limit));
+    c.res.headers.set(
+      "X-RateLimit-Remaining",
+      String(Math.max(limit - entry.count, 0)),
+    );
+    await next();
+  };
+}

--- a/app/api/videos.ts
+++ b/app/api/videos.ts
@@ -14,6 +14,7 @@ import {
 import Account from "./models/account.ts";
 import authRequired from "./utils/auth.ts";
 import { getEnv } from "./utils/env_store.ts";
+import { rateLimit } from "./utils/rate_limit.ts";
 import {
   buildActivityFromStored,
   createCreateActivity,
@@ -252,7 +253,7 @@ app.get("/videos", async (c) => {
   return c.json(result);
 });
 
-app.post("/videos", async (c) => {
+app.post("/videos", rateLimit({ windowMs: 60_000, limit: 5 }), async (c) => {
   const domain = getDomain(c);
   const contentType = c.req.header("content-type") || "";
   if (!contentType.includes("multipart/form-data")) {


### PR DESCRIPTION
## Summary
- レート制限ミドルウェアに keyGenerator オプションを追加
- ツイート・動画・メッセージ投稿エンドポイントへ個別レート制限を適用

## Testing
- `deno fmt app/api/utils/rate_limit.ts app/api/microblog.ts app/api/videos.ts app/api/e2ee.ts app/api/server.ts`
- `deno lint app/api/utils/rate_limit.ts app/api/microblog.ts app/api/videos.ts app/api/e2ee.ts app/api/server.ts`


------
https://chatgpt.com/codex/tasks/task_e_68799a87613c832883a7206956ce0c20