### PR TITLE
共通暗号ユーティリティの追加

### DIFF
--- a/app/api/accounts.ts
+++ b/app/api/accounts.ts
@@ -25,43 +25,7 @@ import authRequired from "./utils/auth.ts";
 import { addNotification } from "./services/notification.ts";
 import { createDB } from "./db.ts";
 import { getEnv } from "../../shared/config.ts";
-
-function bufferToBase64(buffer: ArrayBuffer): string {
-  let binary = "";
-  const bytes = new Uint8Array(buffer);
-  for (let i = 0; i < bytes.byteLength; i++) {
-    binary += String.fromCharCode(bytes[i]);
-  }
-  return btoa(binary);
-}
-
-function bufferToPem(
-  buffer: ArrayBuffer,
-  type: "PUBLIC KEY" | "PRIVATE KEY",
-): string {
-  const b64 = bufferToBase64(buffer);
-  const lines = b64.match(/.{1,64}/g)?.join("\n") ?? b64;
-  return `-----BEGIN ${type}-----\n${lines}\n-----END ${type}-----`;
-}
-
-async function generateKeyPair() {
-  const keyPair = await crypto.subtle.generateKey(
-    {
-      name: "RSA-PSS",
-      modulusLength: 2048,
-      publicExponent: new Uint8Array([1, 0, 1]),
-      hash: "SHA-256",
-    },
-    true,
-    ["sign", "verify"],
-  );
-  const priv = await crypto.subtle.exportKey("pkcs8", keyPair.privateKey);
-  const pub = await crypto.subtle.exportKey("spki", keyPair.publicKey);
-  return {
-    privateKey: bufferToPem(priv, "PRIVATE KEY"),
-    publicKey: bufferToPem(pub, "PUBLIC KEY"),
-  };
-}
+import { generateKeyPair } from "../../shared/crypto.ts";
 
 interface AccountDoc {
   _id?: string;

--- a/app/api/services/system_actor.ts
+++ b/app/api/services/system_actor.ts
@@ -1,38 +1,5 @@
 import SystemKey from "../models/system_key.ts";
-
-function bufferToBase64(buffer: ArrayBuffer): string {
-  let binary = "";
-  const bytes = new Uint8Array(buffer);
-  for (let i = 0; i < bytes.byteLength; i++) {
-    binary += String.fromCharCode(bytes[i]);
-  }
-  return btoa(binary);
-}
-
-function bufferToPem(buffer: ArrayBuffer, type: "PUBLIC KEY" | "PRIVATE KEY") {
-  const b64 = bufferToBase64(buffer);
-  const lines = b64.match(/.{1,64}/g)?.join("\n") ?? b64;
-  return `-----BEGIN ${type}-----\n${lines}\n-----END ${type}-----`;
-}
-
-export async function generateKeyPair() {
-  const keyPair = await crypto.subtle.generateKey(
-    {
-      name: "RSA-PSS",
-      modulusLength: 2048,
-      publicExponent: new Uint8Array([1, 0, 1]),
-      hash: "SHA-256",
-    },
-    true,
-    ["sign", "verify"],
-  );
-  const priv = await crypto.subtle.exportKey("pkcs8", keyPair.privateKey);
-  const pub = await crypto.subtle.exportKey("spki", keyPair.publicKey);
-  return {
-    privateKey: bufferToPem(priv, "PRIVATE KEY"),
-    publicKey: bufferToPem(pub, "PUBLIC KEY"),
-  };
-}
+import { generateKeyPair } from "../../shared/crypto.ts";
 
 export async function getSystemKey(domain: string) {
   let doc = await SystemKey.findOne({ domain }).lean<{

--- a/app/api/setup_ui.ts
+++ b/app/api/setup_ui.ts
@@ -6,6 +6,7 @@ import { createAccount } from "./repositories/account.ts";
 import { createDB } from "./db.ts";
 import { getEnv } from "../../shared/config.ts";
 import authRequired from "./utils/auth.ts";
+import { generateKeyPair, sha256Hex } from "../../shared/crypto.ts";
 
 const app = new Hono();
 app.use("/setup", authRequired);
@@ -16,39 +17,6 @@ app.get("/setup/status", (c) => {
   const configured = Boolean(env["hashedPassword"] && env["salt"]);
   return c.json({ configured });
 });
-
-async function sha256Hex(text: string): Promise<string> {
-  const buf = new TextEncoder().encode(text);
-  const hash = await crypto.subtle.digest("SHA-256", buf);
-  return Array.from(new Uint8Array(hash))
-    .map((b) => b.toString(16).padStart(2, "0"))
-    .join("");
-}
-
-function bufferToPem(buffer: ArrayBuffer, type: "PRIVATE KEY" | "PUBLIC KEY") {
-  const b64 = btoa(String.fromCharCode(...new Uint8Array(buffer)));
-  const lines = b64.match(/.{1,64}/g)?.join("\n") ?? b64;
-  return `-----BEGIN ${type}-----\n${lines}\n-----END ${type}-----`;
-}
-
-async function generateKeyPair() {
-  const pair = await crypto.subtle.generateKey(
-    {
-      name: "RSA-PSS",
-      modulusLength: 2048,
-      publicExponent: new Uint8Array([1, 0, 1]),
-      hash: "SHA-256",
-    },
-    true,
-    ["sign", "verify"],
-  );
-  const priv = await crypto.subtle.exportKey("pkcs8", pair.privateKey);
-  const pub = await crypto.subtle.exportKey("spki", pair.publicKey);
-  return {
-    privateKey: bufferToPem(priv, "PRIVATE KEY"),
-    publicKey: bufferToPem(pub, "PUBLIC KEY"),
-  };
-}
 
 app.post("/setup", async (c) => {
   const env = getEnv(c);

--- a/setup.ts
+++ b/setup.ts
@@ -7,39 +7,7 @@ import {
   updateAccountById,
 } from "./app/api/repositories/account.ts";
 import { createDB } from "./app/api/db.ts";
-
-async function sha256Hex(text: string): Promise<string> {
-  const buf = new TextEncoder().encode(text);
-  const hash = await crypto.subtle.digest("SHA-256", buf);
-  return Array.from(new Uint8Array(hash))
-    .map((b) => b.toString(16).padStart(2, "0"))
-    .join("");
-}
-
-function bufferToPem(buffer: ArrayBuffer, type: "PRIVATE KEY" | "PUBLIC KEY") {
-  const b64 = btoa(String.fromCharCode(...new Uint8Array(buffer)));
-  const lines = b64.match(/.{1,64}/g)?.join("\n") ?? b64;
-  return `-----BEGIN ${type}-----\n${lines}\n-----END ${type}-----`;
-}
-
-async function generateKeyPair() {
-  const pair = await crypto.subtle.generateKey(
-    {
-      name: "RSA-PSS",
-      modulusLength: 2048,
-      publicExponent: new Uint8Array([1, 0, 1]),
-      hash: "SHA-256",
-    },
-    true,
-    ["sign", "verify"],
-  );
-  const priv = await crypto.subtle.exportKey("pkcs8", pair.privateKey);
-  const pub = await crypto.subtle.exportKey("spki", pair.publicKey);
-  return {
-    privateKey: bufferToPem(priv, "PRIVATE KEY"),
-    publicKey: bufferToPem(pub, "PUBLIC KEY"),
-  };
-}
+import { generateKeyPair, sha256Hex } from "./shared/crypto.ts";
 
 async function main() {
   const envPath = join("app", "api", ".env");

--- a/shared/crypto.ts
+++ b/shared/crypto.ts
@@ -1,0 +1,35 @@
+export async function sha256Hex(text: string): Promise<string> {
+  const buf = new TextEncoder().encode(text);
+  const hash = await crypto.subtle.digest("SHA-256", buf);
+  return Array.from(new Uint8Array(hash))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+export function bufferToPem(
+  buffer: ArrayBuffer,
+  type: "PRIVATE KEY" | "PUBLIC KEY",
+) {
+  const b64 = btoa(String.fromCharCode(...new Uint8Array(buffer)));
+  const lines = b64.match(/.{1,64}/g)?.join("\n") ?? b64;
+  return `-----BEGIN ${type}-----\n${lines}\n-----END ${type}-----`;
+}
+
+export async function generateKeyPair() {
+  const pair = await crypto.subtle.generateKey(
+    {
+      name: "RSA-PSS",
+      modulusLength: 2048,
+      publicExponent: new Uint8Array([1, 0, 1]),
+      hash: "SHA-256",
+    },
+    true,
+    ["sign", "verify"],
+  );
+  const priv = await crypto.subtle.exportKey("pkcs8", pair.privateKey);
+  const pub = await crypto.subtle.exportKey("spki", pair.publicKey);
+  return {
+    privateKey: bufferToPem(priv, "PRIVATE KEY"),
+    publicKey: bufferToPem(pub, "PUBLIC KEY"),
+  };
+}


### PR DESCRIPTION
## 概要
重複していた鍵生成処理などを `shared/crypto.ts` にまとめました。
関連ファイルでは新しいモジュールを利用するよう修正しています。

## テスト
- `deno fmt` を実行し整形を確認
- `deno lint` を実行し警告がないことを確認

------
https://chatgpt.com/codex/tasks/task_e_687cf1d748408328b691714cdb957d7c