### PR TITLE
DB 経由の操作へ移行

### DIFF
--- a/app/api/e2ee.ts
+++ b/app/api/e2ee.ts
@@ -309,11 +309,9 @@ app.post(
       { to, cc: [] },
     );
 
-    const saved = object as { toObject(): Record<string, unknown> };
-
     const privateMessage = buildActivityFromStored(
       {
-        ...saved.toObject(),
+        ...object,
         type: "PrivateMessage",
       } as {
         _id: unknown;
@@ -382,11 +380,9 @@ app.post(
       { to, cc: [] },
     );
 
-    const savedPub = object as { toObject(): Record<string, unknown> };
-
     const publicMessage = buildActivityFromStored(
       {
-        ...savedPub.toObject(),
+        ...object,
         type: "PublicMessage",
       } as {
         _id: unknown;

--- a/app/api/index.ts
+++ b/app/api/index.ts
@@ -1,13 +1,15 @@
 import { createTakosApp } from "./server.ts";
 import { connectDatabase } from "../shared/db.ts";
 import { ensureTenant } from "./services/tenant.ts";
+import { createDB } from "./db.ts";
 import { loadConfig } from "../shared/config.ts";
 
 const env = await loadConfig();
 await connectDatabase(env);
 if (env["ACTIVITYPUB_DOMAIN"]) {
   const domain = env["ACTIVITYPUB_DOMAIN"];
-  await ensureTenant(domain, domain);
+  const db = createDB(env);
+  await ensureTenant(db, domain, domain);
 }
 const app = await createTakosApp(env);
 Deno.serve(app.fetch);

--- a/app/api/relays.ts
+++ b/app/api/relays.ts
@@ -44,7 +44,7 @@ app.post(
     }
     try {
       const domain = getDomain(c);
-      await getSystemKey(domain);
+      await getSystemKey(db, domain);
       const actorId = `https://${domain}/users/system`;
       const target = "https://www.w3.org/ns/activitystreams#Public";
       const follow = createFollowActivity(domain, actorId, target);
@@ -71,7 +71,7 @@ app.delete("/relays/:id", async (c) => {
   }
   try {
     const domain = getDomain(c);
-    await getSystemKey(domain);
+    await getSystemKey(db, domain);
     const actorId = `https://${domain}/users/system`;
     const target = "https://www.w3.org/ns/activitystreams#Public";
     const undo = createUndoFollowActivity(domain, actorId, target);

--- a/app/api/routes/activitypub.ts
+++ b/app/api/routes/activitypub.ts
@@ -64,7 +64,8 @@ app.get("/.well-known/webfinger", async (c) => {
 
 app.get("/users/system", async (c) => {
   const domain = getDomain(c);
-  const { publicKey } = await getSystemKey(domain);
+  const db = createDB(getEnv(c));
+  const { publicKey } = await getSystemKey(db, domain);
   const actor = createActor(domain, {
     userName: "system",
     displayName: "system",
@@ -77,7 +78,8 @@ app.get("/users/:username", async (c) => {
   const username = c.req.param("username");
   if (username === "system") {
     const domain = getDomain(c);
-    const { publicKey } = await getSystemKey(domain);
+    const db = createDB(getEnv(c));
+    const { publicKey } = await getSystemKey(db, domain);
     const actor = createActor(domain, {
       userName: "system",
       displayName: "system",

--- a/app/api/routes/e2ee.ts
+++ b/app/api/routes/e2ee.ts
@@ -309,11 +309,11 @@ app.post(
       { to, cc: [] },
     );
 
-    const saved = object as { toObject(): Record<string, unknown> };
+    const saved = object as Record<string, unknown>;
 
     const privateMessage = buildActivityFromStored(
       {
-        ...saved.toObject(),
+        ...saved,
         type: "PrivateMessage",
       } as {
         _id: unknown;
@@ -382,11 +382,11 @@ app.post(
       { to, cc: [] },
     );
 
-    const savedPub = object as { toObject(): Record<string, unknown> };
+    const savedPub = object as Record<string, unknown>;
 
     const publicMessage = buildActivityFromStored(
       {
-        ...savedPub.toObject(),
+        ...savedPub,
         type: "PublicMessage",
       } as {
         _id: unknown;

--- a/app/api/routes/relays.ts
+++ b/app/api/routes/relays.ts
@@ -45,7 +45,8 @@ app.post(
     }
     try {
       const domain = getDomain(c);
-      await getSystemKey(domain);
+      const sysDb = createDB(env);
+      await getSystemKey(sysDb, domain);
       const actorId = `https://${domain}/users/system`;
       const target = "https://www.w3.org/ns/activitystreams#Public";
       const follow = createFollowActivity(domain, actorId, target);
@@ -71,7 +72,8 @@ app.delete("/relays/:id", async (c) => {
   }
   try {
     const domain = getDomain(c);
-    await getSystemKey(domain);
+    const sysDb = createDB(env);
+    await getSystemKey(sysDb, domain);
     const actorId = `https://${domain}/users/system`;
     const target = "https://www.w3.org/ns/activitystreams#Public";
     const undo = createUndoFollowActivity(domain, actorId, target);

--- a/app/api/routes/root_inbox.ts
+++ b/app/api/routes/root_inbox.ts
@@ -26,7 +26,7 @@ app.post("/system/inbox", async (c) => {
       stored = await db.saveObject(object);
       objectId = String((stored as { _id?: unknown })._id);
     }
-    await addInboxEntry(env["ACTIVITYPUB_DOMAIN"] ?? "", objectId);
+    await addInboxEntry(db, env["ACTIVITYPUB_DOMAIN"] ?? "", objectId);
   }
   return jsonResponse(c, { status: "ok" }, 200, "application/activity+json");
 });
@@ -81,7 +81,7 @@ app.post("/inbox", async (c) => {
               );
               objectId = String((stored as { _id?: unknown })._id);
             }
-            await addInboxEntry(env["ACTIVITYPUB_DOMAIN"] ?? "", objectId);
+            await addInboxEntry(db, env["ACTIVITYPUB_DOMAIN"] ?? "", objectId);
           }
           continue;
         }

--- a/app/api/services/fcm.ts
+++ b/app/api/services/fcm.ts
@@ -65,9 +65,7 @@ export async function sendNotification(
   const cond = env["DB_MODE"] === "host"
     ? { tenant_id: env["ACTIVITYPUB_DOMAIN"] }
     : {};
-  const list = await collection.find(cond).toArray() as Array<
-    { token: string }
-  >;
+  const list = await collection.find<{ token: string }>(cond).toArray();
   const tokens: string[] = list.map((t) => t.token);
   if (tokens.length === 0) return;
   await admin.messaging().sendEachForMulticast({

--- a/app/api/services/inbox.ts
+++ b/app/api/services/inbox.ts
@@ -1,7 +1,12 @@
-import InboxEntry from "../models/takos/inbox_entry.ts";
+import type { DB } from "../../shared/db.ts";
 
-export async function addInboxEntry(tenantId: string, objectId: string) {
-  await InboxEntry.updateOne(
+export async function addInboxEntry(
+  db: DB,
+  tenantId: string,
+  objectId: string,
+) {
+  const collection = (await db.getDatabase()).collection("inbox_entry");
+  await collection.updateOne(
     { tenant_id: tenantId, object_id: objectId },
     { $setOnInsert: { received_at: new Date() } },
     { upsert: true },

--- a/app/api/services/notification.ts
+++ b/app/api/services/notification.ts
@@ -1,4 +1,5 @@
-import Notification from "../models/takos/notification.ts";
+import { createDB } from "../db.ts";
+import type { DB } from "../../shared/db.ts";
 import { sendNotification as sendFcm } from "./fcm.ts";
 
 /**
@@ -9,12 +10,10 @@ export async function addNotification(
   message: string,
   type: string = "info",
   env: Record<string, string>,
+  dbInst?: DB,
 ) {
-  const n = new Notification({ title, message, type });
-  (n as unknown as { $locals?: { env?: Record<string, string> } }).$locals = {
-    env,
-  };
-  await n.save();
-  await sendFcm(title, message, env);
-  return n;
+  const db = dbInst ?? createDB(env);
+  await db.createNotification(title, message, type);
+  await sendFcm(title, message, env, db);
+  return true;
 }

--- a/app/api/services/ogp.ts
+++ b/app/api/services/ogp.ts
@@ -1,4 +1,4 @@
-import { DOMParser } from "https://deno.land/x/deno_dom/deno-dom-wasm.ts";
+import { DOMParser } from "https://deno.land/x/deno_dom@v0.1.53/deno-dom-wasm.ts";
 
 export interface OgpData {
   title?: string;

--- a/app/api/services/system_actor.ts
+++ b/app/api/services/system_actor.ts
@@ -1,16 +1,17 @@
-import SystemKey from "../models/takos/system_key.ts";
+import type { DB } from "../../shared/db.ts";
 import { generateKeyPair } from "../../shared/crypto.ts";
 
-export async function getSystemKey(domain: string) {
-  let doc = await SystemKey.findOne({ domain }).lean<{
+export async function getSystemKey(db: DB, domain: string) {
+  const collection = (await db.getDatabase()).collection("system_key");
+  let doc = await collection.findOne<{
     domain: string;
     privateKey: string;
     publicKey: string;
-  }>();
+  }>({ domain });
   if (!doc) {
     const keys = await generateKeyPair();
     doc = { domain, ...keys };
-    await SystemKey.create(doc);
+    await collection.insertOne(doc);
   }
   return doc;
 }

--- a/app/api/services/tenant.ts
+++ b/app/api/services/tenant.ts
@@ -1,9 +1,13 @@
-import Tenant from "../models/takos_host/tenant.ts";
+import type { DB } from "../../shared/db.ts";
 
-export async function ensureTenant(id: string, domain: string) {
-  const exists = await Tenant.findById(id).lean();
+export async function ensureTenant(
+  db: DB,
+  id: string,
+  domain: string,
+) {
+  const collection = (await db.getDatabase()).collection("tenant");
+  const exists = await collection.findOne({ _id: id });
   if (!exists) {
-    const t = new Tenant({ _id: id, domain });
-    await t.save();
+    await collection.insertOne({ _id: id, domain, created_at: new Date() });
   }
 }

--- a/app/api/services/user-info.ts
+++ b/app/api/services/user-info.ts
@@ -53,7 +53,7 @@ async function fetchExternalActorInfo(actorUrl: string, db: DB) {
           icon: data.icon || null,
           summary: data.summary || "",
         });
-        actor = await db.findRemoteActorByUrl(actorUrl);
+        actor = await db.findRemoteActorByUrl(actorUrl) as RemoteActorCache | null;
       }
     } catch {
       /* ignore */

--- a/app/api/services/user-info.ts
+++ b/app/api/services/user-info.ts
@@ -23,8 +23,18 @@ export interface UserInfoCache {
   [key: string]: UserInfo;
 }
 
+interface RemoteActorCache {
+  actorUrl?: string;
+  name?: string;
+  preferredUsername?: string;
+  icon?: unknown;
+  summary?: string;
+}
+
 async function fetchExternalActorInfo(actorUrl: string, db: DB) {
-  let actor = await db.findRemoteActorByUrl(actorUrl);
+  let actor = await db.findRemoteActorByUrl(actorUrl) as
+    | RemoteActorCache
+    | null;
   if (!actor || !(actor.name || actor.preferredUsername) || !actor.icon) {
     try {
       const res = await fetch(actorUrl, {
@@ -237,7 +247,9 @@ export async function getUserInfoBatch(
     isUrl(id) && !processedLocalIds.has(id)
   );
   if (externalUrls.length > 0) {
-    const remoteActors = await db.findRemoteActorsByUrls(externalUrls);
+    const remoteActors = await db.findRemoteActorsByUrls(
+      externalUrls,
+    ) as RemoteActorCache[];
     const actorMap = new Map(
       remoteActors.map((actor) => [actor.actorUrl, actor]),
     );

--- a/app/api/utils/activitypub.ts
+++ b/app/api/utils/activitypub.ts
@@ -138,7 +138,7 @@ export async function sendActivityPubObject(
   const body = JSON.stringify(object);
   let key: { userName: string; privateKey: string };
   if (actor === "system") {
-    const sys = await getSystemKey(domain);
+    const sys = await getSystemKey(createDB(env), domain);
     key = { userName: "system", privateKey: sys.privateKey };
   } else {
     const db = createDB(env);
@@ -732,7 +732,7 @@ export async function fetchJson<T = unknown>(
 ): Promise<T> {
   if (!signer) {
     const domain = env["ACTIVITYPUB_DOMAIN"] || "localhost";
-    const sys = await getSystemKey(domain);
+    const sys = await getSystemKey(createDB(env), domain);
     signer = {
       id: `https://${domain}/users/system`,
       privateKey: sys.privateKey,

--- a/app/shared/db.ts
+++ b/app/shared/db.ts
@@ -167,7 +167,7 @@ export interface DB {
   findSessionById(sessionId: string): Promise<SessionDoc | null>;
   deleteSessionById(sessionId: string): Promise<void>;
   updateSessionExpires(sessionId: string, expires: Date): Promise<void>;
-  getDatabase?(): Promise<Db>;
+  getDatabase(): Promise<Db>;
 }
 
 let currentUri = "";

--- a/app/takos_host/main.ts
+++ b/app/takos_host/main.ts
@@ -3,6 +3,7 @@ import { loadConfig } from "../shared/config.ts";
 import { createTakosApp } from "../api/server.ts";
 import { connectDatabase } from "../shared/db.ts";
 import { ensureTenant } from "../api/services/tenant.ts";
+import { createDB } from "../api/db.ts";
 import Instance from "../models/takos_host/instance.ts";
 import { createConsumerApp } from "./consumer.ts";
 import { createAuthApp } from "./auth.ts";
@@ -133,7 +134,8 @@ async function getAppForHost(host: string): Promise<Hono | null> {
   if (app) return app;
   const appEnv = await getEnvForHost(host);
   if (!appEnv) return null;
-  await ensureTenant(host, host);
+  const db = createDB(hostEnv);
+  await ensureTenant(db, host, host);
   app = await createTakosApp(appEnv);
   apps.set(host, app);
   return app;

--- a/app/takos_host/root_activitypub.ts
+++ b/app/takos_host/root_activitypub.ts
@@ -36,7 +36,8 @@ export function createRootActivityPubApp(env: Record<string, string>) {
 
   app.get("/users/system", async (c) => {
     const domain = getDomain(c);
-    const { publicKey } = await getSystemKey(domain);
+    const db = createDB(env);
+    const { publicKey } = await getSystemKey(db, domain);
     const actor = createActor(domain, {
       userName: "system",
       displayName: "system",

--- a/scripts/host_cli.ts
+++ b/scripts/host_cli.ts
@@ -1,13 +1,10 @@
 import { parse } from "jsr:@std/flags";
 import { loadConfig } from "../app/shared/config.ts";
 import { connectDatabase } from "../app/shared/db.ts";
-import HostUser from "../app/models/takos_host/user.ts";
-import Instance from "../app/models/takos_host/instance.ts";
-import OAuthClient from "../app/models/takos_host/oauth_client.ts";
-import Relay from "../app/models/takos/relay.ts";
 import { createDB } from "../app/api/db.ts";
 import { ensureTenant } from "../app/api/services/tenant.ts";
 import { getSystemKey } from "../app/api/services/system_actor.ts";
+import type { DB } from "../app/shared/db.ts";
 import {
   createFollowActivity,
   createUndoFollowActivity,
@@ -22,6 +19,9 @@ interface Args {
   inboxUrl?: string;
   relayId?: string;
 }
+
+let env: Record<string, string> = {};
+let db: DB;
 
 function showHelp() {
   console.log(`使用方法: deno task host [command] [options]
@@ -63,28 +63,31 @@ function parseArgsFn(): Args | null {
 }
 
 async function getUser(name: string) {
-  const user = await HostUser.findOne({ userName: name });
+  const col = (await db.getDatabase()).collection("hostusers");
+  const user = await col.findOne<{ _id: unknown }>({ userName: name });
   if (!user) throw new Error(`ユーザー ${name} が見つかりません`);
   return user;
 }
 
 async function listInstances(userName: string) {
   const user = await getUser(userName);
-  const list = await Instance.find({ owner: user._id }).lean();
+  const col = (await db.getDatabase()).collection("instances");
+  const list = await col.find({ owner: user._id }).toArray();
   for (const inst of list) {
     console.log(inst.host);
   }
 }
 
 async function createInstance(
-  env: Record<string, string>,
+  cfg: Record<string, string>,
   userName: string,
   host: string,
   pass?: string,
 ) {
   const user = await getUser(userName);
-  const rootDomain = (env["ROOT_DOMAIN"] ?? "").toLowerCase();
-  const reserved = (env["RESERVED_SUBDOMAINS"] ?? "")
+  const col = (await db.getDatabase()).collection("instances");
+  const rootDomain = (cfg["ROOT_DOMAIN"] ?? "").toLowerCase();
+  const reserved = (cfg["RESERVED_SUBDOMAINS"] ?? "")
     .split(",")
     .map((s) => s.trim().toLowerCase())
     .filter((s) => s);
@@ -109,7 +112,7 @@ async function createInstance(
     throw new Error("利用できないサブドメインです");
   }
 
-  const exists = await Instance.findOne({ host: fullHost });
+  const exists = await col.findOne({ host: fullHost });
   if (exists) throw new Error("既に存在します");
 
   const instEnv: Record<string, string> = {};
@@ -118,17 +121,20 @@ async function createInstance(
     const redirect = `https://${fullHost}`;
     const clientId = redirect;
     let clientSecret: string;
-    const existsCli = await OAuthClient.findOne({ clientId });
+    const cliCol = (await db.getDatabase()).collection("oauthclients");
+    const existsCli = await cliCol.findOne<{ clientSecret: string }>({
+      clientId,
+    });
     if (existsCli) {
       clientSecret = existsCli.clientSecret;
     } else {
       clientSecret = crypto.randomUUID();
-      const cli = new OAuthClient({
+      await cliCol.insertOne({
         clientId,
         clientSecret,
         redirectUri: redirect,
+        createdAt: new Date(),
       });
-      await cli.save();
     }
     instEnv.OAUTH_CLIENT_ID = clientId;
     instEnv.OAUTH_CLIENT_SECRET = clientSecret;
@@ -139,61 +145,70 @@ async function createInstance(
     instEnv.hashedPassword = hashed;
     instEnv.salt = salt;
   }
-  const inst = new Instance({ host: fullHost, owner: user._id, env: instEnv });
-  await inst.save();
-  await ensureTenant(fullHost, fullHost);
+  await col.insertOne({
+    host: fullHost,
+    owner: user._id,
+    env: instEnv,
+    createdAt: new Date(),
+  });
+  await ensureTenant(db, fullHost, fullHost);
   if (rootDomain) {
-    const db = createDB({
-      ...env,
+    const relayDb = createDB({
+      ...cfg,
       ACTIVITYPUB_DOMAIN: fullHost,
       DB_MODE: "host",
     });
-    await db.addRelay(rootDomain, "pull");
-    await db.addRelay(rootDomain, "push");
+    await relayDb.addRelay(rootDomain, "pull");
+    await relayDb.addRelay(rootDomain, "push");
   }
   console.log(`作成しました: ${fullHost}`);
 }
 
 async function deleteInstance(userName: string, host: string) {
   const user = await getUser(userName);
-  await Instance.deleteOne({ host: host.toLowerCase(), owner: user._id });
+  const col = (await db.getDatabase()).collection("instances");
+  await col.deleteOne({ host: host.toLowerCase(), owner: user._id });
   console.log("削除しました");
 }
 
 async function setPassword(userName: string, host: string, pass?: string) {
   const user = await getUser(userName);
-  const inst = await Instance.findOne({
-    host: host.toLowerCase(),
-    owner: user._id,
-  });
+  const col = (await db.getDatabase()).collection("instances");
+  const inst = await col.findOne<
+    { _id: unknown; env?: Record<string, string> }
+  >(
+    { host: host.toLowerCase(), owner: user._id },
+  );
   if (!inst) throw new Error("インスタンスが見つかりません");
   if (pass) {
     const salt = crypto.randomUUID();
     const hashed = await hash(pass);
-    inst.env = { ...(inst.env ?? {}), hashedPassword: hashed, salt };
+    const newEnv = { ...(inst.env ?? {}), hashedPassword: hashed, salt };
+    await col.updateOne({ _id: inst._id }, { $set: { env: newEnv } });
   } else if (inst.env) {
-    delete inst.env.hashedPassword;
-    delete inst.env.salt;
+    const newEnv = { ...inst.env };
+    delete newEnv.hashedPassword;
+    delete newEnv.salt;
+    await col.updateOne({ _id: inst._id }, { $set: { env: newEnv } });
   }
-  await inst.save();
   console.log("更新しました");
 }
 
 async function listRelays() {
-  const list = await Relay.find().lean<{
+  const col = (await db.getDatabase()).collection("relays");
+  const list = await col.find().toArray() as Array<{
     _id: unknown;
     host: string;
     inboxUrl: string;
-  }[]>();
+  }>;
   for (const r of list) console.log(`${r._id} ${r.host} ${r.inboxUrl}`);
 }
 
 async function addRelay(env: Record<string, string>, inboxUrl: string) {
   const relayHost = new URL(inboxUrl).hostname;
-  const exists = await Relay.findOne({ host: relayHost });
+  const exists = await db.findRelayByHost(relayHost);
   if (exists) throw new Error("既に存在します");
-  const relay = new Relay({ host: relayHost, inboxUrl });
-  await relay.save();
+  const relay = await db.createRelay({ host: relayHost, inboxUrl });
   const rootDomain = env["ROOT_DOMAIN"];
   if (rootDomain) {
     try {
@@ -208,7 +223,7 @@ async function addRelay(env: Record<string, string>, inboxUrl: string) {
       /* ignore */
     }
     try {
-      await getSystemKey(rootDomain);
+      await getSystemKey(db, rootDomain);
       const actor = `https://${rootDomain}/users/system`;
       const follow = createFollowActivity(
         rootDomain,
@@ -220,11 +235,11 @@ async function addRelay(env: Record<string, string>, inboxUrl: string) {
       console.error("Failed to follow relay:", err);
     }
   }
-  console.log(`追加しました: ${relay.id}`);
+  console.log(`追加しました: ${relay._id}`);
 }
 
 async function deleteRelay(env: Record<string, string>, id: string) {
-  const relay = await Relay.findByIdAndDelete(id);
+  const relay = await db.deleteRelayById(id);
   if (!relay) throw new Error("リレーが見つかりません");
   const rootDomain = env["ROOT_DOMAIN"];
   if (rootDomain) {
@@ -240,7 +255,7 @@ async function deleteRelay(env: Record<string, string>, id: string) {
       /* ignore */
     }
     try {
-      await getSystemKey(rootDomain);
+      await getSystemKey(db, rootDomain);
       const actor = `https://${rootDomain}/users/system`;
       const undo = createUndoFollowActivity(
         rootDomain,
@@ -264,9 +279,10 @@ async function deleteRelay(env: Record<string, string>, id: string) {
 async function main() {
   const args = parseArgsFn();
   if (!args) return;
-  const env = await loadConfig();
+  env = await loadConfig();
   env["DB_MODE"] = "host";
   await connectDatabase(env);
+  db = createDB(env);
   const user = args.user ?? "system";
   try {
     switch (args.command) {


### PR DESCRIPTION
## Summary
- サービス層とホスト用 CLI から Mongoose モデルの直接利用を排除
- DB インスタンスから MongoDB を操作するよう変更
- テナントやシステム鍵取得など既存処理を DB 経由に修正

## Testing
- `deno fmt`
- `deno lint`


------
https://chatgpt.com/codex/tasks/task_e_687f35c8ed288328894ad4c9b2c5272d