### PR TITLE
Add 404 page for unknown domain

### DIFF
--- a/app/takos_host/404.html
+++ b/app/takos_host/404.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <title>404 Not Found</title>
+  </head>
+  <body>
+    <h1>404 Not Found</h1>
+    <p>指定されたドメインは存在しません。</p>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- takos host で存在しないドメインへアクセスした場合に 404 ページを表示

## Testing
- `deno fmt app/takos_host/main.ts app/takos_host/404.html`
- `deno lint app/takos_host/main.ts app/takos_host/404.html`


------
https://chatgpt.com/codex/tasks/task_e_687cc524f1488328b40ad3413f5b83e6