### PR TITLE
Fix e2ee route path

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,24 @@ ActivityPub の `Video` オブジェクトを利用して動画を投稿でき�
 各インスタンスのリストは `relays` コレクションに基づきます。 takos host
 のデフォルトリレーは自動登録されますが、一覧には表示されません。
 
+## チャット API
+
+エンドツーエンド暗号化に対応したチャット機能の API です。
+
+- `GET /api/users/:user/keyPackages` – KeyPackage 一覧取得
+- `POST /api/users/:user/keyPackages` – KeyPackage 登録
+- `GET /api/users/:user/keyPackages/:keyId` – KeyPackage 取得
+- `DELETE /api/users/:user/keyPackages/:keyId` – KeyPackage 削除
+- `GET /api/users/:user/encryptedKeyPair` – 暗号化鍵ペア取得
+- `POST /api/users/:user/encryptedKeyPair` – 暗号化鍵ペア保存
+- `DELETE /api/users/:user/encryptedKeyPair` – 暗号化鍵ペア削除
+- `POST /api/users/:user/resetKeys` – 鍵情報リセット
+- `GET /api/users/:user/messages` – メッセージ一覧取得
+- `POST /api/users/:user/messages` – メッセージ送信
+- `POST /api/files` – ファイルアップロード（HTTP のみ）
+- `GET /api/files/:id` – ファイル取得
+- `GET /api/files/messages/:messageId/:index` – メッセージ添付ファイル取得
+
 ## クライアントでのデータ保存
 
 チャット機能で利用するMLS関連データは、ブラウザのIndexedDBに保存します。データベースは

--- a/app/api/server.ts
+++ b/app/api/server.ts
@@ -73,8 +73,8 @@ export async function createTakosApp(env?: Record<string, string>) {
 
   // ActivityPub ルートは / のみにマウントする
 
-  const rootRoutes = [nodeinfo, activitypub, rootInbox, e2ee];
-  // e2ee アプリは最後に配置し、ActivityPub ルートへ認証不要でアクセスできるようにする
+  const rootRoutes = [nodeinfo, activitypub, rootInbox];
+  // e2ee ルートは /api のみで提供し、ActivityPub ルートと競合しないようにする
   for (const r of rootRoutes) {
     app.route("/", r);
   }

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -375,7 +375,7 @@ paths:
       responses:
         "200":
           description: OGPデータ
-  /users/{user}/keyPackages:
+  /api/users/{user}/keyPackages:
     parameters:
       - name: user
         in: path
@@ -407,7 +407,7 @@ paths:
       responses:
         "200":
           description: 登録結果
-  /users/{user}/keyPackages/{keyId}:
+  /api/users/{user}/keyPackages/{keyId}:
     parameters:
       - name: user
         in: path
@@ -429,7 +429,7 @@ paths:
       responses:
         "200":
           description: 成功
-  /users/{user}/encryptedKeyPair:
+  /api/users/{user}/encryptedKeyPair:
     parameters:
       - name: user
         in: path
@@ -462,7 +462,7 @@ paths:
       responses:
         "200":
           description: 成功
-  /users/{user}/resetKeys:
+  /api/users/{user}/resetKeys:
     parameters:
       - name: user
         in: path
@@ -474,7 +474,7 @@ paths:
       responses:
         "200":
           description: リセット結果
-  /users/{user}/messages:
+  /api/users/{user}/messages:
     parameters:
       - name: user
         in: path
@@ -528,7 +528,7 @@ paths:
       responses:
         "200":
           description: 送信結果
-  /files:
+  /api/files:
     post:
       summary: ファイルアップロード（HTTP のみ）
       requestBody:
@@ -552,7 +552,7 @@ paths:
       responses:
         "201":
           description: アップロード結果
-  /files/{id}:
+  /api/files/{id}:
     parameters:
       - name: id
         in: path
@@ -564,7 +564,7 @@ paths:
       responses:
         "200":
           description: ファイルデータ
-  /files/messages/{messageId}/{index}:
+  /api/files/messages/{messageId}/{index}:
     parameters:
       - name: messageId
         in: path


### PR DESCRIPTION
## Summary
- e2ee ルートを /api のみに変更
- OpenAPI と README を更新しチャット API のパスを統一

## Testing
- `deno fmt README.md app/api/server.ts docs/openapi.yaml`
- `deno lint README.md app/api/server.ts docs/openapi.yaml`


------
https://chatgpt.com/codex/tasks/task_e_6887bcc5c6e08328b1a96f5829a4c4ca