### PR TITLE
Use WebSocket for chat updates

### DIFF
--- a/app/api/routes/e2ee.ts
+++ b/app/api/routes/e2ee.ts
@@ -16,6 +16,7 @@ import {
   resolveActor,
 } from "../utils/activitypub.ts";
 import { deliverToFollowers } from "../utils/deliver.ts";
+import { sendToUser } from "./ws.ts";
 
 interface ActivityPubActivity {
   [key: string]: unknown;
@@ -349,6 +350,20 @@ app.post(
       },
     );
 
+    const newMsg = {
+      id: String(msg._id),
+      from: acct,
+      to,
+      content,
+      mediaType: msg.mediaType,
+      encoding: msg.encoding,
+      createdAt: msg.createdAt,
+    };
+    sendToUser(acct, { type: "encryptedMessage", payload: newMsg });
+    for (const t of to) {
+      sendToUser(t, { type: "encryptedMessage", payload: newMsg });
+    }
+
     return c.json({ result: "sent", id: String(msg._id) });
   },
 );
@@ -424,6 +439,20 @@ app.post(
         console.error("deliver failed", err);
       },
     );
+
+    const newMsg = {
+      id: String(msg._id),
+      from: acct,
+      to,
+      content,
+      mediaType: msg.mediaType,
+      encoding: msg.encoding,
+      createdAt: msg.createdAt,
+    };
+    sendToUser(acct, { type: "publicMessage", payload: newMsg });
+    for (const t of to) {
+      sendToUser(t, { type: "publicMessage", payload: newMsg });
+    }
 
     return c.json({ result: "sent", id: String(msg._id) });
   },


### PR DESCRIPTION
## Summary
- update `/api/ws` to manage user connections and allow sending data to specific users
- notify chat recipients of new messages over WebSocket
- modify chat component to receive updates via WebSocket and drop polling

## Testing
- `deno fmt`
- `deno lint`


------
https://chatgpt.com/codex/tasks/task_e_6880a95bfe4c832890a2bcad354333bc