### PR TITLE
Fix relay list per tenant

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ ActivityPub の `Video` オブジェクトを利用して動画を投稿でき�
 
 ほかのインスタンスと連携するためのリレーサーバーを管理します。
 
-- `GET /api/relays` – 登録済みリレー一覧を取得
+- `GET /api/relays` – 現在のテナントに登録されているリレー一覧を取得
 - `POST /api/relays` – `{ "inboxUrl": "https://relay.example/inbox" }`
   を送信して追加
 - `DELETE /api/relays/:id` – リレーを削除


### PR DESCRIPTION
## Summary
- テナントのリレー一覧取得APIを `relay_edge` ベースに修正
- README を更新してテナント単位で取得する旨を明記

## Testing
- `deno fmt`
- `deno lint`


------
https://chatgpt.com/codex/tasks/task_e_687b707d78ec83289464bcefb93174bb