### PR TITLE
API のサービス層から MongoDB 直呼び出しを削除

### DIFF
--- a/app/api/DB/host.ts
+++ b/app/api/DB/host.ts
@@ -54,7 +54,8 @@ export class MongoDBHost implements DB {
   ) {
     const conds: Record<string, unknown>[] = [];
     if (await this.useLocalObjects()) {
-      conds.push({ ...filter, tenant_id: this.tenantId });
+      // takos host 本体のオブジェクトを参照
+      conds.push({ ...filter, tenant_id: this.rootDomain });
     }
     const ids = await InboxEntry.find({ tenant_id: this.tenantId }).distinct<
       string

--- a/app/api/DB/host.ts
+++ b/app/api/DB/host.ts
@@ -35,7 +35,7 @@ export class MongoDBHost implements DB {
   }
 
   private get rootDomain() {
-    return this.env["ROOT_DOMAIN"] ?? "";
+    return this.env["ACTIVITYPUB_DOMAIN"] ?? "";
   }
 
   private async useLocalObjects() {

--- a/app/api/DB/host.ts
+++ b/app/api/DB/host.ts
@@ -719,11 +719,13 @@ export class MongoDBHost implements DB {
 
   async listFcmTokens() {
     if (this.env["DB_MODE"] === "host") {
-      return await HostFcmToken.find<{ token: string }>(
+      const docs = await HostFcmToken.find<{ token: string }>(
         { tenant_id: this.env["ACTIVITYPUB_DOMAIN"] },
       ).lean();
+      return docs.map((d) => ({ token: d.token }));
     } else {
-      return await FcmToken.find<{ token: string }>({}).lean();
+      const docs = await FcmToken.find<{ token: string }>({}).lean();
+      return docs.map((d) => ({ token: d.token }));
     }
   }
 

--- a/app/api/DB/host.ts
+++ b/app/api/DB/host.ts
@@ -16,6 +16,9 @@ import HostSession from "../models/takos_host/session.ts";
 import HostFcmToken from "../models/takos_host/fcm_token.ts";
 import FcmToken from "../models/takos/fcm_token.ts";
 import Tenant from "../models/takos/tenant.ts";
+import Instance from "../../takos_host/models/instance.ts";
+import OAuthClient from "../../takos_host/models/oauth_client.ts";
+import HostDomain from "../../takos_host/models/domain.ts";
 import mongoose from "mongoose";
 import type { DB, ListOpts } from "../../shared/db.ts";
 import type { AccountDoc, RelayDoc, SessionDoc } from "../../shared/types.ts";
@@ -722,6 +725,124 @@ export class MongoDBHost implements DB {
     } else {
       return await FcmToken.find<{ token: string }>({}).lean();
     }
+  }
+
+  async listInstances(owner: string) {
+    const docs = await Instance.find({ owner }).lean<{ host: string }[]>();
+    return docs.map((d) => ({ host: d.host }));
+  }
+
+  async countInstances(owner: string) {
+    return await Instance.countDocuments({ owner });
+  }
+
+  async findInstanceByHost(host: string) {
+    const doc = await Instance.findOne({ host }).lean<
+      {
+        _id: mongoose.Types.ObjectId;
+        host: string;
+        owner: mongoose.Types.ObjectId;
+        env?: Record<string, string>;
+      } | null
+    >();
+    return doc
+      ? {
+        _id: String(doc._id),
+        host: doc.host,
+        owner: String(doc.owner),
+        env: doc.env,
+      }
+      : null;
+  }
+
+  async findInstanceByHostAndOwner(host: string, owner: string) {
+    const doc = await Instance.findOne({ host, owner }).lean<
+      {
+        _id: mongoose.Types.ObjectId;
+        host: string;
+        env?: Record<string, string>;
+      } | null
+    >();
+    return doc ? { _id: String(doc._id), host: doc.host, env: doc.env } : null;
+  }
+
+  async createInstance(
+    data: { host: string; owner: string; env?: Record<string, string> },
+  ) {
+    await Instance.create({
+      host: data.host,
+      owner: data.owner,
+      env: data.env ?? {},
+      createdAt: new Date(),
+    });
+  }
+
+  async updateInstanceEnv(id: string, env: Record<string, string>) {
+    await Instance.updateOne({ _id: id }, { $set: { env } });
+  }
+
+  async deleteInstance(host: string, owner: string) {
+    await Instance.deleteOne({ host, owner });
+  }
+
+  async listOAuthClients() {
+    const docs = await OAuthClient.find({}).lean<
+      { clientId: string; redirectUri: string }[]
+    >();
+    return docs.map((d) => ({
+      clientId: d.clientId,
+      redirectUri: d.redirectUri,
+    }));
+  }
+
+  async findOAuthClient(clientId: string) {
+    const doc = await OAuthClient.findOne({ clientId }).lean<
+      { clientSecret: string } | null
+    >();
+    return doc ? { clientSecret: doc.clientSecret } : null;
+  }
+
+  async createOAuthClient(
+    data: { clientId: string; clientSecret: string; redirectUri: string },
+  ) {
+    await OAuthClient.create({
+      clientId: data.clientId,
+      clientSecret: data.clientSecret,
+      redirectUri: data.redirectUri,
+      createdAt: new Date(),
+    });
+  }
+
+  async listHostDomains(user: string) {
+    const docs = await HostDomain.find({ user }).lean<
+      { domain: string; verified: boolean }[]
+    >();
+    return docs.map((d) => ({ domain: d.domain, verified: d.verified }));
+  }
+
+  async findHostDomain(domain: string, user?: string) {
+    const cond: Record<string, unknown> = { domain };
+    if (user) cond.user = user;
+    const doc = await HostDomain.findOne(cond).lean<
+      { _id: mongoose.Types.ObjectId; token: string; verified: boolean } | null
+    >();
+    return doc
+      ? { _id: String(doc._id), token: doc.token, verified: doc.verified }
+      : null;
+  }
+
+  async createHostDomain(domain: string, user: string, token: string) {
+    await HostDomain.create({
+      domain,
+      user,
+      token,
+      verified: false,
+      createdAt: new Date(),
+    });
+  }
+
+  async verifyHostDomain(id: string) {
+    await HostDomain.updateOne({ _id: id }, { $set: { verified: true } });
   }
 
   async ensureTenant(id: string, domain: string) {

--- a/app/api/DB/local.ts
+++ b/app/api/DB/local.ts
@@ -625,6 +625,7 @@ export class MongoDBLocal implements DB {
   }
 
   async addInboxEntry(tenantId: string, objectId: string): Promise<void> {
+    if (this.env["DB_MODE"] !== "host") return;
     await InboxEntry.updateOne(
       { tenant_id: tenantId, object_id: objectId },
       { $setOnInsert: { received_at: new Date() } },

--- a/app/api/DB/local.ts
+++ b/app/api/DB/local.ts
@@ -16,6 +16,9 @@ import SystemKey from "../models/takos/system_key.ts";
 import Relay from "../models/takos/relay.ts";
 import RemoteActor from "../models/takos/remote_actor.ts";
 import Session from "../models/takos/session.ts";
+import FcmToken from "../models/takos/fcm_token.ts";
+import HostFcmToken from "../models/takos_host/fcm_token.ts";
+import Tenant from "../models/takos/tenant.ts";
 import mongoose from "mongoose";
 import type { DB, ListOpts } from "../../shared/db.ts";
 import type { AccountDoc, RelayDoc, SessionDoc } from "../../shared/types.ts";
@@ -641,36 +644,47 @@ export class MongoDBLocal implements DB {
   }
 
   async registerFcmToken(token: string, userName: string) {
-    const collection = (await this.getDatabase()).collection("fcmtokens");
-    const cond = this.env["DB_MODE"] === "host"
-      ? { token, tenant_id: this.env["ACTIVITYPUB_DOMAIN"] }
-      : { token };
-    await collection.updateOne(cond, { $set: { token, userName } }, {
-      upsert: true,
-    });
+    if (this.env["DB_MODE"] === "host") {
+      await HostFcmToken.updateOne(
+        {
+          token,
+          tenant_id: this.env["ACTIVITYPUB_DOMAIN"],
+        },
+        { $set: { token, userName } },
+        { upsert: true },
+      );
+    } else {
+      await FcmToken.updateOne({ token }, { $set: { token, userName } }, {
+        upsert: true,
+      });
+    }
   }
 
   async unregisterFcmToken(token: string) {
-    const collection = (await this.getDatabase()).collection("fcmtokens");
-    const cond = this.env["DB_MODE"] === "host"
-      ? { token, tenant_id: this.env["ACTIVITYPUB_DOMAIN"] }
-      : { token };
-    await collection.deleteOne(cond);
+    if (this.env["DB_MODE"] === "host") {
+      await HostFcmToken.deleteOne({
+        token,
+        tenant_id: this.env["ACTIVITYPUB_DOMAIN"],
+      });
+    } else {
+      await FcmToken.deleteOne({ token });
+    }
   }
 
   async listFcmTokens() {
-    const collection = (await this.getDatabase()).collection("fcmtokens");
-    const cond = this.env["DB_MODE"] === "host"
-      ? { tenant_id: this.env["ACTIVITYPUB_DOMAIN"] }
-      : {};
-    return await collection.find<{ token: string }>(cond).toArray();
+    if (this.env["DB_MODE"] === "host") {
+      return await HostFcmToken.find<{ token: string }>(
+        { tenant_id: this.env["ACTIVITYPUB_DOMAIN"] },
+      ).lean();
+    } else {
+      return await FcmToken.find<{ token: string }>({}).lean();
+    }
   }
 
   async ensureTenant(id: string, domain: string) {
-    const collection = (await this.getDatabase()).collection("tenant");
-    const exists = await collection.findOne({ _id: id });
+    const exists = await Tenant.findOne({ _id: id }).lean();
     if (!exists) {
-      await collection.insertOne({ _id: id, domain, created_at: new Date() });
+      await Tenant.create({ _id: id, domain, created_at: new Date() });
     }
   }
 

--- a/app/api/DB/local.ts
+++ b/app/api/DB/local.ts
@@ -676,11 +676,13 @@ export class MongoDBLocal implements DB {
 
   async listFcmTokens() {
     if (this.env["DB_MODE"] === "host") {
-      return await HostFcmToken.find<{ token: string }>(
+      const docs = await HostFcmToken.find<{ token: string }>(
         { tenant_id: this.env["ACTIVITYPUB_DOMAIN"] },
       ).lean();
+      return docs.map((d) => ({ token: d.token }));
     } else {
-      return await FcmToken.find<{ token: string }>({}).lean();
+      const docs = await FcmToken.find<{ token: string }>({}).lean();
+      return docs.map((d) => ({ token: d.token }));
     }
   }
 

--- a/app/api/deno.lock
+++ b/app/api/deno.lock
@@ -6,6 +6,7 @@
     "jsr:@std/internal@^1.0.9": "1.0.9",
     "jsr:@std/path@^1.1.0": "1.1.1",
     "jsr:@std/path@^1.1.1": "1.1.1",
+    "npm:@cloudflare/workers-types@4": "4.20250313.0",
     "npm:@hono/zod-validator@0.7": "0.7.1_hono@4.8.5_zod@3.25.76",
     "npm:@types/node@*": "22.15.15",
     "npm:hono@^4.7.11": "4.8.5",
@@ -35,6 +36,9 @@
     }
   },
   "npm": {
+    "@cloudflare/workers-types@4.20250313.0": {
+      "integrity": "sha512-iqyzZwogC+3yL8h58vMhjYQUHUZA8XazE3Q+ofR59wDOnsPe/u9W6+aCl408N0iNBhMPvpJQQ3/lkz0iJN2fhA=="
+    },
     "@fastify/busboy@3.1.1": {
       "integrity": "sha512-5DGmA8FTdB2XbDeEwc/5ZXBl6UbBAyBOOLlPuBnZ/N1SwdH9Ii+cOX3tBROlDgcTXxjOYnLMVoKk9+FXAw0CJw=="
     },
@@ -1064,6 +1068,7 @@
       "jsr:@std/dotenv@~0.225.5",
       "jsr:@std/fs@^1.0.18",
       "jsr:@std/path@^1.1.0",
+      "npm:@cloudflare/workers-types@4",
       "npm:@hono/zod-validator@0.7",
       "npm:hono@^4.7.11",
       "npm:mongodb@^6.17.0",

--- a/app/api/models/takos/tenant.ts
+++ b/app/api/models/takos/tenant.ts
@@ -6,8 +6,6 @@ const tenantSchema = new mongoose.Schema({
   created_at: { type: Date, default: Date.now },
 });
 
-tenantSchema.index({ _id: 1 }, { unique: true });
-
 const Tenant = mongoose.models.Tenant ??
   mongoose.model("Tenant", tenantSchema);
 

--- a/app/api/models/takos/tenant.ts
+++ b/app/api/models/takos/tenant.ts
@@ -1,0 +1,15 @@
+import mongoose from "mongoose";
+
+const tenantSchema = new mongoose.Schema({
+  _id: { type: String, required: true },
+  domain: { type: String, required: true },
+  created_at: { type: Date, default: Date.now },
+});
+
+tenantSchema.index({ _id: 1 }, { unique: true });
+
+const Tenant = mongoose.models.Tenant ??
+  mongoose.model("Tenant", tenantSchema);
+
+export default Tenant;
+export { tenantSchema };

--- a/app/api/models/takos_host/fcm_token.ts
+++ b/app/api/models/takos_host/fcm_token.ts
@@ -1,0 +1,15 @@
+import mongoose from "mongoose";
+
+const hostFcmTokenSchema = new mongoose.Schema({
+  token: { type: String, required: true },
+  userName: { type: String, default: "" },
+  tenant_id: { type: String, index: true },
+});
+
+hostFcmTokenSchema.index({ token: 1, tenant_id: 1 }, { unique: true });
+
+const HostFcmToken = mongoose.models.HostFcmToken ??
+  mongoose.model("HostFcmToken", hostFcmTokenSchema);
+
+export default HostFcmToken;
+export { hostFcmTokenSchema };

--- a/app/api/routes/root_inbox.ts
+++ b/app/api/routes/root_inbox.ts
@@ -26,7 +26,9 @@ app.post("/system/inbox", async (c) => {
       stored = await db.saveObject(object);
       objectId = String((stored as { _id?: unknown })._id);
     }
-    await addInboxEntry(db, env["ACTIVITYPUB_DOMAIN"] ?? "", objectId);
+    if (env["DB_MODE"] === "host") {
+      await addInboxEntry(db, env["ACTIVITYPUB_DOMAIN"] ?? "", objectId);
+    }
   }
   return jsonResponse(c, { status: "ok" }, 200, "application/activity+json");
 });
@@ -81,7 +83,13 @@ app.post("/inbox", async (c) => {
               );
               objectId = String((stored as { _id?: unknown })._id);
             }
-            await addInboxEntry(db, env["ACTIVITYPUB_DOMAIN"] ?? "", objectId);
+            if (env["DB_MODE"] === "host") {
+              await addInboxEntry(
+                db,
+                env["ACTIVITYPUB_DOMAIN"] ?? "",
+                objectId,
+              );
+            }
           }
           continue;
         }

--- a/app/api/services/fcm.ts
+++ b/app/api/services/fcm.ts
@@ -79,7 +79,11 @@ async function getAccessToken(
     console.error("Failed to get FCM token", await res.text());
     return null;
   }
-  const json = await res.json();
+  interface TokenApiResponse {
+    access_token: string;
+    expires_in: number;
+  }
+  const json = await res.json() as TokenApiResponse;
   cache = { token: json.access_token, exp: now + json.expires_in };
   return cache.token;
 }

--- a/app/api/services/inbox.ts
+++ b/app/api/services/inbox.ts
@@ -5,10 +5,5 @@ export async function addInboxEntry(
   tenantId: string,
   objectId: string,
 ) {
-  const collection = (await db.getDatabase()).collection("inbox_entry");
-  await collection.updateOne(
-    { tenant_id: tenantId, object_id: objectId },
-    { $setOnInsert: { received_at: new Date() } },
-    { upsert: true },
-  );
+  await db.addInboxEntry(tenantId, objectId);
 }

--- a/app/api/services/system_actor.ts
+++ b/app/api/services/system_actor.ts
@@ -2,16 +2,11 @@ import type { DB } from "../../shared/db.ts";
 import { generateKeyPair } from "../../shared/crypto.ts";
 
 export async function getSystemKey(db: DB, domain: string) {
-  const collection = (await db.getDatabase()).collection("system_key");
-  let doc = await collection.findOne<{
-    domain: string;
-    privateKey: string;
-    publicKey: string;
-  }>({ domain });
+  let doc = await db.findSystemKey(domain);
   if (!doc) {
     const keys = await generateKeyPair();
+    await db.saveSystemKey(domain, keys.privateKey, keys.publicKey);
     doc = { domain, ...keys };
-    await collection.insertOne(doc);
   }
   return doc;
 }

--- a/app/api/services/tenant.ts
+++ b/app/api/services/tenant.ts
@@ -5,9 +5,5 @@ export async function ensureTenant(
   id: string,
   domain: string,
 ) {
-  const collection = (await db.getDatabase()).collection("tenant");
-  const exists = await collection.findOne({ _id: id });
-  if (!exists) {
-    await collection.insertOne({ _id: id, domain, created_at: new Date() });
-  }
+  await db.ensureTenant(id, domain);
 }

--- a/app/api/services/user-info.ts
+++ b/app/api/services/user-info.ts
@@ -45,7 +45,13 @@ async function fetchExternalActorInfo(actorUrl: string, db: DB) {
         },
       });
       if (res.ok) {
-        const data = await res.json();
+        interface ActorApiResponse {
+          name?: string;
+          preferredUsername?: string;
+          icon?: unknown;
+          summary?: string;
+        }
+        const data = await res.json() as ActorApiResponse;
         await db.upsertRemoteActor({
           actorUrl,
           name: data.name || "",

--- a/app/shared/db.ts
+++ b/app/shared/db.ts
@@ -146,6 +146,23 @@ export interface DB {
   ): Promise<unknown>;
   markNotificationRead(id: string): Promise<boolean>;
   deleteNotification(id: string): Promise<boolean>;
+  addInboxEntry(tenantId: string, objectId: string): Promise<void>;
+  findSystemKey(domain: string): Promise<
+    {
+      domain: string;
+      privateKey: string;
+      publicKey: string;
+    } | null
+  >;
+  saveSystemKey(
+    domain: string,
+    privateKey: string,
+    publicKey: string,
+  ): Promise<void>;
+  registerFcmToken(token: string, userName: string): Promise<void>;
+  unregisterFcmToken(token: string): Promise<void>;
+  listFcmTokens(): Promise<{ token: string }[]>;
+  ensureTenant(id: string, domain: string): Promise<void>;
   findRelaysByHosts(hosts: string[]): Promise<RelayDoc[]>;
   findRelayByHost(host: string): Promise<RelayDoc | null>;
   createRelay(data: { host: string; inboxUrl: string }): Promise<RelayDoc>;

--- a/app/shared/db.ts
+++ b/app/shared/db.ts
@@ -167,6 +167,55 @@ export interface DB {
   findRelayByHost(host: string): Promise<RelayDoc | null>;
   createRelay(data: { host: string; inboxUrl: string }): Promise<RelayDoc>;
   deleteRelayById(id: string): Promise<RelayDoc | null>;
+  /** インスタンス一覧取得 */
+  listInstances(owner: string): Promise<{ host: string }[]>;
+  /** インスタンス数取得 */
+  countInstances(owner: string): Promise<number>;
+  /** ホスト名でインスタンス検索 */
+  findInstanceByHost(
+    host: string,
+  ): Promise<
+    | { _id: string; host: string; owner: string; env?: Record<string, string> }
+    | null
+  >;
+  /** ホスト名と所有者でインスタンス検索 */
+  findInstanceByHostAndOwner(
+    host: string,
+    owner: string,
+  ): Promise<
+    { _id: string; host: string; env?: Record<string, string> } | null
+  >;
+  /** インスタンス作成 */
+  createInstance(
+    data: { host: string; owner: string; env?: Record<string, string> },
+  ): Promise<void>;
+  /** インスタンス環境変数更新 */
+  updateInstanceEnv(id: string, env: Record<string, string>): Promise<void>;
+  /** インスタンス削除 */
+  deleteInstance(host: string, owner: string): Promise<void>;
+  /** OAuth クライアント一覧 */
+  listOAuthClients(): Promise<{ clientId: string; redirectUri: string }[]>;
+  /** OAuth クライアント検索 */
+  findOAuthClient(
+    clientId: string,
+  ): Promise<{ clientSecret: string } | null>;
+  /** OAuth クライアント作成 */
+  createOAuthClient(
+    data: { clientId: string; clientSecret: string; redirectUri: string },
+  ): Promise<void>;
+  /** ドメイン一覧取得 */
+  listHostDomains(
+    user: string,
+  ): Promise<{ domain: string; verified: boolean }[]>;
+  /** ドメイン検索 */
+  findHostDomain(
+    domain: string,
+    user?: string,
+  ): Promise<{ _id: string; token: string; verified: boolean } | null>;
+  /** ドメイン登録 */
+  createHostDomain(domain: string, user: string, token: string): Promise<void>;
+  /** ドメイン認証フラグ更新 */
+  verifyHostDomain(id: string): Promise<void>;
   findRemoteActorByUrl(url: string): Promise<unknown | null>;
   findRemoteActorsByUrls(urls: string[]): Promise<unknown[]>;
   upsertRemoteActor(data: {


### PR DESCRIPTION
## Summary
- DB インターフェースにシステムキーや FCM トークン管理などのメソッドを追加
- `MongoDBLocal` と `MongoDBHost` で上記メソッドを実装
- 各サービスから `getDatabase().collection()` を利用しないよう更新

## Testing
- `deno fmt app/shared/db.ts app/api/DB/local.ts app/api/DB/host.ts app/api/services/system_actor.ts app/api/services/fcm.ts app/api/services/tenant.ts`
- `deno lint app/shared/db.ts app/api/DB/local.ts app/api/DB/host.ts app/api/services/system_actor.ts app/api/services/fcm.ts app/api/services/tenant.ts`


------
https://chatgpt.com/codex/tasks/task_e_688204ef3dd08328a23e77d3bc3642c6