### PR TITLE
フォロー取得処理を共通化

### DIFF
--- a/app/api/routes/activitypub.ts
+++ b/app/api/routes/activitypub.ts
@@ -18,6 +18,22 @@ import {
 
 const app = new Hono();
 
+export async function getActivityPubFollowCollection(
+  username: string,
+  type: "followers" | "following",
+  page: string | undefined,
+  domain: string,
+  env: Record<string, string>,
+) {
+  return await buildActivityPubFollowCollection(
+    username,
+    type,
+    page,
+    domain,
+    env,
+  );
+}
+
 interface KeyPackageDoc {
   _id: unknown;
 }
@@ -292,7 +308,7 @@ app.get("/users/:username/followers", async (c) => {
   const domain = getDomain(c);
   let data: Record<string, unknown>;
   try {
-    data = await buildActivityPubFollowCollection(
+    data = await getActivityPubFollowCollection(
       username,
       "followers",
       page,
@@ -328,7 +344,7 @@ app.get("/users/:username/following", async (c) => {
   const domain = getDomain(c);
   let data: Record<string, unknown>;
   try {
-    data = await buildActivityPubFollowCollection(
+    data = await getActivityPubFollowCollection(
       username,
       "following",
       page,

--- a/app/api/routes/users.ts
+++ b/app/api/routes/users.ts
@@ -5,7 +5,8 @@ import { createDB } from "../DB/mod.ts";
 import { getEnv } from "../../shared/config.ts";
 import { getDomain } from "../utils/activitypub.ts";
 import { getUserInfo, getUserInfoBatch } from "../services/user-info.ts";
-import { getFormattedFollowInfo } from "../services/follow-info.ts";
+import { formatFollowList } from "../services/follow-info.ts";
+import { getActivityPubFollowCollection } from "./activitypub.ts";
 import authRequired from "../utils/auth.ts";
 
 const app = new Hono();
@@ -84,12 +85,17 @@ app.get("/users/:username/followers", async (c) => {
     const domain = getDomain(c);
     const username = c.req.param("username");
     const env = getEnv(c);
-    const data = await getFormattedFollowInfo(
+    const collection = await getActivityPubFollowCollection(
       username,
       "followers",
+      "1",
       domain,
       env,
     );
+    const list = Array.isArray(collection.orderedItems)
+      ? collection.orderedItems as string[]
+      : [];
+    const data = await formatFollowList(list, domain, env);
     return c.json(data);
   } catch (error) {
     console.error("Error fetching followers:", error);
@@ -106,12 +112,17 @@ app.get("/users/:username/following", async (c) => {
     const domain = getDomain(c);
     const username = c.req.param("username");
     const env = getEnv(c);
-    const data = await getFormattedFollowInfo(
+    const collection = await getActivityPubFollowCollection(
       username,
       "following",
+      "1",
       domain,
       env,
     );
+    const list = Array.isArray(collection.orderedItems)
+      ? collection.orderedItems as string[]
+      : [];
+    const data = await formatFollowList(list, domain, env);
     return c.json(data);
   } catch (error) {
     console.error("Error fetching following:", error);


### PR DESCRIPTION
## Summary
- `activitypub.ts` にフォロー情報取得用関数 `getActivityPubFollowCollection` を追加
- `/api/users/:username/followers` と `/api/users/:username/following` で同関数を利用
- ActivityPub ルートでは同関数経由で処理を統一

## Testing
- `deno fmt`
- `deno lint`


------
https://chatgpt.com/codex/tasks/task_e_6887c53963c48328915ad0f6d3188721