### PR TITLE
フォロー一覧取得ロジックの共通化

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,12 @@ deno task build
 
 - `POST /api/follow` – 他のユーザーをフォロー
 - `DELETE /api/follow` – フォロー解除
+- `GET /api/users/:username/followers` – フォロワー一覧を JSON で取得
+- `GET /api/users/:username/following` – フォロー中ユーザー一覧を JSON で取得
+
+ActivityPub 形式の一覧が必要な場合は、`/activitypub/users/:username/followers`
+や `/activitypub/users/:username/following` を利用します。こちらは
+`OrderedCollection` 形式で返され、ページングに対応しています。
 
 ## JSON 投稿 API
 

--- a/app/api/routes/activitypub.ts
+++ b/app/api/routes/activitypub.ts
@@ -1,7 +1,7 @@
 import { Hono } from "hono";
 import { createDB } from "../DB/mod.ts";
 import { getEnv } from "../../shared/config.ts";
-import { getFollowList } from "../services/follow-info.ts";
+import { buildActivityPubFollowCollection } from "../services/follow-info.ts";
 
 import { activityHandlers } from "../activity_handlers.ts";
 import { getSystemKey } from "../services/system_actor.ts";
@@ -289,44 +289,20 @@ app.get("/users/:username/followers", async (c) => {
   }
   const page = c.req.query("page");
   const env = getEnv(c);
-  let list: string[];
+  const domain = getDomain(c);
+  let data: Record<string, unknown>;
   try {
-    list = await getFollowList(username, "followers", env);
+    data = await buildActivityPubFollowCollection(
+      username,
+      "followers",
+      page,
+      domain,
+      env,
+    );
   } catch {
     return jsonResponse(c, { error: "Not found" }, 404);
   }
-  const domain = getDomain(c);
-  const baseId = `https://${domain}/users/${username}/followers`;
-
-  if (page) {
-    return jsonResponse(
-      c,
-      {
-        "@context": "https://www.w3.org/ns/activitystreams",
-        id: `${baseId}?page=1`,
-        type: "OrderedCollectionPage",
-        partOf: baseId,
-        orderedItems: list,
-        next: null,
-        prev: null,
-      },
-      200,
-      "application/activity+json",
-    );
-  }
-
-  return jsonResponse(
-    c,
-    {
-      "@context": "https://www.w3.org/ns/activitystreams",
-      id: baseId,
-      type: "OrderedCollection",
-      totalItems: list.length,
-      first: `${baseId}?page=1`,
-    },
-    200,
-    "application/activity+json",
-  );
+  return jsonResponse(c, data, 200, "application/activity+json");
 });
 
 app.get("/users/:username/following", async (c) => {
@@ -349,44 +325,20 @@ app.get("/users/:username/following", async (c) => {
   }
   const page = c.req.query("page");
   const env = getEnv(c);
-  let list: string[];
+  const domain = getDomain(c);
+  let data: Record<string, unknown>;
   try {
-    list = await getFollowList(username, "following", env);
+    data = await buildActivityPubFollowCollection(
+      username,
+      "following",
+      page,
+      domain,
+      env,
+    );
   } catch {
     return jsonResponse(c, { error: "Not found" }, 404);
   }
-  const domain = getDomain(c);
-  const baseId = `https://${domain}/users/${username}/following`;
-
-  if (page) {
-    return jsonResponse(
-      c,
-      {
-        "@context": "https://www.w3.org/ns/activitystreams",
-        id: `${baseId}?page=1`,
-        type: "OrderedCollectionPage",
-        partOf: baseId,
-        orderedItems: list,
-        next: null,
-        prev: null,
-      },
-      200,
-      "application/activity+json",
-    );
-  }
-
-  return jsonResponse(
-    c,
-    {
-      "@context": "https://www.w3.org/ns/activitystreams",
-      id: baseId,
-      type: "OrderedCollection",
-      totalItems: list.length,
-      first: `${baseId}?page=1`,
-    },
-    200,
-    "application/activity+json",
-  );
+  return jsonResponse(c, data, 200, "application/activity+json");
 });
 
 export default app;

--- a/app/api/routes/users.ts
+++ b/app/api/routes/users.ts
@@ -5,7 +5,7 @@ import { createDB } from "../DB/mod.ts";
 import { getEnv } from "../../shared/config.ts";
 import { getDomain } from "../utils/activitypub.ts";
 import { getUserInfo, getUserInfoBatch } from "../services/user-info.ts";
-import { formatFollowList, getFollowList } from "../services/follow-info.ts";
+import { getFormattedFollowInfo } from "../services/follow-info.ts";
 import authRequired from "../utils/auth.ts";
 
 const app = new Hono();
@@ -84,8 +84,12 @@ app.get("/users/:username/followers", async (c) => {
     const domain = getDomain(c);
     const username = c.req.param("username");
     const env = getEnv(c);
-    const list = await getFollowList(username, "followers", env);
-    const data = await formatFollowList(list, domain, env);
+    const data = await getFormattedFollowInfo(
+      username,
+      "followers",
+      domain,
+      env,
+    );
     return c.json(data);
   } catch (error) {
     console.error("Error fetching followers:", error);
@@ -102,8 +106,12 @@ app.get("/users/:username/following", async (c) => {
     const domain = getDomain(c);
     const username = c.req.param("username");
     const env = getEnv(c);
-    const list = await getFollowList(username, "following", env);
-    const data = await formatFollowList(list, domain, env);
+    const data = await getFormattedFollowInfo(
+      username,
+      "following",
+      domain,
+      env,
+    );
     return c.json(data);
   } catch (error) {
     console.error("Error fetching following:", error);


### PR DESCRIPTION
## 概要
- `/users/:username/followers` と `/users/:username/following` の処理を
  `getFormattedFollowInfo` と `buildActivityPubFollowCollection` に集約
- 各ルートから上記関数を利用するよう修正
- README に API 版と ActivityPub 版の違いを追記

## テスト
- `deno fmt`
- `deno lint`


------
https://chatgpt.com/codex/tasks/task_e_6887acc94c748328862209a9ac302de5