### PR TITLE
フォロー処理の共通サービス化

### DIFF
--- a/app/api/routes/activitypub.ts
+++ b/app/api/routes/activitypub.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 import { createDB } from "../DB/mod.ts";
 import { getEnv } from "../../shared/config.ts";
+import { getFollowList } from "../services/follow-info.ts";
 
 import { activityHandlers } from "../activity_handlers.ts";
 import { getSystemKey } from "../services/system_actor.ts";
@@ -288,11 +289,13 @@ app.get("/users/:username/followers", async (c) => {
   }
   const page = c.req.query("page");
   const env = getEnv(c);
-  const db = createDB(env);
-  const account = await db.findAccountByUserName(username);
-  if (!account) return jsonResponse(c, { error: "Not found" }, 404);
+  let list: string[];
+  try {
+    list = await getFollowList(username, "followers", env);
+  } catch {
+    return jsonResponse(c, { error: "Not found" }, 404);
+  }
   const domain = getDomain(c);
-  const list = account.followers ?? [];
   const baseId = `https://${domain}/users/${username}/followers`;
 
   if (page) {
@@ -346,11 +349,13 @@ app.get("/users/:username/following", async (c) => {
   }
   const page = c.req.query("page");
   const env = getEnv(c);
-  const db = createDB(env);
-  const account = await db.findAccountByUserName(username);
-  if (!account) return jsonResponse(c, { error: "Not found" }, 404);
+  let list: string[];
+  try {
+    list = await getFollowList(username, "following", env);
+  } catch {
+    return jsonResponse(c, { error: "Not found" }, 404);
+  }
   const domain = getDomain(c);
-  const list = account.following ?? [];
   const baseId = `https://${domain}/users/${username}/following`;
 
   if (page) {

--- a/app/api/services/follow-info.ts
+++ b/app/api/services/follow-info.ts
@@ -1,0 +1,67 @@
+import { createDB } from "../DB/mod.ts";
+import type { DB } from "../../shared/db.ts";
+
+/**
+ * 指定したユーザーのフォロー/フォロワー一覧を取得
+ */
+export async function getFollowList(
+  username: string,
+  type: "followers" | "following",
+  env: Record<string, string>,
+  dbInst?: DB,
+): Promise<string[]> {
+  const db = dbInst ?? createDB(env);
+  const account = await db.findAccountByUserName(username);
+  if (!account) {
+    throw new Error("User not found");
+  }
+  return (account[type] ?? []) as string[];
+}
+
+export interface FollowInfo {
+  userName: string;
+  displayName: string;
+  avatarInitial: string;
+  domain: string;
+}
+
+/**
+ * URL のリストをローカル向けオブジェクト配列へ変換
+ */
+export async function formatFollowList(
+  list: string[],
+  domain: string,
+  env: Record<string, string>,
+  dbInst?: DB,
+): Promise<FollowInfo[]> {
+  const db = dbInst ?? createDB(env);
+  const result: FollowInfo[] = [];
+  for (const url of list) {
+    try {
+      if (url.includes(domain)) {
+        const name = url.split("/").pop();
+        const acc = await db.findAccountByUserName(name ?? "");
+        if (acc) {
+          result.push({
+            userName: acc.userName,
+            displayName: acc.displayName,
+            avatarInitial: acc.avatarInitial || "",
+            domain,
+          });
+        }
+      } else {
+        const remoteName = url.split("/").pop();
+        const remoteDomain = new URL(url).host;
+        result.push({
+          userName: remoteName ?? "",
+          displayName: remoteName ?? "",
+          avatarInitial: "",
+          domain: remoteDomain,
+        });
+      }
+    } catch (err) {
+      console.error("Error processing follow:", err);
+    }
+  }
+  return result;
+}


### PR DESCRIPTION
## Summary
- add follow-info service for shared follower logic
- refactor followers/following routes to use service
- unify ActivityPub followers APIs to use service

## Testing
- `deno fmt app/api/services/follow-info.ts app/api/routes/users.ts app/api/routes/activitypub.ts`
- `deno lint app/api/services/follow-info.ts app/api/routes/users.ts app/api/routes/activitypub.ts`


------
https://chatgpt.com/codex/tasks/task_e_6887a59baa488328808ef0e461220bcd