### PR TITLE
Tailwind への移行作業

### DIFF
--- a/app/client/src/style.css
+++ b/app/client/src/style.css
@@ -1,8 +1,0 @@
-.external-link {
-  word-break: break-all;
-  color: #2563eb;
-  text-decoration: underline;
-}
-.ellipsis {
-  text-decoration: underline;
-}

--- a/app/client/src/utils/render.ts
+++ b/app/client/src/utils/render.ts
@@ -50,7 +50,6 @@ function plainTextToHtml(text: string): string {
 }
 
 const INVISIBLE_CLS = "invisible";
-const ELLIPSIS_CLS = "ellipsis";
 const MAX_VISIBLE = 45;
 
 function linkifyUrls(text: string, linkify: LinkifyIt, shorten = true): string {
@@ -70,13 +69,13 @@ function linkifyUrls(text: string, linkify: LinkifyIt, shorten = true): string {
       const visible = body.slice(0, MAX_VISIBLE) + "…";
       const hidden = body.slice(MAX_VISIBLE);
       inner = `<span class="${INVISIBLE_CLS}">${escapeHtml(protocol)}</span>` +
-        `<span class="${ELLIPSIS_CLS}">${escapeHtml(visible)}</span>` +
+        `<span>${escapeHtml(visible)}</span>` +
         `<span class="${INVISIBLE_CLS}">${escapeHtml(hidden)}</span>`;
     }
 
     out += `<a href="${
       escapeHtml(url)
-    }" class="external-link" target="_blank" rel="noopener noreferrer nofollow">${inner}</a>`;
+    }" target="_blank" rel="noopener noreferrer nofollow">${inner}</a>`;
     last = m.lastIndex;
   }
   out += escapeHtml(text.slice(last));

--- a/app/client/src/utils/sanitize.ts
+++ b/app/client/src/utils/sanitize.ts
@@ -22,7 +22,7 @@ const ALLOWED_ATTRS: Record<string, string[]> = {
   span: ["class"],
 };
 const GLOBAL_ATTRS = ["data-og", "lang"];
-const ALLOWED_CLASSES = ["invisible", "ellipsis", "hashtag", "mention"];
+const ALLOWED_CLASSES = ["invisible", "hashtag", "mention"];
 
 export function sanitizeHtml(fragment: string): string {
   const clean = DOMPurify.sanitize(fragment, {


### PR DESCRIPTION
## 概要
CSS ファイル `style.css` を削除し、関連するクラスを使用しないようリファクタリングしました。これに伴い、サニタイズ処理と URL 変換処理を更新しています。

## 主な変更点
- `app/client/src/style.css` を削除
- `sanitize.ts` の `ALLOWED_CLASSES` から `ellipsis` を削除
- `render.ts` で `external-link` および `ellipsis` クラスを利用しない形に修正

## 動作確認
- `deno fmt` と `deno lint` を実行しエラーがないことを確認済み

------
https://chatgpt.com/codex/tasks/task_e_687c5d0bc92c832883a99b8d5df207b4