### PR TITLE
リレー取得オブジェクトの公開取得対応

### DIFF
--- a/app/api/microblog.ts
+++ b/app/api/microblog.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 import { z } from "zod";
 import { zValidator } from "@hono/zod-validator";
 import {
+  type ActivityObject,
   deleteNote,
   findNotes,
   getObject,
@@ -12,11 +13,9 @@ import {
 } from "./services/unified_store.ts";
 
 // 型定義用のimport
-import type { InferSchemaType } from "mongoose";
-import { noteSchema } from "./models/note.ts";
 import { getEnv } from "../../shared/config.ts";
 
-type ActivityPubObjectType = InferSchemaType<typeof noteSchema>;
+type ActivityPubObjectType = ActivityObject;
 import Account from "./models/account.ts";
 import {
   buildActivityFromStored,


### PR DESCRIPTION
## 概要
- リレーから保存したオブジェクトも `/api/microblog` の取得対象に含めました
- `getPublicNotes` を修正し `object_store` と `notes` の両方から取得するよう変更
- 型定義を `ActivityObject` に更新

## テスト
- `deno fmt` で整形確認
- `deno lint` で静的解析実行

------
https://chatgpt.com/codex/tasks/task_e_687b66f2a0288328a1b19859d1a1fbdc