### PR TITLE
Fix proxy for ActivityPub endpoints in dev mode

### DIFF
--- a/app/takos_host/main.ts
+++ b/app/takos_host/main.ts
@@ -105,11 +105,16 @@ if (termsText) {
 if (isDev) {
   root.use("/auth/*", proxy("/auth"));
   root.use("/user/*", proxy("/user"));
-  if (rootDomain) {
+  if (rootDomain && rootActivityPubApp) {
+    const proxyRoot = proxy("");
     root.use(async (c, next) => {
       const host = getRealHost(c);
       if (host === rootDomain) {
-        return await proxy("")(c, next);
+        const res = await rootActivityPubApp.fetch(c.req.raw);
+        if (res.status !== 404) {
+          return res;
+        }
+        return await proxyRoot(c, next);
       }
       await next();
     });


### PR DESCRIPTION
## Summary
- 開発モードで root ドメインへのアクセスが全て Vite に転送されていたため、`/users/system` など ActivityPub 用エンドポイントが 404 となっていました
- `/users/system` など ActivityPub 関連パスをプロキシ対象から除外するよう修正しました
- さらに ActivityPub アプリでルートを確認してから Vite に転送するよう改良しました

## Testing
- `deno fmt app/takos_host/main.ts` *(failed: command not found)*
- `deno lint app/takos_host/main.ts` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b86bd7af48328afcef86e85e5c3b3