### PR TITLE
Fix bcrypt salt parameter

### DIFF
--- a/app/takos_host/auth.ts
+++ b/app/takos_host/auth.ts
@@ -7,7 +7,7 @@ import { sendVerifyMail } from "./mailer.ts";
 
 /** bcrypt.hash をラップ（saltRounds = 10） */
 export async function hash(text: string): Promise<string> {
-  return await bcryptHash(text, "10");
+  return await bcryptHash(text, 10);
 }
 
 export function createAuthApp(options?: {


### PR DESCRIPTION
## Summary
- bcrypt ハッシュ関数の salt 指定を数値に修正

## Testing
- `deno fmt app/takos_host/auth.ts`
- `deno lint app/takos_host/auth.ts`


------
https://chatgpt.com/codex/tasks/task_e_6879e7c44b80832884844e84fdc173bb