### PR TITLE
Fix Mongo connection reuse for host

### DIFF
--- a/app/shared/db.ts
+++ b/app/shared/db.ts
@@ -87,6 +87,7 @@ let currentUri = "";
 
 export async function connectDatabase(env: Record<string, string>) {
   const uri = env["MONGO_URI"];
+  if (!uri) return;
   if (mongoose.connection.readyState === 1 && currentUri === uri) {
     return;
   }

--- a/app/takos_host/takos_env.ts
+++ b/app/takos_host/takos_env.ts
@@ -7,6 +7,7 @@ const hostEnv = await loadConfig({
 
 export const takosEnv: Record<string, string> = {
   DB_MODE: "host",
+  MONGO_URI: hostEnv["MONGO_URI"],
   hashedPassword: "",
   salt: "",
   ACTIVITYPUB_DOMAIN: "",


### PR DESCRIPTION
## Summary
- takos_host のデフォルト環境変数に `MONGO_URI` を追加
- `connectDatabase` で空文字列の URI を無視

## Testing
- `deno fmt app/takos_host/takos_env.ts app/shared/db.ts`
- `deno lint app/takos_host/takos_env.ts app/shared/db.ts`


------
https://chatgpt.com/codex/tasks/task_e_687dd0397dc08328bf67d6a7a89d8e2e