### PR TITLE
統一WebSocketエンドポイントの追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,9 @@ deno task build
 
 ActivityPub の `Video` オブジェクトを利用して動画を投稿できます。
 
+- `WebSocket /api/ws` – 動画アップロードや今後の双方向機能で利用する統一
+  WebSocket
+
 - `GET /api/videos` – 動画一覧を取得
 - `POST /api/videos` – 動画を作成するとフォロワーへ `Create` Activity を配信
 - `POST /api/videos/:id/like` – いいね数を増加

--- a/app/api/server.ts
+++ b/app/api/server.ts
@@ -18,7 +18,8 @@ import rootInbox from "./root_inbox.ts";
 import nodeinfo from "./nodeinfo.ts";
 import e2ee from "./e2ee.ts";
 import relays from "./relays.ts";
-import videos, { initVideoModule } from "./videos.ts";
+import videos, { initVideoModule, initVideoWebSocket } from "./videos.ts";
+import wsRouter from "./ws.ts";
 import config from "./config.ts";
 import fcm from "./fcm.ts";
 import { fetchOgpData } from "./services/ogp.ts";
@@ -33,6 +34,8 @@ export async function createTakosApp(env?: Record<string, string>) {
   initEnv(app, e);
   app.use("/api/*", rateLimit({ windowMs: 60_000, limit: 100 }));
   initVideoModule(e);
+  initVideoWebSocket();
+  app.route("/api", wsRouter);
   app.route("/api", login);
   app.route("/api", logout);
   if (e["OAUTH_HOST"] || e["ROOT_DOMAIN"]) {

--- a/app/api/ws.ts
+++ b/app/api/ws.ts
@@ -1,0 +1,77 @@
+import { Hono } from "hono";
+import { upgradeWebSocket } from "hono/deno";
+
+export type WsState = Record<string, unknown>;
+export type MessageHandler = (
+  payload: unknown,
+  ws: WebSocket,
+  state: WsState,
+) => void | Promise<void>;
+export type LifecycleHandler = (
+  ws: WebSocket,
+  state: WsState,
+) => void | Promise<void>;
+
+const messageHandlers = new Map<string, MessageHandler>();
+let binaryHandler: MessageHandler | null = null;
+const openHandlers: LifecycleHandler[] = [];
+const closeHandlers: LifecycleHandler[] = [];
+const errorHandlers: LifecycleHandler[] = [];
+
+export function registerMessageHandler(
+  type: string,
+  handler: MessageHandler,
+) {
+  messageHandlers.set(type, handler);
+}
+
+export function registerBinaryHandler(handler: MessageHandler) {
+  binaryHandler = handler;
+}
+
+export function registerOpenHandler(handler: LifecycleHandler) {
+  openHandlers.push(handler);
+}
+
+export function registerCloseHandler(handler: LifecycleHandler) {
+  closeHandlers.push(handler);
+}
+
+export function registerErrorHandler(handler: LifecycleHandler) {
+  errorHandlers.push(handler);
+}
+
+const app = new Hono();
+
+app.get(
+  "/ws",
+  upgradeWebSocket((c) => {
+    const state: WsState = { context: c };
+    return {
+      onOpen(_evt, ws) {
+        for (const h of openHandlers) h(ws, state);
+      },
+      onMessage(evt, ws) {
+        if (typeof evt.data === "string") {
+          try {
+            const msg = JSON.parse(evt.data);
+            const handler = messageHandlers.get(msg.type);
+            handler?.(msg.payload, ws, state);
+          } catch {
+            ws.send(JSON.stringify({ error: "invalid message" }));
+          }
+        } else if (binaryHandler) {
+          binaryHandler(evt.data, ws, state);
+        }
+      },
+      async onClose(_evt, ws) {
+        for (const h of closeHandlers) await h(ws, state);
+      },
+      onError(_evt, ws) {
+        for (const h of errorHandlers) h(ws, state);
+      },
+    };
+  }),
+);
+
+export default app;

--- a/app/client/src/components/videos/api.ts
+++ b/app/client/src/components/videos/api.ts
@@ -24,7 +24,7 @@ export const createVideo = (
 ): Promise<Video | null> => {
   return new Promise((resolve) => {
     try {
-      const wsUrl = apiUrl("/api/videos/upload").replace(/^http/, "ws");
+      const wsUrl = apiUrl("/api/ws").replace(/^http/, "ws");
       const ws = new WebSocket(wsUrl);
       let uploaded = false;
 


### PR DESCRIPTION
## Summary
- WebSocket用モジュール `ws.ts` を追加
- 動画アップロード処理を新しいWebSocketに対応
- サーバーで `/api/ws` を提供し各機能から利用できるように
- クライアント側WebSocket URLを更新
- README に統一 WebSocket を追記

## Testing
- `deno fmt` 実行
- `deno lint` 実行

------
https://chatgpt.com/codex/tasks/task_e_687b97a3b1c88328b944ab10ee5e915c