### PR TITLE
deno.json で mongoose を一元管理

### DIFF
--- a/app/api/accounts.ts
+++ b/app/api/accounts.ts
@@ -326,7 +326,9 @@ app.delete("/accounts/:id/follow", async (c) => {
           (err) => console.error("Delivery failed:", err),
         );
       }
-      await db.unfollow(accountExist.userName, target);
+      if (db.unfollow) {
+        await db.unfollow(accountExist.userName, target);
+      }
     }
   } catch (err) {
     console.error("Unfollow request failed:", err);

--- a/app/api/db.ts
+++ b/app/api/db.ts
@@ -29,6 +29,7 @@ import {
 import mongoose from "mongoose";
 import type { DB, ListOpts } from "../../shared/db.ts";
 import type { SortOrder } from "mongoose";
+import type { Db } from "mongodb";
 import { connectDatabase } from "../../shared/db.ts";
 
 /** takos 用 MongoDB 実装 */
@@ -208,7 +209,7 @@ export class MongoDBLocal implements DB {
 
   async getDatabase() {
     await connectDatabase(this.env);
-    return mongoose.connection.db;
+    return mongoose.connection.db as Db;
   }
 }
 

--- a/app/takos_host/db.ts
+++ b/app/takos_host/db.ts
@@ -4,6 +4,7 @@ import RelayEdge from "./models/relay_edge.ts";
 import mongoose from "mongoose";
 import type { DB, ListOpts } from "../../shared/db.ts";
 import type { SortOrder } from "mongoose";
+import type { Db } from "mongodb";
 import { connectDatabase } from "../../shared/db.ts";
 import { createObjectId } from "../api/utils/activitypub.ts";
 
@@ -116,7 +117,7 @@ export class MongoDBHost implements DB {
       type: "Note",
       "aud.to": "https://www.w3.org/ns/activitystreams#Public",
     });
-    if (before) query.where("created_at").lt(before);
+    if (before) query.where("created_at").lt(before.getTime());
     return await query.sort({ created_at: -1 }).limit(limit).lean();
   }
 
@@ -288,6 +289,6 @@ export class MongoDBHost implements DB {
 
   async getDatabase() {
     await connectDatabase({ MONGO_URI: this.mongoUri });
-    return mongoose.connection.db;
+    return mongoose.connection.db as Db;
   }
 }

--- a/shared/deno.json
+++ b/shared/deno.json
@@ -1,0 +1,6 @@
+{
+  "imports": {
+    "mongoose": "npm:mongoose@^8.16.4",
+    "mongodb": "npm:mongodb@^6.17.0"
+  }
+}


### PR DESCRIPTION
## Summary
- shared ディレクトリに `deno.json` を追加し、mongoose と mongodb の import を定義
- 以前 `npm:` プレフィックスに変更した各ファイルの import を元に戻して deno.json 管理に
- `MongoDBLocal#getDatabase` は DB 型に合わせて `as Db` を継続
- `getPublicNotes` 内の `lt()` に `before.getTime()` を指定し型エラーを修正

## Testing
- `deno fmt`
- `deno lint`


------
https://chatgpt.com/codex/tasks/task_e_687ce949485c83289864c2970046c5b9