### PR TITLE
Add generic ActivityPub delivery helper

### DIFF
--- a/app/api/utils/deliver.ts
+++ b/app/api/utils/deliver.ts
@@ -1,0 +1,37 @@
+import { findAccountByUserName } from "../repositories/account.ts";
+import { deliverActivityPubObject, fetchActorInbox } from "./activitypub.ts";
+
+export async function deliverToFollowers(
+  env: Record<string, string>,
+  user: string,
+  activity: unknown,
+  domain: string,
+): Promise<void> {
+  const account = await findAccountByUserName(env, user);
+  if (!account || !account.followers) return;
+
+  const inboxes = await Promise.all(
+    account.followers.map(async (actorUrl) => {
+      try {
+        const url = new URL(actorUrl);
+        if (url.host === domain && url.pathname.startsWith("/users/")) {
+          return null;
+        }
+        return await fetchActorInbox(actorUrl, env);
+      } catch {
+        return null;
+      }
+    }),
+  );
+
+  const valid = inboxes.filter((i): i is string =>
+    typeof i === "string" && !!i
+  );
+  if (valid.length > 0) {
+    deliverActivityPubObject(valid, activity, user, domain, env).catch(
+      (err) => {
+        console.error("Delivery failed:", err);
+      },
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- 新しい `deliverToFollowers` ユーティリティを追加
- microblog・videos・e2ee の各モジュールで共通関数を利用
- 既存の個別実装を削除して整理

## Testing
- `deno fmt app/api/utils/deliver.ts app/api/microblog.ts app/api/videos.ts app/api/e2ee.ts`
- `deno lint app/api/utils/deliver.ts app/api/microblog.ts app/api/videos.ts app/api/e2ee.ts`

------
https://chatgpt.com/codex/tasks/task_e_687cf7bec45c8328b632ba3424226170