### PR TITLE
ユーザー関連APIの整理

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,9 +182,22 @@ ActivityPub の `Video` オブジェクトを利用して動画を投稿でき�
 各インスタンスのリストは `relays` コレクションに基づきます。 takos host
 のデフォルトリレーは自動登録されますが、一覧には表示されません。
 
+## アカウント管理 API
+
+ローカルアカウントの作成や編集に利用するエンドポイントです。公開ユーザー情報の取得
+やチャット関連機能を提供する `/api/users/*` とは目的が異なります。
+
+- `GET /api/accounts` – アカウント一覧取得
+- `POST /api/accounts` – アカウント作成
+- `GET /api/accounts/:id` – アカウント取得（鍵情報を含む）
+- `PUT /api/accounts/:id` – アカウント更新
+- `DELETE /api/accounts/:id` – アカウント削除
+
 ## チャット API
 
-エンドツーエンド暗号化に対応したチャット機能の API です。
+エンドツーエンド暗号化に対応したチャット機能の API です。 `/api/users/*`
+プレフィックスには公開ユーザー情報取得用のエンドポイントも含まれますが、
+アカウント管理機能は `/api/accounts/*` で提供されます。
 
 - `GET /api/users/:user/keyPackages` – KeyPackage 一覧取得
 - `POST /api/users/:user/keyPackages` – KeyPackage 登録

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -58,11 +58,13 @@ paths:
   /accounts:
     get:
       summary: アカウント一覧取得
+      description: ローカルアカウントの一覧を取得します。
       responses:
         "200":
           description: アカウントの配列
     post:
       summary: アカウント作成
+      description: 新しいローカルアカウントを作成します。
       requestBody:
         required: true
         content:
@@ -88,11 +90,13 @@ paths:
           type: string
     get:
       summary: アカウント取得
+      description: 対象アカウントの詳細情報を返します。
       responses:
         "200":
           description: アカウント情報
     put:
       summary: アカウント更新
+      description: アカウント情報を更新します。
       requestBody:
         required: true
         content:
@@ -104,6 +108,7 @@ paths:
           description: 更新後のアカウント
     delete:
       summary: アカウント削除
+      description: アカウントを削除します。
       responses:
         "200":
           description: 成功
@@ -323,13 +328,15 @@ paths:
     get:
       summary: ユーザー情報取得
       description: |
-        ローカルユーザー名、`user@domain` 形式、または ActivityPub URL を指定します。
+        ローカルユーザー名、`user@domain` 形式、または ActivityPub URL を指定して
+        公開プロフィールを取得します。
       responses:
         "200":
           description: ユーザー情報
   /users/batch:
     post:
       summary: ユーザー情報バッチ取得
+      description: 複数の識別子からユーザーの公開情報をまとめて取得します。
       requestBody:
         required: true
         content:
@@ -384,11 +391,13 @@ paths:
           type: string
     get:
       summary: KeyPackage一覧取得
+      description: チャット用MLSキーの公開情報を取得します。
       responses:
         "200":
           description: KeyPackageのコレクション
     post:
       summary: KeyPackage登録
+      description: チャット用KeyPackageを登録します。
       requestBody:
         required: true
         content:
@@ -421,11 +430,13 @@ paths:
           type: string
     get:
       summary: KeyPackage取得
+      description: 指定IDのKeyPackageを取得します。
       responses:
         "200":
           description: KeyPackage
     delete:
       summary: KeyPackage削除
+      description: KeyPackageを削除します。
       responses:
         "200":
           description: 成功
@@ -438,11 +449,13 @@ paths:
           type: string
     get:
       summary: 暗号化鍵ペア取得
+      description: クライアント側で復号するための鍵ペアを取得します。
       responses:
         "200":
           description: 鍵ペア
     post:
       summary: 暗号化鍵ペア保存
+      description: 鍵ペアを保存します。
       requestBody:
         required: true
         content:
@@ -459,6 +472,7 @@ paths:
           description: 保存結果
     delete:
       summary: 暗号化鍵ペア削除
+      description: 保存済みの鍵ペアを削除します。
       responses:
         "200":
           description: 成功
@@ -471,6 +485,7 @@ paths:
           type: string
     post:
       summary: 鍵情報リセット
+      description: 既存のKeyPackageと鍵ペアをすべて削除します。
       responses:
         "200":
           description: リセット結果
@@ -483,6 +498,7 @@ paths:
           type: string
     get:
       summary: メッセージ一覧取得（公開・非公開共通）
+      description: 2者間のメッセージ履歴を取得します。
       parameters:
         - name: limit
           in: query
@@ -505,6 +521,7 @@ paths:
           description: メッセージの配列
     post:
       summary: メッセージ送信
+      description: メッセージを送信します。
       requestBody:
         required: true
         content:


### PR DESCRIPTION
## Summary
- README にアカウント管理 API を追加し、`/api/users/*` との違いを明記
- OpenAPI 仕様にアカウント・ユーザー周りの説明を追記

## Testing
- `deno fmt README.md docs/openapi.yaml`
- `deno lint`


------
https://chatgpt.com/codex/tasks/task_e_6887c5033a648328888df464b6ecf726