### PR TITLE
README更新: リレー参加説明とCLIオプション修正

### DIFF
--- a/app/takos_host/README.md
+++ b/app/takos_host/README.md
@@ -112,6 +112,10 @@ OAuth ボタンを表示します。
 
 `takos host` を CLI から操作するスクリプト `scripts/host_manager.ts`
 を用意しています。ログインユーザーを指定することで、インスタンスの一覧表示や作成・削除に加え、リレーサーバーの登録や削除も行えます。
+リレーサーバーの追加 (`relay-add`) はユーザーが所有するインスタンスではなく、
+**takos host 自体が外部リレーへ参加するための設定**
+です。追加したリレーからの投稿はホスト側で受信のみ行われ、各インスタンスへ配信されます。`--user`
+を省略した場合は管理用ユーザー `system` としてログインします。
 
 ### 使用例
 
@@ -122,7 +126,7 @@ deno task host create --host myapp --inst-pass pw --user alice --pass secret
 
 deno task host relay-list --user alice --pass secret
 
-deno task host relay-add --inbox-url https://relay.example/inbox --user alice --pass secret
+deno task host relay-add --inbox-url https://relay.example/inbox --pass secret
 
 deno task host relay-delete --relay-id RELAY_ID --user alice --pass secret
 ```

--- a/scripts/host_manager.ts
+++ b/scripts/host_manager.ts
@@ -2,7 +2,7 @@ import { parseArgs } from "jsr:@std/flags";
 
 interface Args {
   url: string;
-  user: string;
+  user?: string;
   pass: string;
   command: string;
   host?: string;
@@ -25,7 +25,7 @@ Commands:
 
 Options:
   --url        takos host のベース URL (既定: http://localhost:8001)
-  --user       ユーザー名
+  --user       ユーザー名 (省略時 system)
   --pass       ログインパスワード
   --inst-pass  インスタンス用パスワード
   --inbox-url  追加するリレーのInbox URL
@@ -56,7 +56,7 @@ function parse(): Args | null {
   const command = String(parsed._[0]);
   return {
     url: String(parsed.url),
-    user: String(parsed.user ?? ""),
+    user: parsed.user ? String(parsed.user) : undefined,
     pass: String(parsed.pass ?? ""),
     command,
     host: parsed.host ? String(parsed.host) : undefined,
@@ -189,11 +189,12 @@ async function deleteRelay(baseUrl: string, cookie: string, id: string) {
 async function main() {
   const args = parse();
   if (!args) return;
-  if (!args.user || !args.pass) {
-    console.error("--user と --pass を指定してください");
+  if (!args.pass) {
+    console.error("--pass を指定してください");
     return;
   }
-  const cookie = await login(args.url, args.user, args.pass);
+  const user = args.user ?? "system";
+  const cookie = await login(args.url, user, args.pass);
   try {
     switch (args.command) {
       case "list":


### PR DESCRIPTION
## Summary
- `relay-add` コマンドが takos host 自身のリレー参加設定であることを追記
- `--user` 省略時は管理ユーザー `system` を使用するよう CLI スクリプトを変更
- README の使用例を更新

## Testing
- `deno fmt app/takos_host/README.md`
- `deno fmt scripts/host_manager.ts`
- `deno lint`

------
https://chatgpt.com/codex/tasks/task_e_687b2eb5391c832885855fbe8e499f06