### PR TITLE
NodeInfo ルートの整理

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,10 @@ deno task build
   新しい Activity を追加しやすくしています。
 - `/inbox` – サイト全体の共有 inbox。`to` などにローカルアクターが含まれる
   Activity をそれぞれの inbox 処理へ振り分けます。
+- `/.well-known/nodeinfo` – NodeInfo へのリンクを返します
+- `/nodeinfo/2.0` – NodeInfo 本体を返します
+- `/.well-known/x-nodeinfo2` – `/nodeinfo/2.0` へリダイレクト
+- `/api/v1/instance` – Mastodon 互換のインスタンス情報
 
 これらのルートは `/` 直下に配置されており、`/api` のルートとは競合しません。
 

--- a/app/api/routes/nodeinfo.ts
+++ b/app/api/routes/nodeinfo.ts
@@ -2,10 +2,18 @@ import { Hono } from "hono";
 import { createDB } from "../DB/mod.ts";
 import { getDomain } from "../utils/activitypub.ts";
 import { getEnv } from "../../shared/config.ts";
-// NodeInfo は外部からの参照を想定しているため認証は不要
+// NodeInfo は外部から参照されるため認証は不要
 
 const app = new Hono();
 // app.use("*", authRequired); // 認証ミドルウェアは適用しない
+
+async function getNodeStats(env: Record<string, string>) {
+  const db = createDB(env);
+  const users = await db.countAccounts();
+  const posts = (await db.findObjects({}, {})).length;
+  const version = env["TAKOS_VERSION"] ?? "1.0.0";
+  return { users, posts, version };
+}
 
 app.get("/.well-known/nodeinfo", (c) => {
   const domain = getDomain(c);
@@ -21,11 +29,7 @@ app.get("/.well-known/nodeinfo", (c) => {
 
 app.get("/nodeinfo/2.0", async (c) => {
   const env = getEnv(c);
-  const version = env["TAKOS_VERSION"] ?? "1.0.0";
-  const db = createDB(env);
-  const users = await db.countAccounts();
-  const posts = (await db.findObjects({}, {})).length;
-
+  const { users, posts, version } = await getNodeStats(env);
   return c.json({
     version: "2.0",
     software: {
@@ -46,11 +50,7 @@ app.get("/nodeinfo/2.0", async (c) => {
 app.get("/api/v1/instance", async (c) => {
   const env = getEnv(c);
   const domain = getDomain(c);
-  const version = env["TAKOS_VERSION"] ?? "1.0.0";
-  const db = createDB(env);
-  const userCount = await db.countAccounts();
-  const statusCount = (await db.findObjects({}, {})).length;
-
+  const { users, posts, version } = await getNodeStats(env);
   return c.json({
     uri: domain,
     title: "Takos Instance",
@@ -59,11 +59,7 @@ app.get("/api/v1/instance", async (c) => {
     email: `info@${domain}`,
     version,
     urls: {},
-    stats: {
-      user_count: userCount,
-      status_count: statusCount,
-      domain_count: 1,
-    },
+    stats: { user_count: users, status_count: posts, domain_count: 1 },
     thumbnail: null,
     languages: ["ja"],
     registrations: false,
@@ -72,23 +68,9 @@ app.get("/api/v1/instance", async (c) => {
   });
 });
 
-app.get("/.well-known/x-nodeinfo2", async (c) => {
-  const env = getEnv(c);
-  const version = env["TAKOS_VERSION"] ?? "1.0.0";
-  const db = createDB(env);
-  const users = await db.countAccounts();
-  const posts = (await db.findObjects({}, {})).length;
-
-  return c.json({
-    software: "takos",
-    version,
-    protocols: ["activitypub"],
-    openRegistrations: false,
-    usage: {
-      users: { total: users },
-      localPosts: posts,
-    },
-  });
+app.get("/.well-known/x-nodeinfo2", (c) => {
+  // Misskey 互換のルート。実体は /nodeinfo/2.0 へ統合したためリダイレクトのみ
+  return c.redirect("/nodeinfo/2.0");
 });
 
 export default app;

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -738,3 +738,27 @@ paths:
       responses:
         "200":
           description: ファイルデータ
+  /.well-known/nodeinfo:
+    get:
+      summary: NodeInfo リンク取得
+      responses:
+        "200":
+          description: NodeInfo へのリンクを含む JSON
+  /nodeinfo/2.0:
+    get:
+      summary: NodeInfo 2.0
+      responses:
+        "200":
+          description: サーバー情報を返します
+  /.well-known/x-nodeinfo2:
+    get:
+      summary: NodeInfo2 互換リダイレクト
+      responses:
+        "302":
+          description: /nodeinfo/2.0 へリダイレクト
+  /api/v1/instance:
+    get:
+      summary: インスタンス情報
+      responses:
+        "200":
+          description: Mastodon 互換のインスタンス情報


### PR DESCRIPTION
## Summary
- NodeInfo 関連ルートを `/nodeinfo/2.0` に集約し、`/.well-known/x-nodeinfo2` はリダイレクトのみに変更
- `docs/openapi.yaml` に NodeInfo とインスタンス情報のエンドポイントを追加
- README に新しいエンドポイントを追記

## Testing
- `deno fmt app/api/routes/nodeinfo.ts docs/openapi.yaml README.md`
- `deno lint app/api/routes/nodeinfo.ts`


------
https://chatgpt.com/codex/tasks/task_e_688845e6acbc8328a04934dd93d5fec7