### PR TITLE
Fix bcrypt usage for browser

### DIFF
--- a/app/client/src/utils/crypto.ts
+++ b/app/client/src/utils/crypto.ts
@@ -1,4 +1,4 @@
-import { hash as bcryptHash } from "bcrypt";
+import { hashSync } from "npm:bcryptjs";
 
 export const encryptWithPassword = async (
   data: string,
@@ -83,8 +83,8 @@ const BCRYPT_SALT = "$2b$10$GxW5ntweCe9L1LiK1roc/3";
  * 暗号化キー用パスワードをハッシュ化する
  * 別アカウントでも同一の入力で同じ値になるよう共通ソルトを利用
  */
-export const hashEncryptionPassword = async (
+export const hashEncryptionPassword = (
   password: string,
-): Promise<string> => {
-  return await bcryptHash(ENCRYPTION_PASS_SALT + password, BCRYPT_SALT);
+): string => {
+  return hashSync(ENCRYPTION_PASS_SALT + password, BCRYPT_SALT);
 };


### PR DESCRIPTION
## Summary
- bcrypt を `npm:bcryptjs` に置き換え、ブラウザ環境での実行時エラーを回避

## Testing
- `deno fmt app/client/src/utils/crypto.ts`
- `deno lint app/client/src/utils/crypto.ts`


------
https://chatgpt.com/codex/tasks/task_e_687a06555338832890dd4bc474fb2df1