### PR TITLE
メール認証の再送信機能追加

### DIFF
--- a/app/takos_host/README.md
+++ b/app/takos_host/README.md
@@ -48,6 +48,7 @@ takos を運用できるようにすることが目的です。
 - `GET /auth/status` セッション状態確認
 - `DELETE /auth/logout` ログアウト
 - `POST /auth/verify` メールアドレス確認
+- `POST /auth/resend` 確認コード再送信
 
 ユーザー API では以下のエンドポイントが利用できます。
 
@@ -104,4 +105,5 @@ OAuth ボタンを表示します。
 - `RESERVED_SUBDOMAINS`
   には利用禁止とするサブドメインをカンマ区切りで設定します。
 - `SMTP_HOST` などを設定すると登録時に確認メールを送信します。
+
 2. `deno run -A app/takos_host/main.ts` でサーバーを起動します。

--- a/app/takos_host/client/src/api.ts
+++ b/app/takos_host/client/src/api.ts
@@ -57,6 +57,15 @@ export async function verify(
   return res.ok;
 }
 
+export async function resend(userName: string): Promise<boolean> {
+  const res = await fetch("/auth/resend", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ userName }),
+  });
+  return res.ok;
+}
+
 export async function logout(): Promise<void> {
   await fetch("/auth/logout", { method: "DELETE" });
 }

--- a/app/takos_host/client/src/pages/VerifyPage.tsx
+++ b/app/takos_host/client/src/pages/VerifyPage.tsx
@@ -1,6 +1,6 @@
 import { Component, createSignal, Show } from "solid-js";
 import { useAtom } from "solid-jotai";
-import { verify as apiVerify } from "../api.ts";
+import { resend as apiResend, verify as apiVerify } from "../api.ts";
 import { loggedInState, userNameState } from "../state.ts";
 
 const VerifyPage: Component = () => {
@@ -8,6 +8,7 @@ const VerifyPage: Component = () => {
   const [, setLoggedIn] = useAtom(loggedInState);
   const [code, setCode] = createSignal("");
   const [error, setError] = createSignal("");
+  const [message, setMessage] = createSignal("");
 
   const submit = async (e: SubmitEvent) => {
     e.preventDefault();
@@ -16,6 +17,15 @@ const VerifyPage: Component = () => {
       globalThis.location.href = "/user";
     } else {
       setError("確認に失敗しました");
+    }
+  };
+
+  const resend = async () => {
+    if (await apiResend(userName())) {
+      setMessage("確認コードを再送信しました");
+      setError("");
+    } else {
+      setMessage("再送信に失敗しました");
     }
   };
 
@@ -49,11 +59,23 @@ const VerifyPage: Component = () => {
                 {error()}
               </p>
             </Show>
+            <Show when={message()}>
+              <p class="text-green-400 text-sm font-medium bg-green-900/30 p-3 rounded-md">
+                {message()}
+              </p>
+            </Show>
             <button
               type="submit"
               class="w-full bg-blue-600 text-white py-3 px-4 rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-gray-800 transition-colors duration-200"
             >
               送信
+            </button>
+            <button
+              type="button"
+              onClick={resend}
+              class="w-full bg-gray-600 text-white py-3 px-4 rounded-md hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-offset-2 focus:ring-offset-gray-800 transition-colors duration-200"
+            >
+              確認コード再送信
             </button>
           </form>
         </div>


### PR DESCRIPTION
## Summary
- 再登録時に既存未確認ユーザーを更新するよう改善
- `/auth/resend` エンドポイントを追加
- API クライアントと確認ページに再送信機能を実装
- README に再送信 API を追記

## Testing
- `deno fmt`
- `deno lint`


------
https://chatgpt.com/codex/tasks/task_e_6879fbf019448328b7957803f4eaf97c