### PR TITLE
おすすめタイムライン機能の廃止

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,10 +116,10 @@ deno task build
 
 ## Microblog API
 
-簡単なテキスト投稿を行う `/api/microblog` エンドポイントも利用できます。
+-簡単なテキスト投稿を行う `/api/microblog` エンドポイントも利用できます。
 
 - `GET /api/microblog` –
-  おすすめタイムラインを取得（登録済みリレーからの投稿も含む）
+  公開タイムラインを取得（登録済みリレーからの投稿も含む）
 - `GET /api/microblog?timeline=followers&actor=URI` –
   フォロー中アクターの投稿のみ取得
 - `POST /api/microblog` – 投稿を作成

--- a/app/api/microblog.ts
+++ b/app/api/microblog.ts
@@ -45,7 +45,7 @@ app.get("/microblog", async (c) => {
   const env = getEnv(c);
   const tenantId = env["ACTIVITYPUB_DOMAIN"] ?? "";
   const actor = c.req.query("actor");
-  const timeline = c.req.query("timeline") ?? "recommend";
+  const timeline = c.req.query("timeline") ?? "latest";
   const limit = Math.min(
     parseInt(c.req.query("limit") ?? "50", 10) || 50,
     100,

--- a/app/api/routes/microblog.ts
+++ b/app/api/routes/microblog.ts
@@ -45,7 +45,7 @@ app.get("/microblog", async (c) => {
   const env = getEnv(c);
   const tenantId = env["ACTIVITYPUB_DOMAIN"] ?? "";
   const actor = c.req.query("actor");
-  const timeline = c.req.query("timeline") ?? "recommend";
+  const timeline = c.req.query("timeline") ?? "latest";
   const limit = Math.min(
     parseInt(c.req.query("limit") ?? "50", 10) || 50,
     100,
@@ -215,42 +215,6 @@ app.post(
     );
   },
 );
-
-app.get("/microblog/recommend", async (c) => {
-  const domain = getDomain(c);
-  const env = getEnv(c);
-  const limit = Math.min(
-    parseInt(c.req.query("limit") ?? "50", 10) || 50,
-    100,
-  );
-  const before = c.req.query("before");
-  const db = createDB(env);
-
-  // TODO: ここに独自のおすすめアルゴリズムを実装する
-  const list = await db.getPublicNotes(
-    limit,
-    before ? new Date(before) : undefined,
-  ) as ActivityObject[];
-
-  const identifiers = list.map((doc) => doc.actor_id as string);
-  const userInfos = await getUserInfoBatch(
-    identifiers as string[],
-    domain,
-    env,
-  );
-  const formatted = list.map((doc, index) => {
-    const userInfo = userInfos[index];
-    const postData = {
-      _id: doc._id,
-      content: doc.content,
-      published: doc.published,
-      extra: doc.extra,
-    } as Record<string, unknown>;
-    return formatUserInfoForPost(userInfo, postData);
-  });
-
-  return c.json(formatted);
-});
 
 app.get("/microblog/:id", async (c) => {
   const domain = getDomain(c);

--- a/app/client/src/components/Microblog.tsx
+++ b/app/client/src/components/Microblog.tsx
@@ -20,7 +20,6 @@ import {
   fetchPostById,
   fetchPostReplies,
   fetchPosts,
-  fetchRecommendedPosts,
   fetchStories,
   likePost,
   retweetPost,
@@ -30,9 +29,9 @@ import {
 import type { MicroblogPost, Story } from "./microblog/types.ts";
 
 export function Microblog() {
-  // タブ切り替え: "following" | "recommend" | "latest"
+  // タブ切り替え: "following" | "latest"
   const [account] = useAtom(activeAccount);
-  const [tab, setTab] = createSignal<"following" | "recommend" | "latest">(
+  const [tab, setTab] = createSignal<"following" | "latest">(
     "following",
   );
   const [newPostContent, setNewPostContent] = createSignal("");
@@ -131,11 +130,6 @@ export function Microblog() {
   onCleanup(() => {
     observer?.disconnect();
   });
-  const [recommendedPosts, { refetch: refetchRecommended }] = createResource(
-    () => {
-      return fetchRecommendedPosts();
-    },
-  );
   // フォロー中投稿の取得
   const [followingTimelinePosts, { refetch: _refetchFollowing }] =
     createResource(() => {
@@ -200,8 +194,6 @@ export function Microblog() {
         postsToFilter = posts() || [];
       } else if (tab() === "following") {
         postsToFilter = followingTimelinePosts() || [];
-      } else if (tab() === "recommend") {
-        postsToFilter = recommendedPosts() || [];
       } else {
         postsToFilter = [];
       }
@@ -403,20 +395,7 @@ export function Microblog() {
               </button>
               <button
                 type="button"
-                class={`tab-btn ${
-                  tab() === "recommend" ? "tab-btn-active" : ""
-                }`}
-                onClick={() => {
-                  setTab("recommend");
-                }}
-              >
-                おすすめ
-              </button>
-              <button
-                type="button"
-                class={`tab-btn ${
-                  tab() === "latest" ? "tab-btn-active" : ""
-                }`}
+                class={`tab-btn ${tab() === "latest" ? "tab-btn-active" : ""}`}
                 onClick={() => {
                   setTab("latest");
                 }}
@@ -427,7 +406,7 @@ export function Microblog() {
           </div>
         </div>
         <div class="max-w-2xl mx-auto">
-          {(tab() === "latest" || tab() === "following" || tab() === "recommend") && (
+          {(tab() === "latest" || tab() === "following") && (
             <StoryTray
               stories={stories() || []}
               refetchStories={refetchStories}
@@ -435,7 +414,7 @@ export function Microblog() {
             />
           )}
 
-          {(tab() === "latest" || tab() === "following" || tab() === "recommend") && (
+          {(tab() === "latest" || tab() === "following") && (
             <PostList
               posts={filteredPosts()}
               tab={tab()}

--- a/app/client/src/components/home/AccountSettingsContent.tsx
+++ b/app/client/src/components/home/AccountSettingsContent.tsx
@@ -452,7 +452,7 @@ const AccountSettingsContent: Component<{
               <div class="mb-8">
                 <PostList
                   posts={posts() || []}
-                  tab="recommend"
+                  tab="latest"
                   handleReply={() => {}}
                   handleRetweet={() => {}}
                   handleQuote={() => {}}

--- a/app/client/src/components/microblog/Post.tsx
+++ b/app/client/src/components/microblog/Post.tsx
@@ -141,7 +141,7 @@ function formatUserInfo(post: MicroblogPost) {
 
 type PostItemProps = {
   post: MicroblogPost;
-  tab: "recommend" | "following" | "community";
+  tab: "latest" | "following" | "community";
   handleReply: (postId: string) => void;
   handleRetweet: (postId: string) => void;
   handleQuote: (postId: string) => void;
@@ -443,7 +443,7 @@ function PostItem(props: PostItemProps) {
 
 export function PostList(props: {
   posts: MicroblogPost[];
-  tab: "recommend" | "following" | "community";
+  tab: "latest" | "following" | "community";
   handleReply: (postId: string) => void;
   handleRetweet: (postId: string) => void;
   handleQuote: (postId: string) => void;

--- a/app/client/src/components/microblog/api.ts
+++ b/app/client/src/components/microblog/api.ts
@@ -86,27 +86,6 @@ export const fetchPostReplies = async (
   }
 };
 
-export const fetchRecommendedPosts = async (
-  params?: { limit?: number; before?: string },
-): Promise<MicroblogPost[]> => {
-  try {
-    const search = new URLSearchParams();
-    if (params?.limit) search.set("limit", String(params.limit));
-    if (params?.before) search.set("before", params.before);
-    const query = search.toString();
-    const response = await apiFetch(
-      `/api/microblog/recommend${query ? `?${query}` : ""}`,
-    );
-    if (!response.ok) {
-      throw new Error("Failed to fetch recommended posts");
-    }
-    return await response.json();
-  } catch (error) {
-    console.error("Error fetching recommended posts:", error);
-    return [];
-  }
-};
-
 export const fetchFollowingPosts = async (
   username: string,
 ): Promise<MicroblogPost[]> => {

--- a/microblog-algorithm-image.md
+++ b/microblog-algorithm-image.md
@@ -1,4 +1,7 @@
-以下は **「既存DBとTypeScript(Deno/Hono想定) に“興味関心ベース推薦”を追加実装するための具体的仕様」** です。AIモデルや外部APIに依存せず、タグ・キーワード・閲覧/いいね履歴のみで実現します。
+以下は **「既存DBとTypeScript(Deno/Hono想定)
+に“興味関心ベース推薦”を追加実装するための具体的仕様」**
+です。(現在この機能は廃止されています)
+AIモデルや外部APIに依存せず、タグ・キーワード・閲覧/いいね履歴のみで実現します。
 
 ---
 
@@ -6,10 +9,14 @@
 
 1. ユーザーが過去に興味を示した投稿（閲覧、いいね、リブログ等）や、事前に設定した興味関心タグに基づき類似投稿を推薦する。
 2. API: `GET /api/recommendations` で最大 N 件の投稿を返す。
-3. リアルタイム性: ユーザー行動が発生したら遅延なくプロファイル更新（同期 or 短時間バッチ）。
-4. コールドスタート: 行動履歴がない場合は「ユーザーの明示的興味タグ」→ なければ「全体トレンド」を返す。
-5. パフォーマンス: 単一ユーザーの推薦を 50ms 以内（DB I/Oを除く）で計算可能にする。
-6. 冪等性: 同じリクエストで順序が安定するようスコア＋二次キー(created\_atなど)でソート。
+3. リアルタイム性: ユーザー行動が発生したら遅延なくプロファイル更新（同期 or
+   短時間バッチ）。
+4. コールドスタート: 行動履歴がない場合は「ユーザーの明示的興味タグ」→
+   なければ「全体トレンド」を返す。
+5. パフォーマンス: 単一ユーザーの推薦を 50ms 以内（DB
+   I/Oを除く）で計算可能にする。
+6. 冪等性:
+   同じリクエストで順序が安定するようスコア＋二次キー(created\_atなど)でソート。
 
 ---
 
@@ -19,22 +26,25 @@
 
 **ユーザープロファイルキャッシュ (user\_interest\_profiles)**
 
-| カラム              | 型         | 説明                        |
-| ---------------- | --------- | ------------------------- |
-| user\_id (PK)    | string    | ユーザーID                    |
+| カラム           | 型        | 説明                            |
+| ---------------- | --------- | ------------------------------- |
+| user\_id (PK)    | string    | ユーザーID                      |
 | tag\_weights     | JSON      | `{tag: number}` 重み (正規化済) |
-| keyword\_weights | JSON      | `{token: number}` 重み (任意) |
-| updated\_at      | timestamp | 最終更新                      |
+| keyword\_weights | JSON      | `{token: number}` 重み (任意)   |
+| updated\_at      | timestamp | 最終更新                        |
 
 **投稿特徴量拡張 (posts テーブルにカラム追加)**
 
-| カラム                   | 型         | 説明                             |
-| --------------------- | --------- | ------------------------------ |
-| tags                  | text\[]   | 既存 or 追加                       |
+| カラム                | 型        | 説明                                   |
+| --------------------- | --------- | -------------------------------------- |
+| tags                  | text\[]   | 既存 or 追加                           |
 | keyword\_vector       | JSON      | `{token: number}` (トークン出現頻度TF) |
-| score\_cache\_indices | GIN index | `tags` / JSON Path index で高速検索 |
+| score\_cache\_indices | GIN index | `tags` / JSON Path index で高速検索    |
 
-> 既にキーワード抽出処理が無ければ、簡易トークナイザ(正規表現で日本語/英数字切り出し)＋ストップワード除去で TF を計算し保存。TF-IDF の IDF は全投稿数/出現投稿数でバッチ計算し、`keyword_vector` 保存時に TF×IDF を数値化。
+> 既にキーワード抽出処理が無ければ、簡易トークナイザ(正規表現で日本語/英数字切り出し)＋ストップワード除去で
+> TF を計算し保存。TF-IDF の IDF
+> は全投稿数/出現投稿数でバッチ計算し、`keyword_vector` 保存時に TF×IDF
+> を数値化。
 
 ---
 
@@ -61,23 +71,25 @@ onUserAction(userId: string, postId: string, type: 'view'|'like'|'boost') {
 
 ### 3.3 更新処理ワーカー
 
-キューを処理し `user_interest_profiles` を更新。
-重み付け例:
+キューを処理し `user_interest_profiles` を更新。 重み付け例:
 
-| イベント         | 基本増分 (α) |
-| ------------ | -------- |
-| view         | 1        |
-| like         | 3        |
-| boost/reblog | 4        |
+| イベント     | 基本増分 (α) |
+| ------------ | ------------ |
+| view         | 1            |
+| like         | 3            |
+| boost/reblog | 4            |
 
 Pseudo:
 
 ```ts
 function applyEvent(profile, post, type) {
-  const inc = { view:1, like:3, boost:4 }[type];
-  for (const t of post.tags) profile.tagWeights[t] = (profile.tagWeights[t] ?? 0) + inc;
+  const inc = { view: 1, like: 3, boost: 4 }[type];
+  for (const t of post.tags) {
+    profile.tagWeights[t] = (profile.tagWeights[t] ?? 0) + inc;
+  }
   for (const [token, w] of Object.entries(post.keyword_vector)) {
-    profile.keywordWeights[token] = (profile.keywordWeights[token] ?? 0) + inc * w;
+    profile.keywordWeights[token] = (profile.keywordWeights[token] ?? 0) +
+      inc * w;
   }
 }
 ```
@@ -119,15 +131,15 @@ recencyBonus = exp(-μ * hoursSincePost)  (μ例:0.01)
 finalScore = tagScore + keywordScore + recencyBonus
 ```
 
-`cosine` 計算用にユーザー/投稿側で正規化済みベクトルを保持。
-`TAG_WEIGHT_COEF` と `KEYWORD_COEF` は環境変数で調整 (初期値 1.0 / 0.5 等)。
+`cosine` 計算用にユーザー/投稿側で正規化済みベクトルを保持。 `TAG_WEIGHT_COEF`
+と `KEYWORD_COEF` は環境変数で調整 (初期値 1.0 / 0.5 等)。
 
 ### 4.3 ソートとフィルタ
 
-* 除外: ユーザーが既に見た/いいねした投稿 (履歴テーブル参照)。
-* ソート: `ORDER BY finalScore DESC, created_at DESC`
-* 上位 N (例:20) を返却。
-* キャッシュ: ユーザーごとに 5 分間メモリ/LRU に保存 (再計算削減)。
+- 除外: ユーザーが既に見た/いいねした投稿 (履歴テーブル参照)。
+- ソート: `ORDER BY finalScore DESC, created_at DESC`
+- 上位 N (例:20) を返却。
+- キャッシュ: ユーザーごとに 5 分間メモリ/LRU に保存 (再計算削減)。
 
 ---
 
@@ -136,9 +148,11 @@ finalScore = tagScore + keywordScore + recencyBonus
 ### 5.1 ルータ (Hono例)
 
 ```ts
-app.get('/api/recommendations', authMiddleware, async (c) => {
+app.get("/api/recommendations", authMiddleware, async (c) => {
   const userId = c.var.user.id;
-  const recs = await recommendationService.getRecommendations(userId, {limit:20});
+  const recs = await recommendationService.getRecommendations(userId, {
+    limit: 20,
+  });
   return c.json(recs);
 });
 ```
@@ -147,7 +161,7 @@ app.get('/api/recommendations', authMiddleware, async (c) => {
 
 ```ts
 class RecommendationService {
-  async getRecommendations(userId: string, {limit}: {limit:number}) {
+  async getRecommendations(userId: string, { limit }: { limit: number }) {
     const profile = await this.loadProfile(userId);
     if (!profile) return this.coldStart(userId, limit);
     const candidates = await this.fetchCandidates(profile);
@@ -161,11 +175,11 @@ class RecommendationService {
 
 ## 6. バッチ/バックグラウンド
 
-| 処理       | 頻度    | 内容                                                        |
-| -------- | ----- | --------------------------------------------------------- |
-| プロファイル減衰 | 1日1回  | 全ユーザー weights 減衰→正規化                                      |
-| IDF再計算   | 週1回   | 全投稿から token -> docFreq → IDF 更新。`keyword_vector` 再生成（非同期） |
-| トレンド投稿更新 | 10分おき | コールドスタート用: 直近いいね数などでランキング                                 |
+| 処理             | 頻度     | 内容                                                                      |
+| ---------------- | -------- | ------------------------------------------------------------------------- |
+| プロファイル減衰 | 1日1回   | 全ユーザー weights 減衰→正規化                                            |
+| IDF再計算        | 週1回    | 全投稿から token -> docFreq → IDF 更新。`keyword_vector` 再生成（非同期） |
+| トレンド投稿更新 | 10分おき | コールドスタート用: 直近いいね数などでランキング                          |
 
 ---
 
@@ -179,9 +193,9 @@ class RecommendationService {
 
 ## 8. セキュリティ/プライバシ
 
-* プロファイルJSONは公開APIに返さない。
-* 明示削除リクエストで `user_interest_profiles` 行を削除し再生成可能。
-* PII含むカラムは使用しない。
+- プロファイルJSONは公開APIに返さない。
+- 明示削除リクエストで `user_interest_profiles` 行を削除し再生成可能。
+- PII含むカラムは使用しない。
 
 ---
 
@@ -200,12 +214,12 @@ class RecommendationService {
 
 ## 10. テスト計画 (抜粋)
 
-| 種類          | ケース                     |
-| ----------- | ----------------------- |
-| Unit        | 重み更新 / 減衰計算 / cosine    |
-| Integration | イベント→プロファイル更新→API応答     |
+| 種類        | ケース                                    |
+| ----------- | ----------------------------------------- |
+| Unit        | 重み更新 / 減衰計算 / cosine              |
+| Integration | イベント→プロファイル更新→API応答         |
 | Load        | 1,000ユーザー並列リクエストで応答時間測定 |
-| Regression  | コールドスタート時のフォールバック       |
+| Regression  | コールドスタート時のフォールバック        |
 
 ---
 


### PR DESCRIPTION
## 変更内容
- おすすめタイムライン関連のAPIとUIを削除
- 既定タイムラインを`latest`へ変更
- READMEとドキュメントを更新

## 動作確認
- `deno fmt`
- `deno lint`


------
https://chatgpt.com/codex/tasks/task_e_68833697cc748328a2488928dc21efb3