### PR TITLE
ActivityPubメッセージ保存方式の変更

### DIFF
--- a/app/api/e2ee.ts
+++ b/app/api/e2ee.ts
@@ -3,7 +3,7 @@ import KeyPackage from "./models/key_package.ts";
 import EncryptedMessage from "./models/encrypted_message.ts";
 import PublicMessage from "./models/public_message.ts";
 import EncryptedKeyPair from "./models/encrypted_keypair.ts";
-import { saveObject } from "./services/unified_store.ts";
+import { saveMessage } from "./services/unified_store.ts";
 import Account from "./models/account.ts";
 import authRequired from "./utils/auth.ts";
 import { getEnv } from "../../shared/config.ts";
@@ -315,21 +315,20 @@ app.post(
     });
     const domain = getDomain(c);
     const actorId = `https://${domain}/users/${sender}`;
-    const object = await saveObject(
+    const object = await saveMessage(
       getEnv(c),
-      {
-        type: "PrivateMessage",
-        attributedTo: acct,
-        content,
-        to,
-        extra: { mediaType: msg.mediaType, encoding: msg.encoding },
-        actor_id: actorId,
-        aud: { to, cc: [] },
-      },
+      domain,
+      sender,
+      content,
+      { mediaType: msg.mediaType, encoding: msg.encoding },
+      { to, cc: [] },
     );
 
     const privateMessage = buildActivityFromStored(
-      object.toObject() as {
+      {
+        ...object.toObject(),
+        type: "PrivateMessage",
+      } as {
         _id: unknown;
         type: string;
         content: string;
@@ -386,21 +385,20 @@ app.post(
     });
     const domain = getDomain(c);
     const actorId = `https://${domain}/users/${sender}`;
-    const object = await saveObject(
+    const object = await saveMessage(
       getEnv(c),
-      {
-        type: "PublicMessage",
-        attributedTo: acct,
-        content,
-        to,
-        extra: { mediaType: msg.mediaType, encoding: msg.encoding },
-        actor_id: actorId,
-        aud: { to, cc: [] },
-      },
+      domain,
+      sender,
+      content,
+      { mediaType: msg.mediaType, encoding: msg.encoding },
+      { to, cc: [] },
     );
 
     const publicMessage = buildActivityFromStored(
-      object.toObject() as {
+      {
+        ...object.toObject(),
+        type: "PublicMessage",
+      } as {
         _id: unknown;
         type: string;
         content: string;

--- a/app/api/models/message.ts
+++ b/app/api/models/message.ts
@@ -1,0 +1,34 @@
+import mongoose from "mongoose";
+
+const messageSchema = new mongoose.Schema({
+  _id: { type: String },
+  attributedTo: { type: String, required: true },
+  actor_id: { type: String, required: true, index: true },
+  content: { type: String, default: "" },
+  extra: { type: mongoose.Schema.Types.Mixed, default: {} },
+  tenant_id: { type: String, index: true },
+  published: { type: Date, default: Date.now },
+  created_at: { type: Date, default: Date.now },
+  updated_at: { type: Date, default: Date.now },
+  deleted_at: { type: Date },
+  aud: {
+    to: { type: [String], default: [] },
+    cc: { type: [String], default: [] },
+  },
+});
+
+messageSchema.pre("save", function (next) {
+  const self = this as unknown as {
+    $locals?: { env?: Record<string, string> };
+  };
+  const env = self.$locals?.env;
+  if (!this.tenant_id && env?.ACTIVITYPUB_DOMAIN) {
+    this.tenant_id = env.ACTIVITYPUB_DOMAIN;
+  }
+  next();
+});
+
+const Message = mongoose.model("Message", messageSchema, "messages");
+
+export default Message;
+export { messageSchema };

--- a/app/api/models/note.ts
+++ b/app/api/models/note.ts
@@ -1,0 +1,34 @@
+import mongoose from "mongoose";
+
+const noteSchema = new mongoose.Schema({
+  _id: { type: String },
+  attributedTo: { type: String, required: true },
+  actor_id: { type: String, required: true, index: true },
+  content: { type: String, default: "" },
+  extra: { type: mongoose.Schema.Types.Mixed, default: {} },
+  tenant_id: { type: String, index: true },
+  published: { type: Date, default: Date.now },
+  created_at: { type: Date, default: Date.now },
+  updated_at: { type: Date, default: Date.now },
+  deleted_at: { type: Date },
+  aud: {
+    to: { type: [String], default: [] },
+    cc: { type: [String], default: [] },
+  },
+});
+
+noteSchema.pre("save", function (next) {
+  const self = this as unknown as {
+    $locals?: { env?: Record<string, string> };
+  };
+  const env = self.$locals?.env;
+  if (!this.tenant_id && env?.ACTIVITYPUB_DOMAIN) {
+    this.tenant_id = env.ACTIVITYPUB_DOMAIN;
+  }
+  next();
+});
+
+const Note = mongoose.model("Note", noteSchema, "notes");
+
+export default Note;
+export { noteSchema };

--- a/app/api/models/video.ts
+++ b/app/api/models/video.ts
@@ -1,0 +1,34 @@
+import mongoose from "mongoose";
+
+const videoSchema = new mongoose.Schema({
+  _id: { type: String },
+  attributedTo: { type: String, required: true },
+  actor_id: { type: String, required: true, index: true },
+  content: { type: String, default: "" },
+  extra: { type: mongoose.Schema.Types.Mixed, default: {} },
+  tenant_id: { type: String, index: true },
+  published: { type: Date, default: Date.now },
+  created_at: { type: Date, default: Date.now },
+  updated_at: { type: Date, default: Date.now },
+  deleted_at: { type: Date },
+  aud: {
+    to: { type: [String], default: [] },
+    cc: { type: [String], default: [] },
+  },
+});
+
+videoSchema.pre("save", function (next) {
+  const self = this as unknown as {
+    $locals?: { env?: Record<string, string> };
+  };
+  const env = self.$locals?.env;
+  if (!this.tenant_id && env?.ACTIVITYPUB_DOMAIN) {
+    this.tenant_id = env.ACTIVITYPUB_DOMAIN;
+  }
+  next();
+});
+
+const Video = mongoose.model("Video", videoSchema, "videos");
+
+export default Video;
+export { videoSchema };


### PR DESCRIPTION
## Summary
- Private/Public メッセージ用 `Message` スキーマを追加
- unified_store にメッセージ関連の保存・検索関数を実装
- E2EE API を `saveMessage` 利用に変更
- E2EE API の生成メッセージに型を明示
- microblog で `noteSchema` の import を修正

## Testing
- `deno fmt`
- `deno lint app/api`


------
https://chatgpt.com/codex/tasks/task_e_687ae45a774c8328acd37464c97284e8