### PR TITLE
takos host: add verification page

### DIFF
--- a/app/api/login.ts
+++ b/app/api/login.ts
@@ -1,6 +1,6 @@
 import { Hono } from "hono";
 import { setCookie } from "hono/cookie";
-import { compare } from "bcrypt";                   // bcrypt で検証
+import { compare } from "bcrypt"; // bcrypt で検証
 import { z } from "zod";
 import { zValidator } from "@hono/zod-validator";
 import { getEnv } from "./utils/env_store.ts";
@@ -21,7 +21,7 @@ app.post(
     const { password } = c.req.valid("json") as { password: string };
 
     const env = getEnv(c);
-    const hashedPassword = env["hashedPassword"];   // bcrypt でハッシュ化済み文字列を想定
+    const hashedPassword = env["hashedPassword"]; // bcrypt でハッシュ化済み文字列を想定
 
     if (!hashedPassword) {
       return c.json({ error: "not_configured" }, 400);
@@ -36,11 +36,12 @@ app.post(
 
       // ✅ セッション生成
       const sessionId = crypto.randomUUID();
-      const expiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000); // 7 days
+      const expiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000); // 7 days
 
       const session = new Session({ sessionId, expiresAt });
       // Mongoose 互換の $locals に環境変数を渡す
-      (session as unknown as { $locals?: { env?: Record<string, string> } }).$locals = { env };
+      (session as unknown as { $locals?: { env?: Record<string, string> } })
+        .$locals = { env };
       await session.save();
 
       // ✅ Cookie 設定

--- a/app/takos_host/auth.ts
+++ b/app/takos_host/auth.ts
@@ -15,7 +15,7 @@ export function createAuthApp(options?: {
   termsRequired?: boolean;
 }) {
   const app = new Hono();
-  const rootDomain   = options?.rootDomain   ?? "";
+  const rootDomain = options?.rootDomain ?? "";
   const termsRequired = options?.termsRequired ?? false;
 
   /* --------------------------- REGISTER --------------------------- */
@@ -23,7 +23,7 @@ export function createAuthApp(options?: {
     const { userName, email, password, accepted } = await c.req.json();
     if (
       typeof userName !== "string" ||
-      typeof email   !== "string" ||
+      typeof email !== "string" ||
       typeof password !== "string" ||
       (termsRequired && accepted !== true)
     ) {
@@ -33,9 +33,9 @@ export function createAuthApp(options?: {
     const exists = await HostUser.findOne({ $or: [{ userName }, { email }] });
     if (exists) return c.json({ error: "exists" }, 400);
 
-    const hashedPassword     = await hash(password);
-    const verifyCode         = Math.floor(100000 + Math.random() * 900000).toString();
-    const verifyCodeExpires  = new Date(Date.now() + 10 * 60 * 1000); // 10 min
+    const hashedPassword = await hash(password);
+    const verifyCode = Math.floor(100000 + Math.random() * 900000).toString();
+    const verifyCodeExpires = new Date(Date.now() + 10 * 60 * 1000); // 10 min
 
     const user = new HostUser({
       userName,
@@ -62,15 +62,15 @@ export function createAuthApp(options?: {
     if (
       !user ||
       user.emailVerified ||
-      user.verifyCode          !== code ||
-      !user.verifyCodeExpires  ||
-      user.verifyCodeExpires   <= new Date()
+      user.verifyCode !== code ||
+      !user.verifyCodeExpires ||
+      user.verifyCodeExpires <= new Date()
     ) {
       return c.json({ error: "invalid" }, 400);
     }
 
-    user.emailVerified   = true;
-    user.verifyCode      = undefined;
+    user.emailVerified = true;
+    user.verifyCode = undefined;
     user.verifyCodeExpires = undefined;
     await user.save();
 
@@ -85,22 +85,22 @@ export function createAuthApp(options?: {
     }
 
     const user = await HostUser.findOne({ userName });
-    if (!user)                    return c.json({ error: "invalid"   }, 401);
-    if (!user.emailVerified)      return c.json({ error: "unverified"}, 403);
+    if (!user) return c.json({ error: "invalid" }, 401);
+    if (!user.emailVerified) return c.json({ error: "unverified" }, 403);
 
     const ok = await compare(password, user.hashedPassword);
     if (!ok) return c.json({ error: "invalid" }, 401);
 
-    const sessionId  = crypto.randomUUID();
-    const expiresAt  = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000); // 7 days
+    const sessionId = crypto.randomUUID();
+    const expiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000); // 7 days
     await new HostSession({ sessionId, user: user._id, expiresAt }).save();
 
     setCookie(c, "hostSessionId", sessionId, {
-      httpOnly : true,
-      secure   : c.req.url.startsWith("https://"),
-      expires  : expiresAt,
-      sameSite : "Lax",
-      path     : "/",
+      httpOnly: true,
+      secure: c.req.url.startsWith("https://"),
+      expires: expiresAt,
+      sameSite: "Lax",
+      path: "/",
     });
 
     return c.json({ success: true });
@@ -117,15 +117,15 @@ export function createAuthApp(options?: {
       session.expiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
       await session.save();
       setCookie(c, "hostSessionId", sid, {
-        httpOnly : true,
-        secure   : c.req.url.startsWith("https://"),
-        expires  : session.expiresAt,
-        sameSite : "Lax",
-        path     : "/",
+        httpOnly: true,
+        secure: c.req.url.startsWith("https://"),
+        expires: session.expiresAt,
+        sameSite: "Lax",
+        path: "/",
       });
       return c.json({
-        login : true,
-        user  : session.user,
+        login: true,
+        user: session.user,
         rootDomain,
         termsRequired,
       });
@@ -153,7 +153,9 @@ export const authRequired: MiddlewareHandler = async (c, next) => {
   const sid = getCookie(c, "hostSessionId");
   if (!sid) return c.json({ error: "unauthorized" }, 401);
 
-  const session = await HostSession.findOne({ sessionId: sid }).populate("user");
+  const session = await HostSession.findOne({ sessionId: sid }).populate(
+    "user",
+  );
   if (!session || session.expiresAt <= new Date()) {
     if (session) await HostSession.deleteOne({ sessionId: sid });
     return c.json({ error: "unauthorized" }, 401);
@@ -164,11 +166,11 @@ export const authRequired: MiddlewareHandler = async (c, next) => {
   await session.save();
 
   setCookie(c, "hostSessionId", sid, {
-    httpOnly : true,
-    secure   : c.req.url.startsWith("https://"),
-    expires  : session.expiresAt,
-    sameSite : "Lax",
-    path     : "/",
+    httpOnly: true,
+    secure: c.req.url.startsWith("https://"),
+    expires: session.expiresAt,
+    sameSite: "Lax",
+    path: "/",
   });
 
   c.set("user", session.user);

--- a/app/takos_host/client/src/App.tsx
+++ b/app/takos_host/client/src/App.tsx
@@ -2,6 +2,7 @@ import { Match, onMount, Switch } from "solid-js";
 import { useAtom } from "solid-jotai";
 import LoginPage from "./pages/LoginPage.tsx";
 import RegisterPage from "./pages/RegisterPage.tsx";
+import VerifyPage from "./pages/VerifyPage.tsx";
 import UserPage from "./pages/UserPage.tsx";
 import WelcomePage from "./pages/WelcomePage.tsx";
 import TermsPage from "./pages/TermsPage.tsx";
@@ -47,6 +48,9 @@ export default function App() {
       </Match>
       <Match when={path === "/signup"}>
         <RegisterPage />
+      </Match>
+      <Match when={path === "/verify"}>
+        <VerifyPage />
       </Match>
       <Match when={path === "/user"}>
         <UserPage />

--- a/app/takos_host/client/src/api.ts
+++ b/app/takos_host/client/src/api.ts
@@ -33,13 +33,26 @@ export async function login(
 
 export async function register(
   userName: string,
+  email: string,
   password: string,
   accepted: boolean,
 ): Promise<boolean> {
   const res = await fetch("/auth/register", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ userName, password, accepted }),
+    body: JSON.stringify({ userName, email, password, accepted }),
+  });
+  return res.ok;
+}
+
+export async function verify(
+  userName: string,
+  code: string,
+): Promise<boolean> {
+  const res = await fetch("/auth/verify", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ userName, code }),
   });
   return res.ok;
 }

--- a/app/takos_host/client/src/pages/RegisterPage.tsx
+++ b/app/takos_host/client/src/pages/RegisterPage.tsx
@@ -2,6 +2,7 @@ import { Component, createSignal, Show } from "solid-js";
 import { useAtom } from "solid-jotai";
 import { register as apiRegister } from "../api.ts";
 import {
+  emailState,
   loggedInState,
   passwordState,
   termsRequiredState,
@@ -10,6 +11,7 @@ import {
 
 const RegisterPage: Component = () => {
   const [userName, setUserName] = useAtom(userNameState);
+  const [email, setEmail] = useAtom(emailState);
   const [password, setPassword] = useAtom(passwordState);
   const [, setLoggedIn] = useAtom(loggedInState);
   const [termsRequired] = useAtom(termsRequiredState);
@@ -18,9 +20,9 @@ const RegisterPage: Component = () => {
 
   const signup = async (e: SubmitEvent) => {
     e.preventDefault();
-    if (await apiRegister(userName(), password(), agreed())) {
-      setLoggedIn(true);
-      globalThis.location.href = "/user";
+    if (await apiRegister(userName(), email(), password(), agreed())) {
+      setLoggedIn(false);
+      globalThis.location.href = "/verify";
     } else {
       setError("登録に失敗しました");
     }
@@ -47,6 +49,23 @@ const RegisterPage: Component = () => {
                 placeholder="ユーザー名"
                 value={userName()}
                 onInput={(e) => setUserName(e.currentTarget.value)}
+                class="w-full px-4 py-3 bg-gray-700 border border-gray-600 rounded-md text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 placeholder-gray-500"
+                required
+              />
+            </div>
+            <div>
+              <label
+                for="email"
+                class="block text-sm font-medium text-gray-300 mb-2"
+              >
+                メールアドレス
+              </label>
+              <input
+                id="email"
+                type="email"
+                placeholder="example@example.com"
+                value={email()}
+                onInput={(e) => setEmail(e.currentTarget.value)}
                 class="w-full px-4 py-3 bg-gray-700 border border-gray-600 rounded-md text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 placeholder-gray-500"
                 required
               />

--- a/app/takos_host/client/src/pages/VerifyPage.tsx
+++ b/app/takos_host/client/src/pages/VerifyPage.tsx
@@ -1,0 +1,68 @@
+import { Component, createSignal, Show } from "solid-js";
+import { useAtom } from "solid-jotai";
+import { verify as apiVerify } from "../api.ts";
+import { loggedInState, userNameState } from "../state.ts";
+
+const VerifyPage: Component = () => {
+  const [userName] = useAtom(userNameState);
+  const [, setLoggedIn] = useAtom(loggedInState);
+  const [code, setCode] = createSignal("");
+  const [error, setError] = createSignal("");
+
+  const submit = async (e: SubmitEvent) => {
+    e.preventDefault();
+    if (await apiVerify(userName(), code())) {
+      setLoggedIn(true);
+      globalThis.location.href = "/user";
+    } else {
+      setError("確認に失敗しました");
+    }
+  };
+
+  return (
+    <div class="min-h-screen flex flex-col bg-[#181818] text-gray-100">
+      <main class="flex-grow flex items-center justify-center px-4 py-12">
+        <div class="w-full max-w-md bg-[#212121] p-8 rounded-lg shadow-xl">
+          <div class="mb-8 text-center">
+            <h2 class="text-3xl font-semibold mb-2 text-white">メール確認</h2>
+            <p class="text-gray-400 text-sm">確認コードを入力してください</p>
+          </div>
+          <form onSubmit={submit} class="space-y-6">
+            <div>
+              <label
+                for="code"
+                class="block text-sm font-medium text-gray-300 mb-2"
+              >
+                確認コード
+              </label>
+              <input
+                id="code"
+                placeholder="123456"
+                value={code()}
+                onInput={(e) => setCode(e.currentTarget.value)}
+                class="w-full px-4 py-3 bg-gray-700 border border-gray-600 rounded-md text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 placeholder-gray-500"
+                required
+              />
+            </div>
+            <Show when={error()}>
+              <p class="text-red-400 text-sm font-medium bg-red-900/30 p-3 rounded-md">
+                {error()}
+              </p>
+            </Show>
+            <button
+              type="submit"
+              class="w-full bg-blue-600 text-white py-3 px-4 rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-gray-800 transition-colors duration-200"
+            >
+              送信
+            </button>
+          </form>
+        </div>
+      </main>
+      <footer class="py-6 border-t border-gray-700 text-center">
+        <a href="/" class="text-gray-400 hover:text-gray-200">戻る</a>
+      </footer>
+    </div>
+  );
+};
+
+export default VerifyPage;

--- a/app/takos_host/client/src/state.ts
+++ b/app/takos_host/client/src/state.ts
@@ -3,6 +3,7 @@ import type { Instance } from "./api.ts";
 
 export const loggedInState = atom(false);
 export const userNameState = atom("");
+export const emailState = atom("");
 export const passwordState = atom("");
 export const instancesState = atom<Instance[]>([]);
 export const hostState = atom("");


### PR DESCRIPTION
## Summary
- takos host の登録後にメール確認コードを入力する VerifyPage を追加
- 新規登録時にメールアドレスを送信するよう RegisterPage を更新
- API に verify 関数を実装し RegisterPage から利用
- 状態管理に emailState を追加
- 既存ファイルの全角スペースを修正

## Testing
- `deno lint`
- `deno fmt`

------
https://chatgpt.com/codex/tasks/task_e_6879e305ac0c832880ba2b92b8f2f0b3