### PR TITLE
DB 型定義の改善

### DIFF
--- a/app/api/accounts.ts
+++ b/app/api/accounts.ts
@@ -12,17 +12,7 @@ import { addNotification } from "./services/notification.ts";
 import { createDB } from "./db.ts";
 import { getEnv } from "../shared/config.ts";
 import { generateKeyPair } from "../shared/crypto.ts";
-
-interface AccountDoc {
-  _id?: string;
-  userName: string;
-  displayName: string;
-  avatarInitial: string;
-  privateKey: string;
-  publicKey: string;
-  followers: string[];
-  following: string[];
-}
+import type { AccountDoc } from "../shared/types.ts";
 
 function formatAccount(doc: AccountDoc) {
   return {
@@ -43,7 +33,7 @@ app.get("/accounts", async (c) => {
   const env = getEnv(c);
   const db = createDB(env);
   const list = await db.listAccounts();
-  const formatted = (list as AccountDoc[]).map((doc) => formatAccount(doc));
+  const formatted = list.map((doc) => formatAccount(doc));
   return jsonResponse(c, formatted);
 });
 
@@ -83,14 +73,14 @@ app.post("/accounts", async (c) => {
     followers: [],
     following: [],
   });
-  return jsonResponse(c, formatAccount(account as AccountDoc));
+  return jsonResponse(c, formatAccount(account));
 });
 
 app.get("/accounts/:id", async (c) => {
   const env = getEnv(c);
   const db = createDB(env);
   const id = c.req.param("id");
-  const account = await db.findAccountById(id) as AccountDoc | null;
+  const account = await db.findAccountById(id);
   if (!account) return jsonResponse(c, { error: "Account not found" }, 404);
   return jsonResponse(c, {
     ...formatAccount(account),
@@ -116,7 +106,7 @@ app.put("/accounts/:id", async (c) => {
 
   const account = await db.updateAccountById(id, data);
   if (!account) return jsonResponse(c, { error: "Account not found" }, 404);
-  return jsonResponse(c, formatAccount(account as AccountDoc));
+  return jsonResponse(c, formatAccount(account));
 });
 
 app.post("/accounts/:id/followers", async (c) => {
@@ -156,7 +146,7 @@ app.get("/accounts/:id/following", async (c) => {
   const env = getEnv(c);
   const db = createDB(env);
   const id = c.req.param("id");
-  const account = await db.findAccountById(id) as AccountDoc | null;
+  const account = await db.findAccountById(id);
   if (!account) return jsonResponse(c, { error: "Account not found" }, 404);
   return jsonResponse(c, { following: account.following });
 });
@@ -180,7 +170,7 @@ app.post("/accounts/:id/follow", async (c) => {
   if (typeof target !== "string" || typeof userName !== "string") {
     return jsonResponse(c, { error: "Invalid body" }, 400);
   }
-  const accountExist = await db.findAccountById(id) as AccountDoc | null;
+  const accountExist = await db.findAccountById(id);
   if (!accountExist) {
     return jsonResponse(c, { error: "Account not found" }, 404);
   }
@@ -240,7 +230,7 @@ app.delete("/accounts/:id/follow", async (c) => {
   if (typeof target !== "string") {
     return jsonResponse(c, { error: "Invalid body" }, 400);
   }
-  const accountExist = await db.findAccountById(id) as AccountDoc | null;
+  const accountExist = await db.findAccountById(id);
   if (!accountExist) {
     return jsonResponse(c, { error: "Account not found" }, 404);
   }

--- a/app/api/db.ts
+++ b/app/api/db.ts
@@ -16,6 +16,7 @@ import RemoteActor from "../models/takos/remote_actor.ts";
 import Session from "../models/takos/session.ts";
 import mongoose from "mongoose";
 import type { DB, ListOpts } from "../shared/db.ts";
+import type { AccountDoc } from "../shared/types.ts";
 import type { SortOrder } from "mongoose";
 import type { Db } from "mongodb";
 import { connectDatabase } from "../shared/db.ts";
@@ -79,11 +80,11 @@ export class MongoDBLocal implements DB {
     await FollowEdge.deleteOne({ actor_id: target });
   }
 
-  async listAccounts<T = unknown>(): Promise<T[]> {
-    return await Account.find({}).lean<T[]>();
+  async listAccounts(): Promise<AccountDoc[]> {
+    return await Account.find({}).lean<AccountDoc[]>();
   }
 
-  async createAccount<T = unknown>(data: Record<string, unknown>): Promise<T> {
+  async createAccount(data: Record<string, unknown>): Promise<AccountDoc> {
     const doc = new Account({
       ...data,
       tenant_id: this.env["ACTIVITYPUB_DOMAIN"] ?? "",
@@ -93,25 +94,27 @@ export class MongoDBLocal implements DB {
         env: this.env,
       };
     await doc.save();
-    return doc.toObject() as T;
+    return doc.toObject() as AccountDoc;
   }
 
-  async findAccountById<T = unknown>(id: string): Promise<T | null> {
-    return await Account.findOne({ _id: id }).lean<T | null>();
+  async findAccountById(id: string): Promise<AccountDoc | null> {
+    return await Account.findOne({ _id: id }).lean<AccountDoc | null>();
   }
 
-  async findAccountByUserName<T = unknown>(
+  async findAccountByUserName(
     username: string,
-  ): Promise<T | null> {
-    return await Account.findOne({ userName: username }).lean<T | null>();
+  ): Promise<AccountDoc | null> {
+    return await Account.findOne({ userName: username }).lean<
+      AccountDoc | null
+    >();
   }
 
-  async updateAccountById<T = unknown>(
+  async updateAccountById(
     id: string,
     update: Record<string, unknown>,
-  ): Promise<T | null> {
+  ): Promise<AccountDoc | null> {
     return await Account.findOneAndUpdate({ _id: id }, update, { new: true })
-      .lean<T | null>();
+      .lean<AccountDoc | null>();
   }
 
   async deleteAccountById(id: string) {
@@ -353,15 +356,15 @@ export class MongoDBLocal implements DB {
     });
   }
 
-  async searchAccounts<T = unknown>(
+  async searchAccounts(
     query: RegExp,
     limit = 20,
-  ): Promise<T[]> {
+  ): Promise<AccountDoc[]> {
     return await Account.find({
       $or: [{ userName: query }, { displayName: query }],
     })
       .limit(limit)
-      .lean<T[]>();
+      .lean<AccountDoc[]>();
   }
 
   async updateAccountByUserName(
@@ -371,10 +374,12 @@ export class MongoDBLocal implements DB {
     await Account.updateOne({ userName: username }, update);
   }
 
-  async findAccountsByUserNames<T = unknown>(
+  async findAccountsByUserNames(
     usernames: string[],
-  ): Promise<T[]> {
-    return await Account.find({ userName: { $in: usernames } }).lean<T[]>();
+  ): Promise<AccountDoc[]> {
+    return await Account.find({ userName: { $in: usernames } }).lean<
+      AccountDoc[]
+    >();
   }
 
   async countAccounts() {
@@ -707,35 +712,37 @@ export class MongoDBHost implements DB {
     });
   }
 
-  async listAccounts<T = unknown>(): Promise<T[]> {
-    return await Account.find({}).lean<T[]>();
+  async listAccounts(): Promise<AccountDoc[]> {
+    return await Account.find({}).lean<AccountDoc[]>();
   }
 
-  async createAccount<T = unknown>(data: Record<string, unknown>): Promise<T> {
+  async createAccount(data: Record<string, unknown>): Promise<AccountDoc> {
     const doc = new Account({
       ...data,
       tenant_id: this.tenantId,
     });
     await doc.save();
-    return doc.toObject() as T;
+    return doc.toObject() as AccountDoc;
   }
 
-  async findAccountById<T = unknown>(id: string): Promise<T | null> {
-    return await Account.findOne({ _id: id }).lean<T | null>();
+  async findAccountById(id: string): Promise<AccountDoc | null> {
+    return await Account.findOne({ _id: id }).lean<AccountDoc | null>();
   }
 
-  async findAccountByUserName<T = unknown>(
+  async findAccountByUserName(
     username: string,
-  ): Promise<T | null> {
-    return await Account.findOne({ userName: username }).lean<T | null>();
+  ): Promise<AccountDoc | null> {
+    return await Account.findOne({ userName: username }).lean<
+      AccountDoc | null
+    >();
   }
 
-  async updateAccountById<T = unknown>(
+  async updateAccountById(
     id: string,
     update: Record<string, unknown>,
-  ): Promise<T | null> {
+  ): Promise<AccountDoc | null> {
     return await Account.findOneAndUpdate({ _id: id }, update, { new: true })
-      .lean<T | null>();
+      .lean<AccountDoc | null>();
   }
 
   async deleteAccountById(id: string) {
@@ -1016,15 +1023,15 @@ export class MongoDBHost implements DB {
     });
   }
 
-  async searchAccounts<T = unknown>(
+  async searchAccounts(
     query: RegExp,
     limit = 20,
-  ): Promise<T[]> {
+  ): Promise<AccountDoc[]> {
     return await Account.find({
       $or: [{ userName: query }, { displayName: query }],
     })
       .limit(limit)
-      .lean<T[]>();
+      .lean<AccountDoc[]>();
   }
 
   async updateAccountByUserName(
@@ -1034,10 +1041,12 @@ export class MongoDBHost implements DB {
     await Account.updateOne({ userName: username }, update);
   }
 
-  async findAccountsByUserNames<T = unknown>(
+  async findAccountsByUserNames(
     usernames: string[],
-  ): Promise<T[]> {
-    return await Account.find({ userName: { $in: usernames } }).lean<T[]>();
+  ): Promise<AccountDoc[]> {
+    return await Account.find({ userName: { $in: usernames } }).lean<
+      AccountDoc[]
+    >();
   }
 
   async countAccounts() {

--- a/app/api/routes/accounts.ts
+++ b/app/api/routes/accounts.ts
@@ -12,17 +12,7 @@ import { addNotification } from "../services/notification.ts";
 import { createDB } from "../db.ts";
 import { getEnv } from "../../shared/config.ts";
 import { generateKeyPair } from "../../shared/crypto.ts";
-
-interface AccountDoc {
-  _id?: string;
-  userName: string;
-  displayName: string;
-  avatarInitial: string;
-  privateKey: string;
-  publicKey: string;
-  followers: string[];
-  following: string[];
-}
+import type { AccountDoc } from "../../shared/types.ts";
 
 function formatAccount(doc: AccountDoc) {
   return {
@@ -42,7 +32,7 @@ app.use("/accounts/*", authRequired);
 app.get("/accounts", async (c) => {
   const env = getEnv(c);
   const db = createDB(env);
-  const list = await db.listAccounts() as AccountDoc[];
+  const list = await db.listAccounts();
   const formatted = list.map((doc) => formatAccount(doc));
   return jsonResponse(c, formatted);
 });
@@ -82,7 +72,7 @@ app.post("/accounts", async (c) => {
     publicKey: keys.publicKey,
     followers: [],
     following: [],
-  }) as AccountDoc;
+  });
   return jsonResponse(c, formatAccount(account));
 });
 
@@ -90,7 +80,7 @@ app.get("/accounts/:id", async (c) => {
   const env = getEnv(c);
   const db = createDB(env);
   const id = c.req.param("id");
-  const account = await db.findAccountById(id) as AccountDoc | null;
+  const account = await db.findAccountById(id);
   if (!account) return jsonResponse(c, { error: "Account not found" }, 404);
   return jsonResponse(c, {
     ...formatAccount(account),
@@ -114,7 +104,7 @@ app.put("/accounts/:id", async (c) => {
   if (Array.isArray(updates.followers)) data.followers = updates.followers;
   if (Array.isArray(updates.following)) data.following = updates.following;
 
-  const account = await db.updateAccountById(id, data) as AccountDoc | null;
+  const account = await db.updateAccountById(id, data);
   if (!account) return jsonResponse(c, { error: "Account not found" }, 404);
   return jsonResponse(c, formatAccount(account));
 });
@@ -156,7 +146,7 @@ app.get("/accounts/:id/following", async (c) => {
   const env = getEnv(c);
   const db = createDB(env);
   const id = c.req.param("id");
-  const account = await db.findAccountById(id) as AccountDoc | null;
+  const account = await db.findAccountById(id);
   if (!account) return jsonResponse(c, { error: "Account not found" }, 404);
   return jsonResponse(c, { following: account.following });
 });
@@ -180,7 +170,7 @@ app.post("/accounts/:id/follow", async (c) => {
   if (typeof target !== "string" || typeof userName !== "string") {
     return jsonResponse(c, { error: "Invalid body" }, 400);
   }
-  const accountExist = await db.findAccountById(id) as AccountDoc | null;
+  const accountExist = await db.findAccountById(id);
   if (!accountExist) {
     return jsonResponse(c, { error: "Account not found" }, 404);
   }
@@ -240,7 +230,7 @@ app.delete("/accounts/:id/follow", async (c) => {
   if (typeof target !== "string") {
     return jsonResponse(c, { error: "Invalid body" }, 400);
   }
-  const accountExist = await db.findAccountById(id) as AccountDoc | null;
+  const accountExist = await db.findAccountById(id);
   if (!accountExist) {
     return jsonResponse(c, { error: "Account not found" }, 404);
   }

--- a/app/api/routes/activitypub.ts
+++ b/app/api/routes/activitypub.ts
@@ -21,14 +21,7 @@ interface KeyPackageDoc {
   _id: unknown;
 }
 
-interface AccountDoc {
-  userName: string;
-  displayName: string;
-  publicKey: string;
-  avatarInitial: string;
-  followers?: string[];
-  following?: string[];
-}
+import type { AccountDoc } from "../../shared/types.ts";
 
 app.get("/.well-known/webfinger", async (c) => {
   const resource = c.req.query("resource");
@@ -56,7 +49,7 @@ app.get("/.well-known/webfinger", async (c) => {
   }
   const env = getEnv(c);
   const db = createDB(env);
-  const account = await db.findAccountByUserName(username) as AccountDoc | null;
+  const account: AccountDoc | null = await db.findAccountByUserName(username);
   if (!account) return jsonResponse(c, { error: "Not found" }, 404);
   const jrd = {
     subject: `acct:${username}@${domain}`,
@@ -96,7 +89,7 @@ app.get("/users/:username", async (c) => {
   }
   const env = getEnv(c);
   const db = createDB(env);
-  const account = await db.findAccountByUserName(username) as AccountDoc | null;
+  const account: AccountDoc | null = await db.findAccountByUserName(username);
   if (!account) return jsonResponse(c, { error: "Not found" }, 404);
   const domain = getDomain(c);
 
@@ -126,7 +119,7 @@ app.get("/users/:username/avatar", async (c) => {
   }
   const env = getEnv(c);
   const db = createDB(env);
-  const account = await db.findAccountByUserName(username) as AccountDoc | null;
+  const account: AccountDoc | null = await db.findAccountByUserName(username);
   if (!account) return c.body("Not Found", 404);
 
   let icon = account.avatarInitial ||
@@ -262,7 +255,7 @@ app.post("/users/:username/inbox", async (c) => {
   }
   const env = getEnv(c);
   const db = createDB(env);
-  const account = await db.findAccountByUserName(username) as AccountDoc | null;
+  const account: AccountDoc | null = await db.findAccountByUserName(username);
   if (!account) return jsonResponse(c, { error: "Not found" }, 404);
   const bodyText = await c.req.text();
   const verified = await verifyHttpSignature(c.req.raw, bodyText);
@@ -296,7 +289,7 @@ app.get("/users/:username/followers", async (c) => {
   const page = c.req.query("page");
   const env = getEnv(c);
   const db = createDB(env);
-  const account = await db.findAccountByUserName(username) as AccountDoc | null;
+  const account: AccountDoc | null = await db.findAccountByUserName(username);
   if (!account) return jsonResponse(c, { error: "Not found" }, 404);
   const domain = getDomain(c);
   const list = account.followers ?? [];
@@ -354,7 +347,7 @@ app.get("/users/:username/following", async (c) => {
   const page = c.req.query("page");
   const env = getEnv(c);
   const db = createDB(env);
-  const account = await db.findAccountByUserName(username) as AccountDoc | null;
+  const account: AccountDoc | null = await db.findAccountByUserName(username);
   if (!account) return jsonResponse(c, { error: "Not found" }, 404);
   const domain = getDomain(c);
   const list = account.following ?? [];

--- a/app/api/services/user-info.ts
+++ b/app/api/services/user-info.ts
@@ -1,5 +1,6 @@
 import { createDB } from "../db.ts";
 import type { DB } from "../../shared/db.ts";
+import type { AccountDoc } from "../../shared/types.ts";
 import { resolveActor } from "../utils/activitypub.ts";
 
 function isUrl(value: string): boolean {
@@ -211,7 +212,7 @@ export async function getUserInfoBatch(
   }
 
   if (localIds.length > 0) {
-    const accounts = await db.findAccountsByUserNames(
+    const accounts: AccountDoc[] = await db.findAccountsByUserNames(
       localIds.map((l) => l.username),
     );
     const accountMap = new Map(accounts.map((acc) => [acc.userName, acc]));

--- a/app/api/utils/activitypub.ts
+++ b/app/api/utils/activitypub.ts
@@ -1,6 +1,7 @@
 import { createDB } from "../db.ts";
 import { getEnv } from "../../shared/config.ts";
 import { getSystemKey } from "../services/system_actor.ts";
+import type { AccountDoc } from "../../shared/types.ts";
 import type { Context } from "hono";
 
 function base64ToArrayBuffer(base64: string): ArrayBuffer {
@@ -142,7 +143,7 @@ export async function sendActivityPubObject(
     key = { userName: "system", privateKey: sys.privateKey };
   } else {
     const db = createDB(env);
-    const account = await db.findAccountByUserName(actor);
+    const account: AccountDoc | null = await db.findAccountByUserName(actor);
     if (!account) throw new Error("actor not found");
     key = { userName: actor, privateKey: account.privateKey };
   }

--- a/app/api/utils/deliver.ts
+++ b/app/api/utils/deliver.ts
@@ -1,5 +1,6 @@
 import { createDB } from "../db.ts";
 import { deliverActivityPubObject, fetchActorInbox } from "./activitypub.ts";
+import type { AccountDoc } from "../../shared/types.ts";
 
 export async function deliverToFollowers(
   env: Record<string, string>,
@@ -8,7 +9,7 @@ export async function deliverToFollowers(
   domain: string,
 ): Promise<void> {
   const db = createDB(env);
-  const account = await db.findAccountByUserName(user);
+  const account: AccountDoc | null = await db.findAccountByUserName(user);
   if (!account || !account.followers) return;
 
   const inboxes = await Promise.all(

--- a/app/shared/db.ts
+++ b/app/shared/db.ts
@@ -1,6 +1,7 @@
 import mongoose from "mongoose";
 import type { SortOrder } from "mongoose";
 import type { Db } from "mongodb";
+import type { AccountDoc } from "./types.ts";
 
 /** タイムライン取得用オプション */
 export interface ListOpts {
@@ -15,14 +16,14 @@ export interface DB {
   listTimeline(actor: string, opts: ListOpts): Promise<unknown[]>;
   follow(follower: string, target: string): Promise<void>;
   unfollow?(follower: string, target: string): Promise<void>;
-  listAccounts<T = unknown>(): Promise<T[]>;
-  createAccount<T = unknown>(data: Record<string, unknown>): Promise<T>;
-  findAccountById<T = unknown>(id: string): Promise<T | null>;
-  findAccountByUserName<T = unknown>(username: string): Promise<T | null>;
-  updateAccountById<T = unknown>(
+  listAccounts(): Promise<AccountDoc[]>;
+  createAccount(data: Record<string, unknown>): Promise<AccountDoc>;
+  findAccountById(id: string): Promise<AccountDoc | null>;
+  findAccountByUserName(username: string): Promise<AccountDoc | null>;
+  updateAccountById(
     id: string,
     update: Record<string, unknown>,
-  ): Promise<T | null>;
+  ): Promise<AccountDoc | null>;
   deleteAccountById(id: string): Promise<boolean>;
   addFollower(id: string, follower: string): Promise<string[]>;
   removeFollower(id: string, follower: string): Promise<string[]>;
@@ -95,12 +96,12 @@ export interface DB {
   removeRelay(relay: string): Promise<void>;
   addFollowerByName(username: string, follower: string): Promise<void>;
   removeFollowerByName(username: string, follower: string): Promise<void>;
-  searchAccounts<T = unknown>(query: RegExp, limit?: number): Promise<T[]>;
+  searchAccounts(query: RegExp, limit?: number): Promise<AccountDoc[]>;
   updateAccountByUserName(
     username: string,
     update: Record<string, unknown>,
   ): Promise<void>;
-  findAccountsByUserNames<T = unknown>(usernames: string[]): Promise<T[]>;
+  findAccountsByUserNames(usernames: string[]): Promise<AccountDoc[]>;
   countAccounts(): Promise<number>;
   createEncryptedMessage(data: {
     from: string;

--- a/app/shared/types.ts
+++ b/app/shared/types.ts
@@ -1,0 +1,10 @@
+export interface AccountDoc {
+  _id?: string;
+  userName: string;
+  displayName: string;
+  avatarInitial: string;
+  privateKey?: string;
+  publicKey: string;
+  followers?: string[];
+  following?: string[];
+}


### PR DESCRIPTION
## 概要
- アカウント関連の返値が `unknown` になる問題を解消
- `AccountDoc` インターフェースを `shared/types.ts` として追加
- `DB` インターフェースおよび実装を型定義に合わせて更新
- 関連ルートやユーティリティでの型アサーションを削除し、明示的に型を指定

## テスト
- `deno fmt`
- `deno lint`


------
https://chatgpt.com/codex/tasks/task_e_687e450d2e4483288318dbd40a60d9d4