### PR TITLE
Fix profile outbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ deno task build
 - `/.well-known/webfinger` – WebFinger でアクターを検索
 - `/users/:username` – `Person` アクター情報を JSON-LD で返します
 - `/users/:username/outbox` – `Note` の投稿と取得
+- `/activitypub/outbox` – `username` や `acct` を指定して任意のアクターの outbox
+  を取得
 - `/users/:username/inbox` – ActivityPub 受信エンドポイント。`Create` Activity
   の場合はオブジェクトを `object_store` に保存し、他の Activity
   は保存せず処理のみ行います。処理は Activity タイプごとにハンドラー化し、

--- a/app/client/src/components/Profile.tsx
+++ b/app/client/src/components/Profile.tsx
@@ -38,8 +38,7 @@ export default function Profile() {
     () => username(),
     async (name) => {
       if (!name) return [];
-      const localName = name.includes("@") ? name.split("@")[0] : name;
-      const objs = await fetchActivityPubObjects(localName, "Note");
+      const objs = await fetchActivityPubObjects(name, "Note");
       const displayName = info()?.displayName || name;
       const avatar = info()?.avatarInitial || "";
       return objs.map((o) => ({

--- a/app/client/src/components/microblog/api.ts
+++ b/app/client/src/components/microblog/api.ts
@@ -10,12 +10,14 @@ export const fetchActivityPubObjects = async (
   type?: string,
 ): Promise<ActivityPubObject[]> => {
   try {
-    const url = type
-      ? `/users/${encodeURIComponent(username)}/outbox?type=${
-        encodeURIComponent(type)
-      }`
-      : `/users/${encodeURIComponent(username)}/outbox`;
-    const response = await apiFetch(url);
+    const qs = new URLSearchParams();
+    if (username.includes("@")) {
+      qs.set("acct", username);
+    } else {
+      qs.set("username", username);
+    }
+    if (type) qs.set("type", type);
+    const response = await apiFetch(`/api/activitypub/outbox?${qs}`);
     if (!response.ok) {
       throw new Error("Failed to fetch ActivityPub objects");
     }


### PR DESCRIPTION
## Summary
- ActivityPub の outbox を `/activitypub/outbox` として統一し、username や acct 指定に対応
- クライアント側の取得ロジックを更新し、新エンドポイントを利用
- README を更新

## Testing
- `deno fmt app/api/routes/activitypub.ts app/client/src/components/microblog/api.ts README.md`
- `deno lint app/api/routes/activitypub.ts app/client/src/components/microblog/api.ts`

------
https://chatgpt.com/codex/tasks/task_e_688704a9a5948328845a0ecaf526d2ac