### PR TITLE
Add reCAPTCHA integration for takos host

### DIFF
--- a/app/takos_host/.env.example
+++ b/app/takos_host/.env.example
@@ -68,3 +68,15 @@ FIREBASE_STORAGE_BUCKET=
 FIREBASE_MESSAGING_SENDER_ID=
 FIREBASE_APP_ID=
 FIREBASE_VAPID_KEY=
+
+############################
+# reCAPTCHA 設定
+############################
+# v3 用サイトキーとシークレットキーを設定
+RECAPTCHA_V3_SITE_KEY=
+RECAPTCHA_V3_SECRET_KEY=
+# v3 のスコア判定閾値 (0-1)
+RECAPTCHA_V3_THRESHOLD=0.5
+# v3 で弾かれた場合に使用する v2 のキー
+RECAPTCHA_V2_SITE_KEY=
+RECAPTCHA_V2_SECRET_KEY=

--- a/app/takos_host/README.md
+++ b/app/takos_host/README.md
@@ -98,8 +98,13 @@ OAuth ボタンを表示します。
    - `FREE_PLAN_LIMIT` で無料プランのインスタンス数上限を指定します。
    - `RESERVED_SUBDOMAINS`
      には利用禁止とするサブドメインをカンマ区切りで設定します。
-   - `TERMS_FILE` に利用規約(テキストまたは Markdown)の
-     ファイルパスを指定します。Markdown の場合は HTML として表示されます。
+
+- `TERMS_FILE` に利用規約(テキストまたは Markdown)の
+  ファイルパスを指定します。Markdown の場合は HTML として表示されます。
+- `RECAPTCHA_V3_SITE_KEY` と `RECAPTCHA_V3_SECRET_KEY` を設定すると
+  ログインと登録時に reCAPTCHA v3 を使用します。`RECAPTCHA_V3_THRESHOLD`
+  でスコアの閾値を変更できます。v3 で弾かれた場合に v2 へ切り替えるには
+  `RECAPTCHA_V2_SITE_KEY` と `RECAPTCHA_V2_SECRET_KEY` も設定してください。
 
 - `FREE_PLAN_LIMIT` で無料プランのインスタンス数上限を指定します。
 - `RESERVED_SUBDOMAINS`

--- a/app/takos_host/client/src/App.tsx
+++ b/app/takos_host/client/src/App.tsx
@@ -11,6 +11,8 @@ import {
   instancesState,
   loggedInState,
   pathState,
+  recaptchaV2SiteKeyState,
+  recaptchaV3SiteKeyState,
   rootDomainState,
   termsRequiredState,
 } from "./state.ts";
@@ -22,6 +24,8 @@ export default function App() {
   const [, setInstances] = useAtom(instancesState);
   const [, setRootDomain] = useAtom(rootDomainState);
   const [, setTermsRequired] = useAtom(termsRequiredState);
+  const [, setRecaptchaV3] = useAtom(recaptchaV3SiteKeyState);
+  const [, setRecaptchaV2] = useAtom(recaptchaV2SiteKeyState);
 
   globalThis.addEventListener("popstate", () => {
     setPath(globalThis.location.pathname.replace(/\/$/, ""));
@@ -32,6 +36,8 @@ export default function App() {
     setLoggedIn(status.login);
     setRootDomain(status.rootDomain ?? "");
     setTermsRequired(status.termsRequired ?? false);
+    setRecaptchaV3(status.recaptchaV3SiteKey ?? "");
+    setRecaptchaV2(status.recaptchaV2SiteKey ?? "");
   };
 
   const loadInstances = async () => {

--- a/app/takos_host/client/src/state.ts
+++ b/app/takos_host/client/src/state.ts
@@ -10,3 +10,5 @@ export const instancesState = atom<Instance[]>([]);
 export const hostState = atom("");
 export const rootDomainState = atom("");
 export const termsRequiredState = atom(false);
+export const recaptchaV3SiteKeyState = atom("");
+export const recaptchaV2SiteKeyState = atom("");

--- a/app/takos_host/main.ts
+++ b/app/takos_host/main.ts
@@ -40,7 +40,15 @@ const consumerApp = createConsumerApp(
   },
   { rootDomain, freeLimit, reservedSubdomains },
 );
-const authApp = createAuthApp({ rootDomain, termsRequired: !!termsText });
+const authApp = createAuthApp({
+  rootDomain,
+  termsRequired: !!termsText,
+  recaptchaV3SiteKey: env["RECAPTCHA_V3_SITE_KEY"],
+  recaptchaV2SiteKey: env["RECAPTCHA_V2_SITE_KEY"],
+  recaptchaV3Secret: env["RECAPTCHA_V3_SECRET_KEY"],
+  recaptchaV2Secret: env["RECAPTCHA_V2_SECRET_KEY"],
+  recaptchaThreshold: Number(env["RECAPTCHA_V3_THRESHOLD"] ?? "0.5"),
+});
 const isDev = Deno.env.get("DEV") === "1";
 
 function parseHost(value: string | undefined): string {
@@ -158,6 +166,6 @@ root.all("/*", async (c) => {
   return app.fetch(c.req.raw);
 });
 
-root.use(logger())
+root.use(logger());
 
 Deno.serve({ port: 8001 }, root.fetch);

--- a/app/takos_host/recaptcha.ts
+++ b/app/takos_host/recaptcha.ts
@@ -1,0 +1,41 @@
+export async function verifyRecaptchaV3(
+  token: string | undefined,
+  secret: string,
+  action: string,
+  threshold = 0.5,
+): Promise<boolean> {
+  if (!secret || !token) return false;
+  const params = new URLSearchParams();
+  params.set("secret", secret);
+  params.set("response", token);
+  const res = await fetch(
+    "https://www.google.com/recaptcha/api/siteverify",
+    {
+      method: "POST",
+      body: params,
+    },
+  );
+  if (!res.ok) return false;
+  const data = await res.json();
+  return data.success && data.action === action && data.score >= threshold;
+}
+
+export async function verifyRecaptchaV2(
+  token: string | undefined,
+  secret: string,
+): Promise<boolean> {
+  if (!secret || !token) return false;
+  const params = new URLSearchParams();
+  params.set("secret", secret);
+  params.set("response", token);
+  const res = await fetch(
+    "https://www.google.com/recaptcha/api/siteverify",
+    {
+      method: "POST",
+      body: params,
+    },
+  );
+  if (!res.ok) return false;
+  const data = await res.json();
+  return data.success;
+}


### PR DESCRIPTION
## Summary
- add reCAPTCHA verification utilities
- support reCAPTCHA v3 and v2 fallback in takos host authentication
- expose site keys in status API
- load keys in client and invoke reCAPTCHA when logging in or registering
- document new environment variables

## Testing
- `deno fmt`
- `deno lint`


------
https://chatgpt.com/codex/tasks/task_e_687cc0114ef8832884f9ba5e1d660075