### PR TITLE
CORSの適用範囲を限定

### DIFF
--- a/app/takos_host/oauth.ts
+++ b/app/takos_host/oauth.ts
@@ -7,7 +7,9 @@ import OAuthToken from "./models/oauth_token.ts";
 import HostSession from "./models/session.ts";
 
 export const oauthApp = new Hono();
-oauthApp.use("/*", cors());
+// CORSミドルウェアの節約化
+oauthApp.use("/token", cors());
+oauthApp.use("/verify", cors());
 
 // Authorization Endpoint
 oauthApp.get("/authorize", async (c) => {


### PR DESCRIPTION
## Summary
- OAuthアプリのCORSミドルウェアを全体から`/token`・`/verify`のみに変更

## Testing
- `deno fmt app/takos_host/oauth.ts`
- `deno lint app/takos_host/oauth.ts`


------
https://chatgpt.com/codex/tasks/task_e_687b938133dc83289062581457fb5b71