### PR TITLE
takos hostのenv管理を修正

### DIFF
--- a/app/shared/config.ts
+++ b/app/shared/config.ts
@@ -2,15 +2,17 @@ import { load } from "@std/dotenv";
 import { z } from "zod";
 import type { Context, Hono } from "hono";
 
-let cachedEnv: Record<string, string> | null = null;
+const cachedEnv = new Map<string | undefined, Record<string, string>>();
 const envMap = new WeakMap<Hono, Record<string, string>>();
 
 export async function loadConfig(options?: { envPath?: string }) {
-  if (!cachedEnv) {
-    cachedEnv = await load(options);
-    validateEnv(cachedEnv);
-  }
-  return cachedEnv;
+  const key = options?.envPath;
+  const cached = cachedEnv.get(key);
+  if (cached) return cached;
+  const env = await load(options);
+  validateEnv(env);
+  cachedEnv.set(key, env);
+  return env;
 }
 
 function validateEnv(env: Record<string, string>) {


### PR DESCRIPTION
## Summary
- `loadConfig` のキャッシュをパスごとに保持するよう変更
- takos host でテナント用の環境変数を `app/api/.env` から生成
- FCM 用の設定値などホスト側の値を引き継ぐよう調整

## Testing
- `deno fmt app/shared/config.ts app/takos_host/main.ts`
- `deno lint app/shared/config.ts app/takos_host/main.ts`


------
https://chatgpt.com/codex/tasks/task_e_687d95a9a2988328982c02d54808df5e