### PR TITLE
フォロータイムラインが空の場合の案内表示追加

### DIFF
--- a/app/client/src/components/Microblog.tsx
+++ b/app/client/src/components/Microblog.tsx
@@ -458,6 +458,15 @@ export function Microblog() {
             />
           )}
 
+          <Show when={tab() === "following" && filteredPosts().length === 0}>
+            <div class="p-8 text-center">
+              <p class="text-gray-400 text-lg">フォロー中の投稿はありません</p>
+              <p class="text-gray-500 text-sm mt-2">
+                気になるユーザーをフォローしてみましょう
+              </p>
+            </div>
+          </Show>
+
           <Show when={!targetPostId()}>
             <div ref={(el) => (sentinel = el)} class="h-4"></div>
             {loadingMore() && (


### PR DESCRIPTION
## 概要
フォロータブに投稿が存在しないとき、ユーザーへフォローを促すメッセージを表示するよう `Microblog` コンポーネントを修正しました。

## 変更点
- `Microblog.tsx` に `Show` ブロックを追加し、フォロー中の投稿が空の場合に案内文を表示

## 動作確認
- `deno fmt` と `deno lint` を実行しエラーが無いことを確認済み

------
https://chatgpt.com/codex/tasks/task_e_68835428a7ec832898a812dbef9f1bb5