### PR TITLE
Fix file input visibility

### DIFF
--- a/app/client/src/components/Chat.tsx
+++ b/app/client/src/components/Chat.tsx
@@ -1324,6 +1324,7 @@ export function Chat(props: ChatProps) {
                           type="file"
                           accept="image/*"
                           class="hidden"
+                          style="display:none;"
                           onChange={(e) => {
                             const f = (e.currentTarget as HTMLInputElement)
                               .files?.[0];

--- a/app/client/src/components/microblog/Post.tsx
+++ b/app/client/src/components/microblog/Post.tsx
@@ -690,6 +690,7 @@ export function PostForm(props: {
                       multiple
                       accept="image/*,video/*,audio/*"
                       class="hidden"
+                      style="display:none;"
                       onChange={handleFileChange}
                     />
                   </button>


### PR DESCRIPTION
## Summary
- hide image attachment file inputs using inline style in Chat and Microblog post forms

## Testing
- `deno fmt`
- `deno lint`


------
https://chatgpt.com/codex/tasks/task_e_6885027783a48328aa1c8fcb3daa8488