### PR TITLE
リアルタイム投稿配信をタイムライン別に改善

### DIFF
--- a/app/api/routes/ws.ts
+++ b/app/api/routes/ws.ts
@@ -30,6 +30,15 @@ export function sendToUser(user: string, data: unknown) {
   }
 }
 
+export function broadcast(data: unknown) {
+  const message = typeof data === "string" ? data : JSON.stringify(data);
+  for (const set of userSockets.values()) {
+    for (const s of set) {
+      s.send(message);
+    }
+  }
+}
+
 export function registerMessageHandler(
   type: string,
   handler: MessageHandler,

--- a/app/client/src/utils/ws.ts
+++ b/app/client/src/utils/ws.ts
@@ -1,0 +1,53 @@
+import { apiUrl } from "./config.ts";
+
+let socket: WebSocket | null = null;
+const handlers: ((data: unknown) => void)[] = [];
+let currentUser: string | null = null;
+
+export function connectWebSocket(): WebSocket {
+  if (socket) return socket;
+  const url = apiUrl("/api/ws").replace(/^http/, "ws");
+  socket = new WebSocket(url);
+  socket.onopen = () => {
+    if (currentUser) {
+      socket?.send(
+        JSON.stringify({ type: "register", payload: { user: currentUser } }),
+      );
+    }
+  };
+  socket.onmessage = (evt) => {
+    try {
+      const msg = JSON.parse(evt.data);
+      for (const h of handlers) h(msg);
+    } catch (err) {
+      console.error("ws message error", err);
+    }
+  };
+  return socket;
+}
+
+export function registerUser(user: string) {
+  currentUser = user;
+  if (!socket) {
+    connectWebSocket();
+    return;
+  }
+  if (socket.readyState === WebSocket.OPEN) {
+    socket.send(
+      JSON.stringify({ type: "register", payload: { user } }),
+    );
+  }
+}
+
+export function addMessageHandler(handler: (data: unknown) => void) {
+  handlers.push(handler);
+}
+
+export function removeMessageHandler(handler: (data: unknown) => void) {
+  const idx = handlers.indexOf(handler);
+  if (idx >= 0) handlers.splice(idx, 1);
+}
+
+export function getWebSocket(): WebSocket | null {
+  return socket;
+}


### PR DESCRIPTION
## 変更内容
- WS用ユーティリティを追加し、グローバルで1本のWebSocket接続を管理
- `Application` で接続を確立しアカウント変更時に登録を送信
- `Microblog` と `Chat` は共通接続を利用するよう更新

## テスト
- `deno fmt app/client/src/utils/ws.ts app/client/src/components/Application.tsx app/client/src/components/Microblog.tsx app/client/src/components/Chat.tsx`
- `deno lint app/client/src/utils/ws.ts app/client/src/components/Application.tsx app/client/src/components/Microblog.tsx app/client/src/components/Chat.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68833f86623483288a246738131040d3