### PR TITLE
JSON 投稿APIのパス変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ MongoDB にはセッション自動削除用の TTL インデックスが必要�
 登録したリレーとは `Follow` を送っておくことで投稿が inbox に届きます。
 `getEnv(c)` で取得した環境変数を `fetchJson` や `deliverActivityPubObject`
 へ渡すことで マルチテナント環境でも正しいドメインが利用されます。
-`RELAY_POLL_INTERVAL` で指定した 間隔ごとに、登録済みリレーの `/api/microblog`
+`RELAY_POLL_INTERVAL` で指定した 間隔ごとに、登録済みリレーの `/api/posts`
 を取得し、新規投稿を `object_store` へ 自動保存します。
 
 ### 初期設定
@@ -122,20 +122,20 @@ deno task build
 - `POST /api/follow` – 他のユーザーをフォロー
 - `DELETE /api/follow` – フォロー解除
 
-## Microblog API
+## JSON 投稿 API
 
--簡単なテキスト投稿を行う `/api/microblog` エンドポイントも利用できます。
+ローカル向けの JSON 版エンドポイント `/api/posts` では手軽に投稿の作成・取得が
+できます。外部との連携には ActivityPub の `/users/:username/outbox` を利用して
+ください。
 
-- `GET /api/microblog` –
-  公開タイムラインを取得（登録済みリレーからの投稿も含む）
-- `GET /api/microblog?timeline=followers&actor=URI` –
+- `GET /api/posts` – 公開タイムラインを取得（登録済みリレーからの投稿も含む）
+- `GET /api/posts?timeline=followers&actor=URI` –
   フォロー中アクターの投稿のみ取得
-- `POST /api/microblog` – 投稿を作成
-  (`{ "author": "user", "content": "hello" }`)
-- `PUT /api/microblog/:id` – 投稿を更新 (`{ "content": "edited" }`)
-- `DELETE /api/microblog/:id` – 投稿を削除
-- `POST /api/microblog/:id/like` – いいねを追加
-- `POST /api/microblog/:id/retweet` – リツイートを追加
+- `POST /api/posts` – 投稿を作成 (`{ "author": "user", "content": "hello" }`)
+- `PUT /api/posts/:id` – 投稿を更新 (`{ "content": "edited" }`)
+- `DELETE /api/posts/:id` – 投稿を削除
+- `POST /api/posts/:id/like` – いいねを追加
+- `POST /api/posts/:id/retweet` – リツイートを追加
 
 ### リンクプレビュー
 

--- a/app/api/routes/posts.ts
+++ b/app/api/routes/posts.ts
@@ -39,9 +39,9 @@ interface PostDoc {
 }
 
 const app = new Hono();
-app.use("/microblog/*", authRequired);
+app.use("/posts/*", authRequired);
 
-app.get("/microblog", async (c) => {
+app.get("/posts", async (c) => {
   const domain = getDomain(c);
   const env = getEnv(c);
   const tenantId = env["ACTIVITYPUB_DOMAIN"] ?? "";
@@ -87,7 +87,7 @@ app.get("/microblog", async (c) => {
 });
 
 app.post(
-  "/microblog",
+  "/posts",
   rateLimit({ windowMs: 60_000, limit: 10 }),
   zValidator(
     "json",
@@ -247,7 +247,7 @@ app.post(
   },
 );
 
-app.get("/microblog/:id", async (c) => {
+app.get("/posts/:id", async (c) => {
   const domain = getDomain(c);
   const env = getEnv(c);
   const id = c.req.param("id");
@@ -266,7 +266,7 @@ app.get("/microblog/:id", async (c) => {
   return c.json(formatUserInfoForPost(userInfo, data));
 });
 
-app.get("/microblog/:id/replies", async (c) => {
+app.get("/posts/:id/replies", async (c) => {
   const domain = getDomain(c);
   const env = getEnv(c);
   const id = c.req.param("id");
@@ -283,7 +283,7 @@ app.get("/microblog/:id/replies", async (c) => {
 });
 
 app.put(
-  "/microblog/:id",
+  "/posts/:id",
   zValidator("json", z.object({ content: z.string() })),
   async (c) => {
     const domain = getDomain(c);
@@ -312,7 +312,7 @@ app.put(
 );
 
 app.post(
-  "/microblog/:id/like",
+  "/posts/:id/like",
   zValidator("json", z.object({ username: z.string() })),
   async (c) => {
     const domain = getDomain(c);
@@ -391,7 +391,7 @@ app.post(
 );
 
 app.post(
-  "/microblog/:id/retweet",
+  "/posts/:id/retweet",
   zValidator("json", z.object({ username: z.string() })),
   async (c) => {
     const domain = getDomain(c);
@@ -468,7 +468,7 @@ app.post(
   },
 );
 
-app.delete("/microblog/:id", async (c) => {
+app.delete("/posts/:id", async (c) => {
   const env = getEnv(c);
   const db = createDB(env);
   const id = c.req.param("id");

--- a/app/api/server.ts
+++ b/app/api/server.ts
@@ -9,7 +9,7 @@ import session from "./routes/session.ts";
 import accounts from "./routes/accounts.ts";
 import notifications from "./routes/notifications.ts";
 import activitypub from "./routes/activitypub.ts";
-import microblog from "./routes/microblog.ts";
+import posts from "./routes/posts.ts";
 import search from "./routes/search.ts";
 import users from "./routes/users.ts";
 import follow from "./routes/follow.ts";
@@ -64,7 +64,7 @@ export async function createTakosApp(env?: Record<string, string>) {
     accounts,
     follow,
     notifications,
-    microblog,
+    posts,
     config,
     fcm,
     adsense,

--- a/app/client/src/components/microblog/api.ts
+++ b/app/client/src/components/microblog/api.ts
@@ -48,7 +48,7 @@ export const fetchPosts = async (
     if (params?.before) search.set("before", params.before);
     const query = search.toString();
     const response = await apiFetch(
-      `/api/microblog${query ? `?${query}` : ""}`,
+      `/api/posts${query ? `?${query}` : ""}`,
     );
     if (!response.ok) {
       throw new Error("Failed to fetch posts");
@@ -64,7 +64,7 @@ export const fetchPostById = async (
   id: string,
 ): Promise<MicroblogPost | null> => {
   try {
-    const res = await apiFetch(`/api/microblog/${encodeURIComponent(id)}`);
+    const res = await apiFetch(`/api/posts/${encodeURIComponent(id)}`);
     if (!res.ok) return null;
     return await res.json();
   } catch (error) {
@@ -78,7 +78,7 @@ export const fetchPostReplies = async (
 ): Promise<MicroblogPost[]> => {
   try {
     const res = await apiFetch(
-      `/api/microblog/${encodeURIComponent(id)}/replies`,
+      `/api/posts/${encodeURIComponent(id)}/replies`,
     );
     if (!res.ok) return [];
     return await res.json();
@@ -97,7 +97,7 @@ export const fetchFollowingPosts = async (
       timeline: "followers",
       actor: `https://${domain}/users/${encodeURIComponent(username)}`,
     });
-    const response = await apiFetch(`/api/microblog?${params.toString()}`);
+    const response = await apiFetch(`/api/posts?${params.toString()}`);
     if (!response.ok) {
       throw new Error("Failed to fetch following posts");
     }
@@ -169,7 +169,7 @@ export const createPost = async (
   quoteId?: string,
 ): Promise<boolean> => {
   try {
-    const response = await apiFetch("/api/microblog", {
+    const response = await apiFetch("/api/posts", {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -189,7 +189,7 @@ export const updatePost = async (
 ): Promise<boolean> => {
   try {
     const response = await apiFetch(
-      `/api/microblog/${encodeURIComponent(id)}`,
+      `/api/posts/${encodeURIComponent(id)}`,
       {
         method: "PUT",
         headers: {
@@ -208,7 +208,7 @@ export const updatePost = async (
 export const deletePost = async (id: string): Promise<boolean> => {
   try {
     const response = await apiFetch(
-      `/api/microblog/${encodeURIComponent(id)}`,
+      `/api/posts/${encodeURIComponent(id)}`,
       {
         method: "DELETE",
       },
@@ -226,7 +226,7 @@ export const likePost = async (
 ): Promise<number | null> => {
   try {
     const response = await apiFetch(
-      `/api/microblog/${encodeURIComponent(id)}/like`,
+      `/api/posts/${encodeURIComponent(id)}/like`,
       {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -248,7 +248,7 @@ export const retweetPost = async (
 ): Promise<number | null> => {
   try {
     const response = await apiFetch(
-      `/api/microblog/${encodeURIComponent(id)}/retweet`,
+      `/api/posts/${encodeURIComponent(id)}/retweet`,
       {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -269,7 +269,7 @@ export const _replyToPost = async (
   content: string,
 ): Promise<boolean> => {
   try {
-    const response = await apiFetch("/api/microblog", {
+    const response = await apiFetch("/api/posts", {
       method: "POST",
       headers: {
         "Content-Type": "application/json",

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -131,7 +131,7 @@ paths:
       responses:
         "200":
           description: アンフォロー送信結果
-  /microblog:
+  /posts:
     get:
       summary: 投稿一覧取得
       parameters:
@@ -165,7 +165,7 @@ paths:
       responses:
         "201":
           description: 作成された投稿
-  /microblog/{id}:
+  /posts/{id}:
     parameters:
       - name: id
         in: path
@@ -198,13 +198,13 @@ paths:
       responses:
         "200":
           description: 成功
-  /microblog/{id}/replies:
+  /posts/{id}/replies:
     get:
       summary: リプライ一覧取得
       responses:
         "200":
           description: リプライの配列
-  /microblog/{id}/like:
+  /posts/{id}/like:
     post:
       summary: いいね
       requestBody:
@@ -221,7 +221,7 @@ paths:
       responses:
         "200":
           description: いいね数
-  /microblog/{id}/retweet:
+  /posts/{id}/retweet:
     post:
       summary: リツイート
       requestBody:


### PR DESCRIPTION
## Summary
- JSON 版投稿APIのルートを `/api/posts` に変更
- サーバー・クライアント・OpenAPI ドキュメントを更新
- README に JSON API と ActivityPub の違いを追記

## Testing
- `deno fmt README.md app/api/routes/posts.ts app/api/server.ts app/client/src/components/microblog/api.ts docs/openapi.yaml`
- `deno lint README.md app/api/routes/posts.ts app/api/server.ts app/client/src/components/microblog/api.ts docs/openapi.yaml`


------
https://chatgpt.com/codex/tasks/task_e_68879ae2311c8328913c292d0d3fe325