### PR TITLE
Add R2 storage support

### DIFF
--- a/app/api/.env.example
+++ b/app/api/.env.example
@@ -18,6 +18,11 @@ OBJECT_STORAGE_PROVIDER=local
 LOCAL_STORAGE_DIR=uploads
 # GridFS を使用する場合の設定
 GRIDFS_BUCKET=uploads
+# R2 を使用する場合の設定
+R2_BUCKET=
+R2_ACCOUNT_ID=
+R2_ACCESS_KEY_ID=
+R2_SECRET_ACCESS_KEY=
 # FCM 用サービスアカウント
 
 FIREBASE_CLIENT_EMAIL=firebase-adminsdk-xxxx@your-project-id.iam.gserviceaccount.com

--- a/app/api/deno.json
+++ b/app/api/deno.json
@@ -9,7 +9,8 @@
     "zod": "npm:zod@^3.25.56",
     "mongodb": "npm:mongodb@^6.17.0",
     "firebase-admin": "npm:firebase-admin@^13",
-    "bcrypt": "https://deno.land/x/bcrypt@v0.4.1/mod.ts"
+    "bcrypt": "https://deno.land/x/bcrypt@v0.4.1/mod.ts",
+    "@cloudflare/workers-types": "npm:@cloudflare/workers-types@^4"
   },
   "tasks": {
     "dev": "deno run -A --unstable-worker-options --watch --no-prompt index.ts"


### PR DESCRIPTION
## Summary
- add `R2Storage` class using `R2Bucket`
- extend `createStorage` to handle `OBJECT_STORAGE_PROVIDER=r2`
- add R2 bucket settings to example env
- register `@cloudflare/workers-types` in imports

## Testing
- `deno fmt **/*.ts *.json .env.example`
- `deno lint **/*.ts`

------
https://chatgpt.com/codex/tasks/task_e_687f4c6c88f88328b15303c96b2af86a