### PR TITLE
Add FCM env vars for takos host

### DIFF
--- a/app/takos_host/.env.example
+++ b/app/takos_host/.env.example
@@ -52,3 +52,12 @@ SMTP_SSL=587
 
 # 送信元アドレス (省略時は SMTP_USER が使用される)
 MAIL_FROM=
+
+############################
+# FCM 設定
+############################
+# Firebase Cloud Messaging を利用する場合に設定します。
+# これらは自動的に各テナントへ渡されます。
+FIREBASE_SERVICE_ACCOUNT=
+FIREBASE_CLIENT_CONFIG=
+FIREBASE_VAPID_KEY=

--- a/docs/fcm.md
+++ b/docs/fcm.md
@@ -6,11 +6,14 @@ Takos では Firebase Cloud Messaging
 
 ## 必要な環境変数
 
-`app/api/.env` に以下の値を設定してください。
+`app/api/.env` または takos host を利用する場合は `app/takos_host/.env` に
+以下の値を設定してください。
 
 - `FIREBASE_SERVICE_ACCOUNT` – Firebase サービスアカウント JSON
 - `FIREBASE_CLIENT_CONFIG` – `google-services.json` 相当のクライアント設定
 - `FIREBASE_VAPID_KEY` – Web Push 用の公開 VAPID キー
+
+takos host ではホスト側で設定した値が各テナントへ自動的に引き継がれます。
 
 ## トークン登録
 


### PR DESCRIPTION
## Summary
- allow host level management of Firebase credentials
- document that `app/takos_host/.env` accepts FCM vars and that tenants inherit them

## Testing
- `deno fmt docs/fcm.md app/takos_host/.env.example`
- `deno lint`

------
https://chatgpt.com/codex/tasks/task_e_687a12d8be9c8328bdb74ef5bc41e0fa