### PR TITLE
READMEとCLIを更新してパスワード省略を反映

### DIFF
--- a/app/takos_host/README.md
+++ b/app/takos_host/README.md
@@ -112,17 +112,22 @@ OAuth ボタンを表示します。
 
 `takos host` を CLI から操作するスクリプト `scripts/host_manager.ts`
 を用意しています。ログインユーザーを指定することで、インスタンスの一覧表示や作成・削除に加え、リレーサーバーの登録や削除も行えます。
+リレーサーバーの追加 (`relay-add`) はユーザーが所有するインスタンスではなく、
+**takos host 自体が外部リレーへ参加するための設定**
+です。追加したリレーからの投稿はホスト側で受信のみ行われ、各インスタンスへ配信されます。`--user`
+を省略した場合は管理用ユーザー `system` としてログインします。 CLI
+ではパスワードを指定する必要はありません。
 
 ### 使用例
 
 ```bash
-deno task host list --user alice --pass secret
+deno task host list --user alice
 
-deno task host create --host myapp --inst-pass pw --user alice --pass secret
+deno task host create --host myapp --inst-pass pw --user alice
 
-deno task host relay-list --user alice --pass secret
+deno task host relay-list --user alice
 
-deno task host relay-add --inbox-url https://relay.example/inbox --user alice --pass secret
+deno task host relay-add --inbox-url https://relay.example/inbox
 
-deno task host relay-delete --relay-id RELAY_ID --user alice --pass secret
+deno task host relay-delete --relay-id RELAY_ID
 ```

--- a/scripts/host_manager.ts
+++ b/scripts/host_manager.ts
@@ -2,8 +2,8 @@ import { parseArgs } from "jsr:@std/flags";
 
 interface Args {
   url: string;
-  user: string;
-  pass: string;
+  user?: string;
+  pass?: string;
   command: string;
   host?: string;
   instPass?: string;
@@ -25,8 +25,8 @@ Commands:
 
 Options:
   --url        takos host のベース URL (既定: http://localhost:8001)
-  --user       ユーザー名
-  --pass       ログインパスワード
+  --user       ユーザー名 (省略時 system)
+  --pass       ログインパスワード (省略可)
   --inst-pass  インスタンス用パスワード
   --inbox-url  追加するリレーのInbox URL
   --relay-id   削除するリレーのID
@@ -56,8 +56,8 @@ function parse(): Args | null {
   const command = String(parsed._[0]);
   return {
     url: String(parsed.url),
-    user: String(parsed.user ?? ""),
-    pass: String(parsed.pass ?? ""),
+    user: parsed.user ? String(parsed.user) : undefined,
+    pass: parsed.pass ? String(parsed.pass) : undefined,
     command,
     host: parsed.host ? String(parsed.host) : undefined,
     instPass: parsed["inst-pass"] ? String(parsed["inst-pass"]) : undefined,
@@ -69,7 +69,7 @@ function parse(): Args | null {
 async function login(
   baseUrl: string,
   user: string,
-  pass: string,
+  pass = "",
 ): Promise<string> {
   const res = await fetch(`${baseUrl}/auth/login`, {
     method: "POST",
@@ -189,11 +189,8 @@ async function deleteRelay(baseUrl: string, cookie: string, id: string) {
 async function main() {
   const args = parse();
   if (!args) return;
-  if (!args.user || !args.pass) {
-    console.error("--user と --pass を指定してください");
-    return;
-  }
-  const cookie = await login(args.url, args.user, args.pass);
+  const user = args.user ?? "system";
+  const cookie = await login(args.url, user, args.pass ?? "");
   try {
     switch (args.command) {
       case "list":


### PR DESCRIPTION
## Summary
- host_manager.ts の `--pass` オプションを任意化
- README の CLI 説明を更新し `--pass` を使わない例を提示

## Testing
- `deno fmt app/takos_host/README.md scripts/host_manager.ts`
- `deno lint scripts/host_manager.ts`


------
https://chatgpt.com/codex/tasks/task_e_687b2eb5391c832885855fbe8e499f06