### PR TITLE
Fix repeated message fetching loop

### DIFF
--- a/app/client/src/components/Chat.tsx
+++ b/app/client/src/components/Chat.tsx
@@ -585,11 +585,8 @@ export function Chat(props: ChatProps) {
 
   createEffect(() => {
     const roomId = selectedRoom();
-    const rooms = chatRooms();
-    groups();
-    account();
+    const room = chatRooms().find((r) => r.id === roomId);
 
-    const room = rooms.find((r) => r.id === roomId);
     if (room) {
       loadMessages(room, true);
     } else if (roomId) {


### PR DESCRIPTION
## Summary
- チャット表示時に選択中ルームの読み込みが不要に繰り返される問題を修正

## Testing
- `deno fmt`
- `deno lint`


------
https://chatgpt.com/codex/tasks/task_e_687af2f588bc83288c009a2c7e02c1f0