### PR TITLE
TAKO Keep icon

### DIFF
--- a/app/client/src/components/Chat.tsx
+++ b/app/client/src/components/Chat.tsx
@@ -402,10 +402,10 @@ export function Chat(props: ChatProps) {
     const rooms: ChatRoom[] = [
       {
         id: `${user.userName}@${getDomain()}`,
-        name: "メモ",
+        name: "TAKO Keep",
         userName: user.userName,
         domain: getDomain(),
-        avatar: user.avatarInitial || user.userName.charAt(0).toUpperCase(),
+        avatar: "📝",
         unreadCount: 0,
         type: "memo",
         members: [`${user.userName}@${getDomain()}`],
@@ -710,7 +710,9 @@ export function Chat(props: ChatProps) {
                                   display: "flex",
                                   "align-items": "center",
                                   "justify-content": "center",
-                                  background: "#444",
+                                  background: room.type === "memo"
+                                    ? "#16a34a"
+                                    : "#444",
                                   color: "#fff",
                                   "border-radius": "50%",
                                   "font-size": "20px",


### PR DESCRIPTION
## Summary
- メモ用チャットルームの名称を **TAKO Keep** に変更
- メモルームのアイコンを📝表示にし、背景色を緑色に変更

## Testing
- `deno fmt app/client/src/components/Chat.tsx`
- `deno lint app/client/src/components/Chat.tsx`


------
https://chatgpt.com/codex/tasks/task_e_687b258c3238832891aba3e80656f782