### PR TITLE
Fix import paths and FCM initialization

### DIFF
--- a/app/api/accounts.ts
+++ b/app/api/accounts.ts
@@ -12,7 +12,7 @@ import {
 import authRequired from "./utils/auth.ts";
 import { addNotification } from "./services/notification.ts";
 import { addFollowEdge, removeFollowEdge } from "./services/unified_store.ts";
-import { getEnv } from "../shared/config.ts";
+import { getEnv } from "../../shared/config.ts";
 
 function bufferToBase64(buffer: ArrayBuffer): string {
   let binary = "";

--- a/app/api/activitypub.ts
+++ b/app/api/activitypub.ts
@@ -3,7 +3,7 @@ import Account from "./models/account.ts";
 import Group from "./models/group.ts";
 import { findObjects, saveObject } from "./services/unified_store.ts";
 import KeyPackage from "./models/key_package.ts";
-import { getEnv } from "../shared/config.ts";
+import { getEnv } from "../../shared/config.ts";
 
 import { activityHandlers } from "./activity_handlers.ts";
 import RemoteActor from "./models/remote_actor.ts";

--- a/app/api/communities.ts
+++ b/app/api/communities.ts
@@ -17,7 +17,7 @@ import {
   getDomain,
 } from "./utils/activitypub.ts";
 import authRequired from "./utils/auth.ts";
-import { getEnv } from "../shared/config.ts";
+import { getEnv } from "../../shared/config.ts";
 
 function bufferToBase64(buffer: ArrayBuffer): string {
   let binary = "";

--- a/app/api/config.ts
+++ b/app/api/config.ts
@@ -1,5 +1,5 @@
 import { Hono } from "hono";
-import { getEnv } from "../shared/config.ts";
+import { getEnv } from "../../shared/config.ts";
 
 const app = new Hono();
 

--- a/app/api/e2ee.ts
+++ b/app/api/e2ee.ts
@@ -6,7 +6,7 @@ import EncryptedKeyPair from "./models/encrypted_keypair.ts";
 import { saveObject } from "./services/unified_store.ts";
 import Account from "./models/account.ts";
 import authRequired from "./utils/auth.ts";
-import { getEnv } from "../shared/config.ts";
+import { getEnv } from "../../shared/config.ts";
 import { rateLimit } from "./utils/rate_limit.ts";
 import {
   type ActivityPubActor,

--- a/app/api/fcm.ts
+++ b/app/api/fcm.ts
@@ -2,7 +2,7 @@ import { Hono } from "hono";
 import { z } from "zod";
 import { zValidator } from "@hono/zod-validator";
 import authRequired from "./utils/auth.ts";
-import { getEnv } from "../shared/config.ts";
+import { getEnv } from "../../shared/config.ts";
 import { registerToken, unregisterToken } from "./services/fcm.ts";
 
 const app = new Hono();

--- a/app/api/group.ts
+++ b/app/api/group.ts
@@ -1,7 +1,7 @@
 import { Hono } from "hono";
 import Group from "./models/group.ts";
 import { findObjects, saveObject } from "./services/unified_store.ts";
-import { getEnv } from "../shared/config.ts";
+import { getEnv } from "../../shared/config.ts";
 import {
   createAcceptActivity,
   createAnnounceActivity,

--- a/app/api/index.ts
+++ b/app/api/index.ts
@@ -1,7 +1,7 @@
 import { createTakosApp } from "./server.ts";
-import { connectDatabase } from "../shared/db.ts";
+import { connectDatabase } from "../../shared/db.ts";
 import { ensureTenant } from "./services/tenant.ts";
-import { loadConfig } from "../shared/config.ts";
+import { loadConfig } from "../../shared/config.ts";
 
 const env = await loadConfig();
 await connectDatabase(env);

--- a/app/api/login.ts
+++ b/app/api/login.ts
@@ -3,7 +3,7 @@ import { setCookie } from "hono/cookie";
 import { compare } from "bcrypt"; // bcrypt で検証
 import { z } from "zod";
 import { zValidator } from "@hono/zod-validator";
-import { getEnv } from "../shared/config.ts";
+import { getEnv } from "../../shared/config.ts";
 import Session from "./models/session.ts";
 
 const app = new Hono();

--- a/app/api/logout.ts
+++ b/app/api/logout.ts
@@ -2,7 +2,7 @@ import { Hono } from "hono";
 import { deleteCookie, getCookie } from "hono/cookie";
 import Session from "./models/session.ts";
 import authRequired from "./utils/auth.ts";
-import { getEnv } from "../shared/config.ts";
+import { getEnv } from "../../shared/config.ts";
 
 const app = new Hono();
 app.use("/logout", authRequired);

--- a/app/api/microblog.ts
+++ b/app/api/microblog.ts
@@ -14,7 +14,7 @@ import {
 // 型定義用のimport
 import type { InferSchemaType } from "mongoose";
 import type { objectStoreSchema } from "./models/object_store.ts";
-import { getEnv } from "../shared/config.ts";
+import { getEnv } from "../../shared/config.ts";
 
 type ActivityPubObjectType = InferSchemaType<typeof objectStoreSchema>;
 import Account from "./models/account.ts";

--- a/app/api/nodeinfo.ts
+++ b/app/api/nodeinfo.ts
@@ -2,7 +2,7 @@ import { Hono } from "hono";
 import Account from "./models/account.ts";
 import { findObjects } from "./services/unified_store.ts";
 import { getDomain } from "./utils/activitypub.ts";
-import { getEnv } from "../shared/config.ts";
+import { getEnv } from "../../shared/config.ts";
 // NodeInfo は外部からの参照を想定しているため認証は不要
 
 const app = new Hono();

--- a/app/api/notifications.ts
+++ b/app/api/notifications.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import { zValidator } from "@hono/zod-validator";
 import Notification from "./models/notification.ts";
 import authRequired from "./utils/auth.ts";
-import { getEnv } from "../shared/config.ts";
+import { getEnv } from "../../shared/config.ts";
 
 const app = new Hono();
 app.use("/notifications/*", authRequired);

--- a/app/api/oauth_login.ts
+++ b/app/api/oauth_login.ts
@@ -2,7 +2,7 @@ import { Hono } from "hono";
 import { setCookie } from "hono/cookie";
 import { z } from "zod";
 import { zValidator } from "@hono/zod-validator";
-import { getEnv } from "../shared/config.ts";
+import { getEnv } from "../../shared/config.ts";
 import Session from "./models/session.ts";
 
 const app = new Hono();

--- a/app/api/relays.ts
+++ b/app/api/relays.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import { zValidator } from "@hono/zod-validator";
 import Relay from "./models/relay.ts";
 import authRequired from "./utils/auth.ts";
-import { getEnv } from "../shared/config.ts";
+import { getEnv } from "../../shared/config.ts";
 import { addRelayEdge, removeRelayEdge } from "./services/unified_store.ts";
 import {
   createFollowActivity,

--- a/app/api/root_inbox.ts
+++ b/app/api/root_inbox.ts
@@ -8,7 +8,7 @@ import {
   jsonResponse,
   verifyHttpSignature,
 } from "./utils/activitypub.ts";
-import { getEnv } from "../shared/config.ts";
+import { getEnv } from "../../shared/config.ts";
 import { activityHandlers } from "./activity_handlers.ts";
 import Group from "./models/group.ts";
 import Account from "./models/account.ts";

--- a/app/api/search.ts
+++ b/app/api/search.ts
@@ -3,7 +3,7 @@ import Account from "./models/account.ts";
 import { findObjects } from "./services/unified_store.ts";
 import Group from "./models/group.ts";
 import { getDomain, resolveActor } from "./utils/activitypub.ts";
-import { getEnv } from "../shared/config.ts";
+import { getEnv } from "../../shared/config.ts";
 import authRequired from "./utils/auth.ts";
 
 interface SearchResult {

--- a/app/api/server.ts
+++ b/app/api/server.ts
@@ -1,6 +1,6 @@
 import { Hono } from "hono";
-import { connectDatabase } from "../shared/db.ts";
-import { initEnv, loadConfig } from "../shared/config.ts";
+import { connectDatabase } from "../../shared/db.ts";
+import { initEnv, loadConfig } from "../../shared/config.ts";
 import { startRelayPolling } from "./services/relay_poller.ts";
 import login from "./login.ts";
 import logout from "./logout.ts";

--- a/app/api/services/fcm.ts
+++ b/app/api/services/fcm.ts
@@ -12,10 +12,9 @@ function init(env: Record<string, string>) {
   ];
   if (!saKeys.every((k) => env[k])) return;
   const cred = {
-    type: "service_account",
-    project_id: env["FIREBASE_PROJECT_ID"],
-    client_email: env["FIREBASE_CLIENT_EMAIL"],
-    private_key: env["FIREBASE_PRIVATE_KEY"],
+    projectId: env["FIREBASE_PROJECT_ID"],
+    clientEmail: env["FIREBASE_CLIENT_EMAIL"],
+    privateKey: env["FIREBASE_PRIVATE_KEY"],
   };
   admin.initializeApp({ credential: admin.credential.cert(cred) });
   initialized = true;

--- a/app/api/setup_ui.ts
+++ b/app/api/setup_ui.ts
@@ -4,7 +4,7 @@ import { ensureFile } from "jsr:@std/fs/ensure-file";
 import { join } from "jsr:@std/path";
 import Account from "./models/account.ts";
 import { addFollowEdge } from "./services/unified_store.ts";
-import { getEnv } from "../shared/config.ts";
+import { getEnv } from "../../shared/config.ts";
 import authRequired from "./utils/auth.ts";
 
 const app = new Hono();

--- a/app/api/stories.ts
+++ b/app/api/stories.ts
@@ -9,7 +9,7 @@ import {
 } from "./services/unified_store.ts";
 import authRequired from "./utils/auth.ts";
 import { createObjectId } from "./utils/activitypub.ts";
-import { getEnv } from "../shared/config.ts";
+import { getEnv } from "../../shared/config.ts";
 
 const app = new Hono();
 app.use("/stories/*", authRequired);

--- a/app/api/users.ts
+++ b/app/api/users.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import { zValidator } from "@hono/zod-validator";
 import Account from "./models/account.ts";
 import { findObjects } from "./services/unified_store.ts";
-import { getEnv } from "../shared/config.ts";
+import { getEnv } from "../../shared/config.ts";
 import {
   createFollowActivity,
   createUndoFollowActivity,

--- a/app/api/videos.ts
+++ b/app/api/videos.ts
@@ -13,7 +13,7 @@ import {
 } from "./services/unified_store.ts";
 import Account from "./models/account.ts";
 import authRequired from "./utils/auth.ts";
-import { getEnv } from "../shared/config.ts";
+import { getEnv } from "../../shared/config.ts";
 import { rateLimit } from "./utils/rate_limit.ts";
 import {
   buildActivityFromStored,


### PR DESCRIPTION
## Summary
- fix paths for shared modules from api
- update FCM initialization to match ServiceAccount fields

## Testing
- `deno fmt`
- `deno lint`
- `deno lint app/api/services/fcm.ts`
- `deno check app/api/server.ts` *(fails: invalid peer certificate)*

------
https://chatgpt.com/codex/tasks/task_e_687acc87f5448328b3a61bfd4d1702da