### PR TITLE
検索APIを統合

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,12 @@ deno task build
 - `POST /api/microblog/:id/like` – いいねを追加
 - `POST /api/microblog/:id/retweet` – リツイートを追加
 
+## 検索 API
+
+- `GET /api/search?q=QUERY&type=users|posts|videos|all` –
+  キーワードからユーザーや投稿、動画を検索します。 `type`
+  を省略するとすべてが対象です。
+
 ### リンクプレビュー
 
 投稿内にURLを含めると、最初に出現したリンクを基にOGP情報を取得し、タイムラインでカード形式のプレビューを表示します。

--- a/app/api/routes/users.ts
+++ b/app/api/routes/users.ts
@@ -10,35 +10,6 @@ import authRequired from "../utils/auth.ts";
 const app = new Hono();
 app.use("/users/*", authRequired);
 
-// ユーザー検索
-app.get("/users/search", async (c) => {
-  try {
-    const query = c.req.query("q");
-    if (!query || typeof query !== "string") {
-      return c.json({ error: "Search query is required" }, 400);
-    }
-
-    const domain = getDomain(c);
-    const regex = new RegExp(query, "i");
-    const db = createDB(getEnv(c));
-    const users = await db.searchAccounts(regex, 20);
-
-    const formatted = users.map((user) => ({
-      userName: user.userName,
-      displayName: user.displayName,
-      avatarInitial: user.avatarInitial || "",
-      domain,
-      followersCount: user.followers?.length || 0,
-      followingCount: user.following?.length || 0,
-    }));
-
-    return c.json(formatted);
-  } catch (error) {
-    console.error("Error searching users:", error);
-    return c.json({ error: "Failed to search users" }, 500);
-  }
-});
-
 // ユーザー詳細取得
 app.get("/users/:identifier", async (c) => {
   try {

--- a/app/client/src/components/microblog/api.ts
+++ b/app/client/src/components/microblog/api.ts
@@ -111,7 +111,7 @@ export const fetchFollowingPosts = async (
 export const searchUsers = async (query: string) => {
   try {
     const response = await apiFetch(
-      `/api/users/search?q=${encodeURIComponent(query)}`,
+      `/api/search?q=${encodeURIComponent(query)}&type=users`,
     );
     if (!response.ok) {
       throw new Error("Failed to search users");


### PR DESCRIPTION
## Summary
- `/api/users/search` を削除して `/api/search` に統一
- クライアント側の検索API呼び出しを更新
- README に検索APIの説明を追加

## Testing
- `deno fmt app/api/routes/users.ts app/client/src/components/microblog/api.ts README.md`
- `deno lint`

------
https://chatgpt.com/codex/tasks/task_e_68879ae62ab4832887f805d522613df5