### PR TITLE
takos host 用モデルの導入とMongoDBHost修正

### DIFF
--- a/app/api/DB/mongodb_host.ts
+++ b/app/api/DB/mongodb_host.ts
@@ -2,15 +2,15 @@ import HostObjectStore from "../../models/takos_host/object_store.ts";
 import HostFollowEdge from "../../models/takos_host/follow_edge.ts";
 import HostRelayEdge from "../../models/takos_host/relay_edge.ts";
 import { createObjectId } from "../utils/activitypub.ts";
-import Account from "../../models/takos/account.ts";
-import EncryptedKeyPair from "../../models/takos/encrypted_keypair.ts";
-import EncryptedMessage from "../../models/takos/encrypted_message.ts";
-import KeyPackage from "../../models/takos/key_package.ts";
-import Notification from "../../models/takos/notification.ts";
-import PublicMessage from "../../models/takos/public_message.ts";
-import Relay from "../../models/takos/relay.ts";
-import RemoteActor from "../../models/takos/remote_actor.ts";
-import Session from "../../models/takos/session.ts";
+import Account from "../../models/takos_host/account.ts";
+import EncryptedKeyPair from "../../models/takos_host/encrypted_keypair.ts";
+import EncryptedMessage from "../../models/takos_host/encrypted_message.ts";
+import KeyPackage from "../../models/takos_host/key_package.ts";
+import Notification from "../../models/takos_host/notification.ts";
+import PublicMessage from "../../models/takos_host/public_message.ts";
+import Relay from "../../models/takos_host/relay.ts";
+import RemoteActor from "../../models/takos_host/remote_actor.ts";
+import HostSession from "../../models/takos_host/session.ts";
 import mongoose from "mongoose";
 import type { DB, ListOpts } from "../../shared/db.ts";
 import type { AccountDoc, RelayDoc, SessionDoc } from "../../shared/types.ts";
@@ -657,7 +657,7 @@ export class MongoDBHost implements DB {
     expiresAt: Date,
     tenantId: string,
   ): Promise<SessionDoc> {
-    const doc = new Session({
+    const doc = new HostSession({
       sessionId,
       expiresAt,
       tenant_id: tenantId,
@@ -671,15 +671,15 @@ export class MongoDBHost implements DB {
   }
 
   async findSessionById(sessionId: string): Promise<SessionDoc | null> {
-    return await Session.findOne({ sessionId }).lean<SessionDoc | null>();
+    return await HostSession.findOne({ sessionId }).lean<SessionDoc | null>();
   }
 
   async deleteSessionById(sessionId: string) {
-    await Session.deleteOne({ sessionId });
+    await HostSession.deleteOne({ sessionId });
   }
 
   async updateSessionExpires(sessionId: string, expires: Date) {
-    await Session.updateOne({ sessionId }, { expiresAt: expires });
+    await HostSession.updateOne({ sessionId }, { expiresAt: expires });
   }
 
   async getDatabase() {

--- a/app/models/takos_host/account.ts
+++ b/app/models/takos_host/account.ts
@@ -1,0 +1,20 @@
+import mongoose from "mongoose";
+
+const accountSchema = new mongoose.Schema({
+  userName: { type: String, required: true },
+  displayName: { type: String, default: "" },
+  avatarInitial: { type: String, default: "" },
+  privateKey: { type: String, default: "" },
+  publicKey: { type: String, default: "" },
+  followers: { type: [String], default: [] },
+  following: { type: [String], default: [] },
+  tenant_id: { type: String, index: true },
+});
+
+accountSchema.index({ userName: 1, tenant_id: 1 }, { unique: true });
+
+const Account = mongoose.models.Account ??
+  mongoose.model("Account", accountSchema);
+
+export default Account;
+export { accountSchema };

--- a/app/models/takos_host/encrypted_keypair.ts
+++ b/app/models/takos_host/encrypted_keypair.ts
@@ -1,0 +1,16 @@
+import mongoose from "mongoose";
+
+const encryptedKeyPairSchema = new mongoose.Schema({
+  userName: { type: String, required: true },
+  content: { type: String, required: true },
+  tenant_id: { type: String, index: true },
+  createdAt: { type: Date, default: Date.now },
+});
+
+encryptedKeyPairSchema.index({ userName: 1, tenant_id: 1 }, { unique: true });
+
+const EncryptedKeyPair = mongoose.models.EncryptedKeyPair ??
+  mongoose.model("EncryptedKeyPair", encryptedKeyPairSchema);
+
+export default EncryptedKeyPair;
+export { encryptedKeyPairSchema };

--- a/app/models/takos_host/encrypted_message.ts
+++ b/app/models/takos_host/encrypted_message.ts
@@ -1,0 +1,17 @@
+import mongoose from "mongoose";
+
+const encryptedMessageSchema = new mongoose.Schema({
+  from: { type: String, required: true },
+  to: { type: [String], required: true },
+  content: { type: String, required: true },
+  mediaType: { type: String, default: "message/mls" },
+  encoding: { type: String, default: "base64" },
+  tenant_id: { type: String, index: true },
+  createdAt: { type: Date, default: Date.now },
+});
+
+const EncryptedMessage = mongoose.models.EncryptedMessage ??
+  mongoose.model("EncryptedMessage", encryptedMessageSchema);
+
+export default EncryptedMessage;
+export { encryptedMessageSchema };

--- a/app/models/takos_host/key_package.ts
+++ b/app/models/takos_host/key_package.ts
@@ -1,0 +1,18 @@
+import mongoose from "mongoose";
+
+const keyPackageSchema = new mongoose.Schema({
+  userName: { type: String, required: true, index: true },
+  content: { type: String, required: true },
+  mediaType: { type: String, default: "message/mls" },
+  encoding: { type: String, default: "base64" },
+  tenant_id: { type: String, index: true },
+  createdAt: { type: Date, default: Date.now },
+});
+
+keyPackageSchema.index({ userName: 1, tenant_id: 1 });
+
+const KeyPackage = mongoose.models.KeyPackage ??
+  mongoose.model("KeyPackage", keyPackageSchema);
+
+export default KeyPackage;
+export { keyPackageSchema };

--- a/app/models/takos_host/notification.ts
+++ b/app/models/takos_host/notification.ts
@@ -1,0 +1,16 @@
+import mongoose from "mongoose";
+
+const notificationSchema = new mongoose.Schema({
+  title: { type: String, required: true },
+  message: { type: String, required: true },
+  type: { type: String, default: "info" },
+  read: { type: Boolean, default: false },
+  tenant_id: { type: String, index: true },
+  createdAt: { type: Date, default: Date.now },
+});
+
+const Notification = mongoose.models.Notification ??
+  mongoose.model("Notification", notificationSchema);
+
+export default Notification;
+export { notificationSchema };

--- a/app/models/takos_host/public_message.ts
+++ b/app/models/takos_host/public_message.ts
@@ -1,0 +1,17 @@
+import mongoose from "mongoose";
+
+const publicMessageSchema = new mongoose.Schema({
+  from: { type: String, required: true },
+  to: { type: [String], required: true },
+  content: { type: String, required: true },
+  mediaType: { type: String, default: "message/mls" },
+  encoding: { type: String, default: "base64" },
+  tenant_id: { type: String, index: true },
+  createdAt: { type: Date, default: Date.now },
+});
+
+const PublicMessage = mongoose.models.PublicMessage ??
+  mongoose.model("PublicMessage", publicMessageSchema);
+
+export default PublicMessage;
+export { publicMessageSchema };

--- a/app/models/takos_host/relay.ts
+++ b/app/models/takos_host/relay.ts
@@ -1,0 +1,14 @@
+import mongoose from "mongoose";
+
+const relaySchema = new mongoose.Schema({
+  host: { type: String, required: true },
+  inboxUrl: { type: String, required: true },
+  tenant_id: { type: String, index: true },
+});
+
+relaySchema.index({ host: 1, tenant_id: 1 }, { unique: true });
+
+const Relay = mongoose.models.Relay ?? mongoose.model("Relay", relaySchema);
+
+export default Relay;
+export { relaySchema };

--- a/app/models/takos_host/remote_actor.ts
+++ b/app/models/takos_host/remote_actor.ts
@@ -1,0 +1,20 @@
+import mongoose from "mongoose";
+
+const remoteActorSchema = new mongoose.Schema({
+  actorUrl: { type: String, required: true },
+  name: { type: String, default: "" },
+  preferredUsername: { type: String, default: "" },
+  icon: { type: mongoose.Schema.Types.Mixed, default: null },
+  summary: { type: String, default: "" },
+  tenant_id: { type: String, index: true },
+  cachedAt: { type: Date, default: Date.now },
+});
+
+remoteActorSchema.index({ actorUrl: 1, tenant_id: 1 }, { unique: true });
+remoteActorSchema.index({ cachedAt: 1 }, { expireAfterSeconds: 60 * 60 * 24 });
+
+const RemoteActor = mongoose.models.RemoteActor ??
+  mongoose.model("RemoteActor", remoteActorSchema);
+
+export default RemoteActor;
+export { remoteActorSchema };


### PR DESCRIPTION
## 概要
`mongodb_host.ts` で takos 側のモデルを参照していた箇所をすべて takos host 専用モデルに置き換えました。これに伴い、host 用の各モデルを新規追加しています。

## 変更点
- `mongodb_host.ts` のインポートを takos host 用モデルへ変更
- `account` など計 8 つの host 専用モデルを追加

## テスト
- `deno fmt app/api/DB/mongodb_host.ts app/models/takos_host/*.ts`
- `deno lint app/api/DB/mongodb_host.ts app/models/takos_host/*.ts`


------
https://chatgpt.com/codex/tasks/task_e_687f7b7b57188328bb8b919f31318c73