### PR TITLE
Add attachment upload endpoint and update message handling

### DIFF
--- a/app/api/routes/attachments.ts
+++ b/app/api/routes/attachments.ts
@@ -1,0 +1,44 @@
+import { Hono } from "hono";
+import {
+  createStorage,
+  type ObjectStorage,
+} from "../services/object-storage.ts";
+import { createDB } from "../DB/mod.ts";
+import authRequired from "../utils/auth.ts";
+
+let storage: ObjectStorage;
+export async function initAttachmentModule(env: Record<string, string>) {
+  const db = createDB(env);
+  storage = await createStorage(env, db);
+}
+
+const app = new Hono();
+app.use("/attachments/*", authRequired);
+
+app.post("/attachments", async (c) => {
+  const { data, mediaType } = await c.req.json();
+  if (typeof data !== "string") {
+    return c.json({ error: "invalid body" }, 400);
+  }
+  const bin = atob(data);
+  const bytes = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+  const ext = mediaType && typeof mediaType === "string"
+    ? `.${mediaType.split("/")[1] || "bin"}`
+    : ".bin";
+  const name = `${crypto.randomUUID()}${ext}`;
+  const stored = await storage.put(`attachments/${name}`, bytes);
+  const url = stored.startsWith("http") ? stored : `/api/attachments/${name}`;
+  return c.json({ url });
+});
+
+app.get("/attachments/:name", async (c) => {
+  const name = c.req.param("name");
+  const data = await storage.get(`attachments/${name}`);
+  if (!data) return c.text("Not found", 404);
+  return new Response(data, {
+    headers: { "content-type": "application/octet-stream" },
+  });
+});
+
+export default app;

--- a/app/api/routes/e2ee.ts
+++ b/app/api/routes/e2ee.ts
@@ -376,13 +376,12 @@ app.post(
       encoding: msg.encoding,
       createdAt: msg.createdAt,
       attachments: Array.isArray(attachments)
-        ? attachments.map((att, idx) => ({
-          url: `https://${domain}/api/message-attachments/${msg._id}/${idx}`,
-          mediaType: (att as { mediaType?: string }).mediaType ||
-            "application/octet-stream",
-          key: (att as { key?: string }).key,
-          iv: (att as { iv?: string }).iv,
-        }))
+        ? attachments as {
+          url: string;
+          mediaType?: string;
+          key?: string;
+          iv?: string;
+        }[]
         : undefined,
     };
     const msgType = isPublic ? "publicMessage" : "encryptedMessage";
@@ -419,8 +418,6 @@ app.get("/users/:user/messages", authRequired, async (c) => {
   if (!partnerActor && partnerUser && partnerDomain) {
     partnerActor = `https://${partnerDomain}/users/${partnerUser}`;
   }
-  const domain = getDomain(c);
-
   const condition = partnerAcct
     ? {
       $or: [
@@ -477,18 +474,12 @@ app.get("/users/:user/messages", authRequired, async (c) => {
     createdAt: doc.createdAt,
     attachments:
       Array.isArray((doc.extra as Record<string, unknown>)?.attachments)
-        ? (doc.extra as { attachments: unknown[] }).attachments.map(
-          (_: unknown, idx: number) => ({
-            url: `https://${domain}/api/message-attachments/${doc._id}/${idx}`,
-            mediaType: ((doc.extra as { attachments: { mediaType?: string }[] })
-              .attachments[idx].mediaType) ||
-              "application/octet-stream",
-            key: ((doc.extra as { attachments: { key?: string }[] })
-              .attachments[idx].key),
-            iv: ((doc.extra as { attachments: { iv?: string }[] })
-              .attachments[idx].iv),
-          }),
-        )
+        ? (doc.extra as { attachments: unknown[] }).attachments as {
+          url: string;
+          mediaType?: string;
+          key?: string;
+          iv?: string;
+        }[]
         : undefined,
   }));
   return c.json(messages);

--- a/app/api/server.ts
+++ b/app/api/server.ts
@@ -24,6 +24,7 @@ import videos, {
   initVideoWebSocket,
 } from "./routes/videos.ts";
 import messageAttachments from "./routes/message_attachments.ts";
+import attachments, { initAttachmentModule } from "./routes/attachments.ts";
 import wsRouter from "./routes/ws.ts";
 import config from "./routes/config.ts";
 import fcm from "./routes/fcm.ts";
@@ -48,6 +49,7 @@ export async function createTakosApp(env?: Record<string, string>) {
   });
   await initVideoModule(e);
   initVideoWebSocket();
+  await initAttachmentModule(e);
 
   const apiRoutes = [
     wsRouter,
@@ -63,6 +65,7 @@ export async function createTakosApp(env?: Record<string, string>) {
     adsense,
     setupUI,
     videos,
+    attachments,
     dms,
     messageAttachments,
     search,

--- a/app/client/src/components/Chat.tsx
+++ b/app/client/src/components/Chat.tsx
@@ -667,7 +667,6 @@ export function Chat(props: ChatProps) {
       isMe: true,
       avatar: room.avatar,
     });
-    loadMessages(room, true);
   };
 
   // 画面サイズ検出

--- a/app/client/src/components/Chat.tsx
+++ b/app/client/src/components/Chat.tsx
@@ -22,6 +22,7 @@ import {
   saveEncryptedKeyPair,
   sendEncryptedMessage,
   sendPublicMessage,
+  uploadEncryptedAttachment,
 } from "./e2ee/api.ts";
 import { getDomain } from "../utils/config.ts";
 import { addMessageHandler, removeMessageHandler } from "../utils/ws.ts";
@@ -573,13 +574,20 @@ export function Chat(props: ChatProps) {
       let atts: unknown[] | undefined;
       if (imageFile()) {
         const enc = await encryptFile(imageFile()!);
-        atts = [{
-          type: "Image",
+        const url = await uploadEncryptedAttachment({
+          data: enc.data,
           mediaType: enc.mediaType,
-          content: enc.data,
-          key: enc.key,
-          iv: enc.iv,
-        }];
+        });
+        if (url) {
+          atts = [{
+            type: "Image",
+            mediaType: enc.mediaType,
+            url,
+            key: enc.key,
+            iv: enc.iv,
+          }];
+          note.attachment = atts;
+        }
       }
       const cipher = await encryptGroupMessage(group, JSON.stringify(note));
       const success = await sendEncryptedMessage(
@@ -607,13 +615,20 @@ export function Chat(props: ChatProps) {
       let atts: unknown[] | undefined;
       if (imageFile()) {
         const enc = await encryptFile(imageFile()!);
-        atts = [{
-          type: "Image",
+        const url = await uploadEncryptedAttachment({
+          data: enc.data,
           mediaType: enc.mediaType,
-          content: enc.data,
-          key: enc.key,
-          iv: enc.iv,
-        }];
+        });
+        if (url) {
+          atts = [{
+            type: "Image",
+            mediaType: enc.mediaType,
+            url,
+            key: enc.key,
+            iv: enc.iv,
+          }];
+          note.attachment = atts;
+        }
       }
       const success = await sendPublicMessage(
         `${user.userName}@${getDomain()}`,

--- a/app/client/src/components/e2ee/api.ts
+++ b/app/client/src/components/e2ee/api.ts
@@ -85,6 +85,24 @@ export const deleteKeyPackage = async (
   }
 };
 
+export const uploadEncryptedAttachment = async (
+  data: { data: string; mediaType?: string },
+): Promise<string | null> => {
+  try {
+    const res = await apiFetch("/api/attachments", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(data),
+    });
+    if (!res.ok) return null;
+    const json = await res.json();
+    return typeof json.url === "string" ? json.url : null;
+  } catch (err) {
+    console.error("Error uploading attachment:", err);
+    return null;
+  }
+};
+
 export const sendEncryptedMessage = async (
   user: string,
   data: {


### PR DESCRIPTION
## Summary
- 添付ファイル保存用の `/api/attachments` エンドポイントを追加
- Chat クライアントから画像をアップロードし Note オブジェクトの `attachment` に埋め込み
- メッセージ送受信処理を添付ファイルの URL 対応に更新

## Testing
- `deno fmt`
- `deno lint`

------
https://chatgpt.com/codex/tasks/task_e_68852571c3b48328848504173ac9b9ef