### PR TITLE
ActivityPubルートを統一

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,8 +105,7 @@ deno task build
 - `/inbox` – サイト全体の共有 inbox。`to` などにローカルアクターが含まれる
   Activity をそれぞれの inbox 処理へ振り分けます。
 
-これらのルートは `/activitypub` プレフィックス付きでもアクセスでき、
-`/api/users` と競合しません。例: `/activitypub/users/alice`。
+これらのルートは `/` 直下に配置されており、`/api` のルートとは競合しません。
 
 `outbox` へ `POST` すると以下の形式でノートを作成できます。
 

--- a/app/api/server.ts
+++ b/app/api/server.ts
@@ -83,8 +83,7 @@ export async function createTakosApp(env?: Record<string, string>) {
     app.route("/api", r);
   }
 
-  // ActivityPub ルートは /activitypub プレフィックスでも利用可能にする
-  app.route("/activitypub", activitypub);
+  // ActivityPub ルートは / のみにマウントする
 
   const rootRoutes = [nodeinfo, activitypub, rootInbox, e2ee];
   // e2ee アプリは最後に配置し、ActivityPub ルートへ認証不要でアクセスできるようにする


### PR DESCRIPTION
## Summary
- ActivityPub ルートを `/` のみにマウント
- README のルート説明を更新

## Testing
- `deno fmt README.md app/api/server.ts`
- `deno lint app/api/server.ts`


------
https://chatgpt.com/codex/tasks/task_e_6887aebd69488328b01c2a58e045786e