### PR TITLE
Fix video type errors

### DIFF
--- a/app/api/services/unified_store.ts
+++ b/app/api/services/unified_store.ts
@@ -21,7 +21,7 @@ function withTenant(
 
 type ObjectStoreType = InferSchemaType<typeof objectStoreSchema>;
 type NoteType = InferSchemaType<typeof noteSchema>;
-type VideoType = InferSchemaType<typeof videoSchema>;
+export type VideoType = InferSchemaType<typeof videoSchema>;
 type MessageType = InferSchemaType<typeof messageSchema>;
 export type ActivityObject =
   | NoteType


### PR DESCRIPTION
## Summary
- export `VideoType` so other modules can use it
- fix unknown type errors in video API by defining `VideoDoc` and casting

## Testing
- `deno fmt app/api/services/unified_store.ts app/api/videos.ts`
- `deno lint app/api/services_unified_store.ts app/api/videos.ts`


------
https://chatgpt.com/codex/tasks/task_e_687d8aa23d38832888286cfdd58358b8