### PR TITLE
ホワイトモード廃止

### DIFF
--- a/app/client/src/App.css
+++ b/app/client/src/App.css
@@ -15,11 +15,6 @@ body.dark {
   color: #f3f4f6;
 }
 
-body.light {
-  background-color: #ffffff;
-  color: #1a1a1a;
-}
-
 input::placeholder {
   color: #9ca3af;
   opacity: 0.8;

--- a/app/client/src/App.tsx
+++ b/app/client/src/App.tsx
@@ -1,7 +1,7 @@
 import { createEffect, createSignal, onMount, Show } from "solid-js";
 import { useAtom } from "solid-jotai";
 import { encryptionKeyState, loginState } from "./states/session.ts";
-import { darkModeState, languageState } from "./states/settings.ts";
+import { languageState } from "./states/settings.ts";
 import { LoginForm } from "./components/LoginForm.tsx";
 import { EncryptionKeyForm } from "./components/EncryptionKeyForm.tsx";
 import { Application } from "./components/Application.tsx";
@@ -14,7 +14,6 @@ import "./stylesheet.css";
 function App() {
   const [isLoggedIn, setIsLoggedIn] = useAtom(loginState);
   const [encryptionKey, setEncryptionKey] = useAtom(encryptionKeyState);
-  const [darkMode, setDarkMode] = useAtom(darkModeState);
   const [language, setLanguage] = useAtom(languageState);
   const [skippedEncryptionKey, setSkippedEncryptionKey] = createSignal(false);
 
@@ -30,10 +29,6 @@ function App() {
       setEncryptionKey(storedKey);
     }
 
-    const storedDark = localStorage.getItem("darkMode");
-    if (storedDark !== null) {
-      setDarkMode(storedDark === "true");
-    }
     const storedLang = localStorage.getItem("language");
     if (storedLang) {
       setLanguage(storedLang);
@@ -55,14 +50,8 @@ function App() {
   });
 
   createEffect(() => {
-    if (darkMode()) {
-      document.body.classList.add("dark");
-      document.body.classList.remove("light");
-    } else {
-      document.body.classList.remove("dark");
-      document.body.classList.add("light");
-    }
-    localStorage.setItem("darkMode", String(darkMode()));
+    document.body.classList.add("dark");
+    localStorage.setItem("darkMode", "true");
   });
 
   createEffect(() => {

--- a/app/client/src/components/Setting/index.tsx
+++ b/app/client/src/components/Setting/index.tsx
@@ -1,5 +1,5 @@
 import { useAtom } from "solid-jotai";
-import { darkModeState, languageState } from "../../states/settings.ts";
+import { languageState } from "../../states/settings.ts";
 import { encryptionKeyState, loginState } from "../../states/session.ts";
 import RelaySettings from "./RelaySettings.tsx";
 import { apiFetch } from "../../utils/config.ts";
@@ -10,13 +10,10 @@ export interface SettingProps {
   onShowEncryptionKeyForm?: () => void;
 }
 export function Setting(props: SettingProps) {
-  const [darkMode, setDarkMode] = useAtom(darkModeState);
   const [language, setLanguage] = useAtom(languageState);
   const [, setIsLoggedIn] = useAtom(loginState);
   const [, setEncryptionKey] = useAtom(encryptionKeyState);
   const [accs] = useAtom(accountsAtom);
-
-  const toggleDark = () => setDarkMode(!darkMode());
 
   const handleLogout = async () => {
     try {
@@ -36,15 +33,6 @@ export function Setting(props: SettingProps) {
 
   return (
     <div class="space-y-6">
-      <div class="flex items-center space-x-3">
-        <input
-          id="darkmode"
-          type="checkbox"
-          checked={darkMode()}
-          onChange={toggleDark}
-        />
-        <label for="darkmode">ダークモード</label>
-      </div>
       <div>
         <label for="lang" class="block mb-1">言語</label>
         <select

--- a/app/takos_host/client/src/index.css
+++ b/app/takos_host/client/src/index.css
@@ -15,11 +15,6 @@ body.dark {
   color: #f3f4f6;
 }
 
-body.light {
-  background-color: #ffffff;
-  color: #1a1a1a;
-}
-
 input::placeholder {
   color: #9ca3af;
   opacity: 0.8;


### PR DESCRIPTION
## Summary
- ホワイトモード関連のCSSと処理を削除
- 設定画面からダークモード切り替えを削除
- 画面表示は常にダークモードに固定

## Testing
- `deno fmt`
- `deno lint`

------
https://chatgpt.com/codex/tasks/task_e_687cb2ed969c832893e23ffacd6a0c11