### PR TITLE
画像添付取得APIの追加

### DIFF
--- a/app/api/routes/message_attachments.ts
+++ b/app/api/routes/message_attachments.ts
@@ -1,0 +1,37 @@
+import { Hono } from "hono";
+import { createDB } from "../DB/mod.ts";
+import authRequired from "../utils/auth.ts";
+import { getEnv } from "../../shared/config.ts";
+
+const app = new Hono();
+app.use("/message-attachments/*", authRequired);
+
+app.get("/message-attachments/:id/:index", async (c) => {
+  const id = c.req.param("id");
+  const index = parseInt(c.req.param("index"), 10) || 0;
+  const db = createDB(getEnv(c));
+  const doc = await db.getObject(id) as {
+    extra?: Record<string, unknown>;
+  } | null;
+  if (!doc || typeof doc.extra !== "object" || !doc.extra) {
+    return c.text("Not Found", 404);
+  }
+  const list = (doc.extra as Record<string, unknown>).attachments;
+  if (!Array.isArray(list) || index < 0 || index >= list.length) {
+    return c.text("Not Found", 404);
+  }
+  const att = list[index] as Record<string, unknown>;
+  const data = att.content;
+  if (typeof data !== "string") {
+    return c.text("Not Found", 404);
+  }
+  const mediaType = typeof att.mediaType === "string"
+    ? att.mediaType
+    : "application/octet-stream";
+  const bin = atob(data);
+  const bytes = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+  return new Response(bytes, { headers: { "content-type": mediaType } });
+});
+
+export default app;

--- a/app/api/server.ts
+++ b/app/api/server.ts
@@ -21,6 +21,7 @@ import videos, {
   initVideoModule,
   initVideoWebSocket,
 } from "./routes/videos.ts";
+import messageAttachments from "./routes/message_attachments.ts";
 import wsRouter from "./routes/ws.ts";
 import config from "./routes/config.ts";
 import fcm from "./routes/fcm.ts";
@@ -59,6 +60,7 @@ export async function createTakosApp(env?: Record<string, string>) {
     adsense,
     setupUI,
     videos,
+    messageAttachments,
     search,
     relays,
     users,

--- a/app/client/src/components/e2ee/api.ts
+++ b/app/client/src/components/e2ee/api.ts
@@ -17,6 +17,12 @@ export interface EncryptedMessage {
   mediaType: string;
   encoding: string;
   createdAt: string;
+  attachments?: {
+    url: string;
+    mediaType: string;
+    key?: string;
+    iv?: string;
+  }[];
 }
 
 export const fetchKeyPackages = async (
@@ -86,6 +92,7 @@ export const sendEncryptedMessage = async (
     content: string;
     mediaType?: string;
     encoding?: string;
+    attachments?: unknown[];
   },
 ): Promise<boolean> => {
   try {
@@ -139,6 +146,12 @@ export interface PublicMessage {
   mediaType: string;
   encoding: string;
   createdAt: string;
+  attachments?: {
+    url: string;
+    mediaType: string;
+    key?: string;
+    iv?: string;
+  }[];
 }
 
 export const sendPublicMessage = async (
@@ -148,6 +161,7 @@ export const sendPublicMessage = async (
     content: string;
     mediaType?: string;
     encoding?: string;
+    attachments?: unknown[];
   },
 ): Promise<boolean> => {
   try {


### PR DESCRIPTION
## Summary
- メッセージ送信時に添付画像を別フィールドとして送信し、保存後はURLで配布
- 受信側ではURLから画像を取得し復号
- API から取得するメッセージにも添付情報を付加

## Testing
- `deno fmt app/api/routes/e2ee.ts app/api/routes/message_attachments.ts app/api/server.ts app/client/src/components/Chat.tsx app/client/src/components/e2ee/api.ts`
- `deno lint app/api/routes/e2ee.ts app/api/routes/message_attachments.ts app/api/server.ts app/client/src/components/Chat.tsx app/client/src/components/e2ee/api.ts`


------
https://chatgpt.com/codex/tasks/task_e_6884bfe974cc8328a5cc2ea476e1df35