### PR TITLE
添付ファイルAPI名の簡略化

### DIFF
--- a/app/api/routes/files.ts
+++ b/app/api/routes/files.ts
@@ -1,0 +1,44 @@
+import { Hono } from "hono";
+import { createDB } from "../DB/mod.ts";
+import authRequired from "../utils/auth.ts";
+import { getEnv } from "../../shared/config.ts";
+
+const app = new Hono();
+app.use("/files/*", authRequired);
+
+app.post("/files", async (c) => {
+  const { content, mediaType, key, iv } = await c.req.json();
+  if (typeof content !== "string") {
+    return c.json({ error: "invalid body" }, 400);
+  }
+  const env = getEnv(c);
+  const db = createDB(env);
+  const domain = env["ACTIVITYPUB_DOMAIN"] ?? "";
+  const obj = await db.saveObject({
+    type: "Attachment",
+    attributedTo: `https://${domain}/system`,
+    content,
+    extra: { mediaType, key, iv },
+  });
+  return c.json({ url: `https://${domain}/api/files/${obj._id}` }, 201);
+});
+
+app.get("/files/:id", async (c) => {
+  const id = c.req.param("id");
+  const env = getEnv(c);
+  const db = createDB(env);
+  const doc = await db.getObject(id) as {
+    content?: string;
+    extra?: Record<string, unknown>;
+  } | null;
+  if (!doc || typeof doc.content !== "string") return c.text("Not Found", 404);
+  const mediaType = typeof doc.extra?.mediaType === "string"
+    ? doc.extra.mediaType
+    : "application/octet-stream";
+  const bin = atob(doc.content);
+  const bytes = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+  return new Response(bytes, { headers: { "content-type": mediaType } });
+});
+
+export default app;

--- a/app/api/server.ts
+++ b/app/api/server.ts
@@ -24,6 +24,7 @@ import videos, {
   initVideoWebSocket,
 } from "./routes/videos.ts";
 import messageAttachments from "./routes/message_attachments.ts";
+import files from "./routes/files.ts";
 import wsRouter from "./routes/ws.ts";
 import config from "./routes/config.ts";
 import fcm from "./routes/fcm.ts";
@@ -65,6 +66,7 @@ export async function createTakosApp(env?: Record<string, string>) {
     videos,
     dms,
     messageAttachments,
+    files,
     search,
     relays,
     users,

--- a/app/client/src/components/Chat.tsx
+++ b/app/client/src/components/Chat.tsx
@@ -22,6 +22,7 @@ import {
   saveEncryptedKeyPair,
   sendEncryptedMessage,
   sendPublicMessage,
+  uploadFile,
 } from "./e2ee/api.ts";
 import { getDomain } from "../utils/config.ts";
 import { addMessageHandler, removeMessageHandler } from "../utils/ws.ts";
@@ -570,16 +571,23 @@ export function Chat(props: ChatProps) {
         id: `urn:uuid:${crypto.randomUUID()}`,
         content: text,
       };
-      let atts: unknown[] | undefined;
       if (imageFile()) {
         const enc = await encryptFile(imageFile()!);
-        atts = [{
-          type: "Image",
-          mediaType: enc.mediaType,
+        const url = await uploadFile({
           content: enc.data,
+          mediaType: enc.mediaType,
           key: enc.key,
           iv: enc.iv,
-        }];
+        });
+        if (url) {
+          note.attachment = [{
+            type: "Image",
+            url,
+            mediaType: enc.mediaType,
+            key: enc.key,
+            iv: enc.iv,
+          }];
+        }
       }
       const cipher = await encryptGroupMessage(group, JSON.stringify(note));
       const success = await sendEncryptedMessage(
@@ -587,7 +595,6 @@ export function Chat(props: ChatProps) {
         {
           to: room.members,
           content: cipher,
-          attachments: atts,
         },
       );
       if (!success) {
@@ -604,16 +611,23 @@ export function Chat(props: ChatProps) {
         id: `urn:uuid:${crypto.randomUUID()}`,
         content: text,
       };
-      let atts: unknown[] | undefined;
       if (imageFile()) {
         const enc = await encryptFile(imageFile()!);
-        atts = [{
-          type: "Image",
-          mediaType: enc.mediaType,
+        const url = await uploadFile({
           content: enc.data,
+          mediaType: enc.mediaType,
           key: enc.key,
           iv: enc.iv,
-        }];
+        });
+        if (url) {
+          note.attachment = [{
+            type: "Image",
+            url,
+            mediaType: enc.mediaType,
+            key: enc.key,
+            iv: enc.iv,
+          }];
+        }
       }
       const success = await sendPublicMessage(
         `${user.userName}@${getDomain()}`,
@@ -622,7 +636,6 @@ export function Chat(props: ChatProps) {
           content: JSON.stringify(note),
           mediaType: "application/json",
           encoding: "utf-8",
-          attachments: atts,
         },
       );
       if (!success) {

--- a/app/client/src/components/Chat.tsx
+++ b/app/client/src/components/Chat.tsx
@@ -91,6 +91,58 @@ function parseActivityPubContent(text: string): string {
   return text;
 }
 
+interface ActivityPubAttachment {
+  url: string;
+  mediaType: string;
+  key?: string;
+  iv?: string;
+}
+
+interface ParsedActivityPubNote {
+  content: string;
+  attachments?: ActivityPubAttachment[];
+}
+
+function parseActivityPubNote(text: string): ParsedActivityPubNote {
+  try {
+    const obj = JSON.parse(text);
+    if (obj && typeof obj === "object" && typeof obj.content === "string") {
+      const attachments =
+        Array.isArray((obj as { attachment?: unknown }).attachment)
+          ? (obj as { attachment?: unknown }).attachment
+            .map((a: unknown) => {
+              if (
+                a && typeof a === "object" &&
+                typeof (a as { url?: unknown }).url === "string"
+              ) {
+                return {
+                  url: (a as { url: string }).url,
+                  mediaType:
+                    typeof (a as { mediaType?: unknown }).mediaType === "string"
+                      ? (a as { mediaType: string }).mediaType
+                      : "application/octet-stream",
+                  key: typeof (a as { key?: unknown }).key === "string"
+                    ? (a as { key: string }).key
+                    : undefined,
+                  iv: typeof (a as { iv?: unknown }).iv === "string"
+                    ? (a as { iv: string }).iv
+                    : undefined,
+                } as ActivityPubAttachment;
+              }
+              return null;
+            })
+            .filter((
+              a: ActivityPubAttachment | null,
+            ): a is ActivityPubAttachment => !!a)
+          : undefined;
+      return { content: obj.content, attachments };
+    }
+  } catch {
+    /* ignore */
+  }
+  return { content: text };
+}
+
 async function encryptFile(file: File) {
   const buf = new Uint8Array(await file.arrayBuffer());
   const key = await crypto.subtle.generateKey(
@@ -404,24 +456,28 @@ export function Chat(props: ChatProps) {
     );
     for (const m of list) {
       const plain = await decryptGroupMessage(group, m.content);
-      const text = parseActivityPubContent(plain ?? m.content);
+      const note = parseActivityPubNote(plain ?? m.content);
+      const text = note.content;
+      const listAtt = Array.isArray(m.attachments)
+        ? m.attachments
+        : note.attachments;
       let attachments: { data: string; mediaType: string }[] | undefined;
-      if (Array.isArray(m.attachments)) {
+      if (Array.isArray(listAtt)) {
         attachments = [];
-        for (const at of m.attachments) {
-          if (
-            typeof at.url === "string" && typeof at.key === "string" &&
-            typeof at.iv === "string"
-          ) {
+        for (const at of listAtt) {
+          if (typeof at.url === "string") {
             try {
               const res = await fetch(at.url);
               const buf = await res.arrayBuffer();
               const encData = bufToB64(buf);
-              const dec = await decryptFile(encData, at.key, at.iv);
+              let data = encData;
+              if (typeof at.key === "string" && typeof at.iv === "string") {
+                data = await decryptFile(encData, at.key, at.iv);
+              }
               const mt = typeof at.mediaType === "string"
                 ? at.mediaType
                 : "image/png";
-              attachments.push({ data: dec, mediaType: mt });
+              attachments.push({ data, mediaType: mt });
             } catch {
               /* ignore */
             }
@@ -765,20 +821,26 @@ export function Chat(props: ChatProps) {
           if (group) {
             const plain = await decryptGroupMessage(group, data.content);
             if (plain) {
-              text = plain;
-              if (Array.isArray(data.attachments)) {
+              const note = parseActivityPubNote(plain);
+              text = note.content;
+              const listAtt = Array.isArray(data.attachments)
+                ? data.attachments
+                : note.attachments;
+              if (Array.isArray(listAtt)) {
                 attachments = [];
-                for (const at of data.attachments) {
-                  if (
-                    typeof at.url === "string" &&
-                    typeof at.key === "string" &&
-                    typeof at.iv === "string"
-                  ) {
+                for (const at of listAtt) {
+                  if (typeof at.url === "string") {
                     try {
                       const res = await fetch(at.url);
                       const buf = await res.arrayBuffer();
                       const enc = bufToB64(buf);
-                      const dec = await decryptFile(enc, at.key, at.iv);
+                      let dec = enc;
+                      if (
+                        typeof at.key === "string" &&
+                        typeof at.iv === "string"
+                      ) {
+                        dec = await decryptFile(enc, at.key, at.iv);
+                      }
                       const mt = typeof at.mediaType === "string"
                         ? at.mediaType
                         : "image/png";
@@ -792,19 +854,26 @@ export function Chat(props: ChatProps) {
             }
           }
         } else {
-          if (Array.isArray(data.attachments)) {
+          const note = parseActivityPubNote(data.content);
+          text = note.content;
+          const listAtt = Array.isArray(data.attachments)
+            ? data.attachments
+            : note.attachments;
+          if (Array.isArray(listAtt)) {
             attachments = [];
-            for (const at of data.attachments) {
-              if (
-                typeof at.url === "string" &&
-                typeof at.key === "string" &&
-                typeof at.iv === "string"
-              ) {
+            for (const at of listAtt) {
+              if (typeof at.url === "string") {
                 try {
                   const res = await fetch(at.url);
                   const buf = await res.arrayBuffer();
                   const enc = bufToB64(buf);
-                  const dec = await decryptFile(enc, at.key, at.iv);
+                  let dec = enc;
+                  if (
+                    typeof at.key === "string" &&
+                    typeof at.iv === "string"
+                  ) {
+                    dec = await decryptFile(enc, at.key, at.iv);
+                  }
                   const mt = typeof at.mediaType === "string"
                     ? at.mediaType
                     : "image/png";

--- a/app/client/src/components/e2ee/api.ts
+++ b/app/client/src/components/e2ee/api.ts
@@ -258,6 +258,24 @@ export const deleteEncryptedKeyPair = async (
   }
 };
 
+export const uploadFile = async (
+  data: { content: string; mediaType?: string; key?: string; iv?: string },
+): Promise<string | null> => {
+  try {
+    const res = await apiFetch("/api/files", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(data),
+    });
+    if (!res.ok) return null;
+    const d = await res.json();
+    return typeof d.url === "string" ? d.url : null;
+  } catch (err) {
+    console.error("Error uploading attachment:", err);
+    return null;
+  }
+};
+
 export const resetKeyData = async (user: string): Promise<boolean> => {
   try {
     const res = await apiFetch(


### PR DESCRIPTION
## Summary
- 新規アップロード用エンドポイントを `/files` に変更
- サーバールーターの登録とフロントエンドのアップロード処理を更新
- `uploadFile` 関数を追加しチャット画面から利用

## Testing
- `deno fmt app/api/routes/files.ts app/api/server.ts app/client/src/components/e2ee/api.ts app/client/src/components/Chat.tsx`
- `deno lint app/api/routes/files.ts app/api/server.ts app/client/src/components/e2ee/api.ts app/client/src/components/Chat.tsx`

------
https://chatgpt.com/codex/tasks/task_e_6885bcb105048328ae26098f44d86ed8