### PR TITLE
Fix duplicate user routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,9 @@ deno task build
 - `/inbox` – サイト全体の共有 inbox。`to` などにローカルアクターが含まれる
   Activity をそれぞれの inbox 処理へ振り分けます。
 
+これらのルートは `/activitypub` プレフィックス付きでもアクセスでき、
+`/api/users` と競合しません。例: `/activitypub/users/alice`。
+
 `outbox` へ `POST` すると以下の形式でノートを作成できます。
 
 ```json

--- a/app/api/server.ts
+++ b/app/api/server.ts
@@ -77,7 +77,6 @@ export async function createTakosApp(env?: Record<string, string>) {
     relays,
     users,
     e2ee,
-    activitypub, // ActivityPubプロキシAPI用
   ];
   if (e["OAUTH_HOST"] || e["ROOT_DOMAIN"]) {
     apiRoutes.splice(3, 0, oauthLogin);
@@ -85,6 +84,9 @@ export async function createTakosApp(env?: Record<string, string>) {
   for (const r of apiRoutes) {
     app.route("/api", r);
   }
+
+  // ActivityPub ルートは /activitypub プレフィックスでも利用可能にする
+  app.route("/activitypub", activitypub);
 
   const rootRoutes = [nodeinfo, activitypub, rootInbox, e2ee];
   // e2ee アプリは最後に配置し、ActivityPub ルートへ認証不要でアクセスできるようにする


### PR DESCRIPTION
## Summary
- ActivityPub用ルートを`/activitypub`配下で利用できるよう変更
- READMEにプレフィックス利用の説明を追記

## Testing
- `deno fmt README.md app/api/server.ts`
- `deno lint README.md app/api/server.ts`


------
https://chatgpt.com/codex/tasks/task_e_68879213b7108328baa731b5ebc6fb05