### PR TITLE
Refactor Firebase config parsing

### DIFF
--- a/app/api/config.ts
+++ b/app/api/config.ts
@@ -1,5 +1,6 @@
 import { Hono } from "hono";
 import { getEnv } from "../../shared/config.ts";
+import { parseFirebaseClientConfig } from "../../shared/firebase_config.ts";
 
 const app = new Hono();
 
@@ -8,33 +9,7 @@ app.get("/config", (c) => {
   const host = env["OAUTH_HOST"] ?? env["ROOT_DOMAIN"] ?? null;
   const clientId = env["OAUTH_CLIENT_ID"] ?? null;
   const clientSecret = env["OAUTH_CLIENT_SECRET"] ?? null;
-  let firebaseConfig: Record<string, string> | null = null;
-  if (env["FIREBASE_CLIENT_CONFIG"]) {
-    try {
-      firebaseConfig = JSON.parse(env["FIREBASE_CLIENT_CONFIG"]);
-    } catch {
-      firebaseConfig = null;
-    }
-  } else {
-    const keys = [
-      "FIREBASE_API_KEY",
-      "FIREBASE_AUTH_DOMAIN",
-      "FIREBASE_PROJECT_ID",
-      "FIREBASE_STORAGE_BUCKET",
-      "FIREBASE_MESSAGING_SENDER_ID",
-      "FIREBASE_APP_ID",
-    ];
-    if (keys.every((k) => env[k])) {
-      firebaseConfig = {
-        apiKey: env["FIREBASE_API_KEY"],
-        authDomain: env["FIREBASE_AUTH_DOMAIN"],
-        projectId: env["FIREBASE_PROJECT_ID"],
-        storageBucket: env["FIREBASE_STORAGE_BUCKET"],
-        messagingSenderId: env["FIREBASE_MESSAGING_SENDER_ID"],
-        appId: env["FIREBASE_APP_ID"],
-      };
-    }
-  }
+  const firebaseConfig = parseFirebaseClientConfig(env);
   return c.json({
     oauthHost: host,
     oauthClientId: clientId,

--- a/app/api/fcm.ts
+++ b/app/api/fcm.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { zValidator } from "@hono/zod-validator";
 import authRequired from "./utils/auth.ts";
 import { getEnv } from "../../shared/config.ts";
+import { parseFirebaseClientConfig } from "../../shared/firebase_config.ts";
 import { registerToken, unregisterToken } from "./services/fcm.ts";
 
 const app = new Hono();
@@ -11,33 +12,7 @@ app.use("/fcm/*", authRequired);
 
 app.get("/fcm/config", (c) => {
   const env = getEnv(c);
-  let firebaseConfig: Record<string, string> | null = null;
-  if (env["FIREBASE_CLIENT_CONFIG"]) {
-    try {
-      firebaseConfig = JSON.parse(env["FIREBASE_CLIENT_CONFIG"]);
-    } catch {
-      firebaseConfig = null;
-    }
-  } else {
-    const keys = [
-      "FIREBASE_API_KEY",
-      "FIREBASE_AUTH_DOMAIN",
-      "FIREBASE_PROJECT_ID",
-      "FIREBASE_STORAGE_BUCKET",
-      "FIREBASE_MESSAGING_SENDER_ID",
-      "FIREBASE_APP_ID",
-    ];
-    if (keys.every((k) => env[k])) {
-      firebaseConfig = {
-        apiKey: env["FIREBASE_API_KEY"],
-        authDomain: env["FIREBASE_AUTH_DOMAIN"],
-        projectId: env["FIREBASE_PROJECT_ID"],
-        storageBucket: env["FIREBASE_STORAGE_BUCKET"],
-        messagingSenderId: env["FIREBASE_MESSAGING_SENDER_ID"],
-        appId: env["FIREBASE_APP_ID"],
-      };
-    }
-  }
+  const firebaseConfig = parseFirebaseClientConfig(env);
   if (!firebaseConfig) return c.json({});
   return c.json({
     firebase: firebaseConfig,

--- a/shared/firebase_config.ts
+++ b/shared/firebase_config.ts
@@ -1,0 +1,30 @@
+export function parseFirebaseClientConfig(
+  env: Record<string, string>,
+): Record<string, string> | null {
+  if (env["FIREBASE_CLIENT_CONFIG"]) {
+    try {
+      return JSON.parse(env["FIREBASE_CLIENT_CONFIG"]);
+    } catch {
+      return null;
+    }
+  }
+  const keys = [
+    "FIREBASE_API_KEY",
+    "FIREBASE_AUTH_DOMAIN",
+    "FIREBASE_PROJECT_ID",
+    "FIREBASE_STORAGE_BUCKET",
+    "FIREBASE_MESSAGING_SENDER_ID",
+    "FIREBASE_APP_ID",
+  ];
+  if (keys.every((k) => env[k])) {
+    return {
+      apiKey: env["FIREBASE_API_KEY"],
+      authDomain: env["FIREBASE_AUTH_DOMAIN"],
+      projectId: env["FIREBASE_PROJECT_ID"],
+      storageBucket: env["FIREBASE_STORAGE_BUCKET"],
+      messagingSenderId: env["FIREBASE_MESSAGING_SENDER_ID"],
+      appId: env["FIREBASE_APP_ID"],
+    };
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary
- Firebase 設定の取得処理を `parseFirebaseClientConfig` として共通化
- `/api/config` と `/api/fcm/config` で共通関数を利用するよう変更

## Testing
- `deno fmt shared/firebase_config.ts app/api/config.ts app/api/fcm.ts`
- `deno lint shared/firebase_config.ts app/api/config.ts app/api/fcm.ts`


------
https://chatgpt.com/codex/tasks/task_e_687d8924d7488328b80fa579b4ed9e9e