### PR TITLE
初期設定をログイン後に実行するように変更

### DIFF
--- a/app/api/setup_ui.ts
+++ b/app/api/setup_ui.ts
@@ -5,8 +5,11 @@ import { join } from "jsr:@std/path";
 import Account from "./models/account.ts";
 import { addFollowEdge } from "./services/unified_store.ts";
 import { getEnv } from "./utils/env_store.ts";
+import authRequired from "./utils/auth.ts";
 
 const app = new Hono();
+app.use("/setup", authRequired);
+app.use("/setup/*", authRequired);
 
 app.get("/setup/status", (c) => {
   const env = getEnv(c);


### PR DESCRIPTION
## 概要
- `/setup` エンドポイントを認証必須に変更
- ログインフォームを常に表示し、ログイン後に未設定の場合のみ初期設定フォームを表示するよう修正

## テスト
- `deno fmt app/api/setup_ui.ts app/client/src/components/LoginForm.tsx`
- `deno lint app/api/setup_ui.ts app/client/src/components/LoginForm.tsx`


------
https://chatgpt.com/codex/tasks/task_e_687a096ee7f0832887fed67e1527b888