### PR TITLE
メモに対する暗号化送信対応

### DIFF
--- a/app/client/src/components/Chat.tsx
+++ b/app/client/src/components/Chat.tsx
@@ -278,7 +278,14 @@ export function Chat(props: ChatProps) {
     if (!group) {
       const kp = await ensureKeyPair();
       if (kp) {
-        const partnerPub = await getPartnerKey(partnerUser, partnerDomain);
+        let partnerPub: string | null = null;
+        const isSelf = partnerUser === user.userName &&
+          (!partnerDomain || partnerDomain === getDomain());
+        if (isSelf) {
+          partnerPub = kp.publicKey;
+        } else {
+          partnerPub = await getPartnerKey(partnerUser, partnerDomain);
+        }
         if (partnerPub) {
           const secret = await deriveMLSSecret(kp.privateKey, partnerPub);
           group = { members: room.members, epoch: Date.now(), secret };
@@ -465,7 +472,14 @@ export function Chat(props: ChatProps) {
           return;
         }
         const [partnerUser, partnerDomain] = splitActor(room.members[0]);
-        const partnerPub = await getPartnerKey(partnerUser, partnerDomain);
+        let partnerPub: string | null;
+        const isSelf = partnerUser === user.userName &&
+          (!partnerDomain || partnerDomain === getDomain());
+        if (isSelf) {
+          partnerPub = kp.publicKey;
+        } else {
+          partnerPub = await getPartnerKey(partnerUser, partnerDomain);
+        }
         if (!partnerPub) {
           setPartnerHasKey(false);
           return;


### PR DESCRIPTION
## 概要
- メモ (自分宛てチャット) の際にも暗号化メッセージが送信できるよう処理を調整しました
- 相手が自分自身の場合はパートナー鍵の取得を省略し、所持している公開鍵を利用します

## テスト
- `deno fmt app/client/src/components/Chat.tsx`
- `deno lint app/client/src/components/Chat.tsx`


------
https://chatgpt.com/codex/tasks/task_e_687af6e026cc8328923d732966337f76