### PR TITLE
Add pemToArrayBuffer utility

### DIFF
--- a/app/api/services/fcm.ts
+++ b/app/api/services/fcm.ts
@@ -1,13 +1,6 @@
 import { createDB } from "../DB/mod.ts";
 import type { DB } from "../../shared/db.ts";
-
-function pemToArrayBuffer(pem: string): ArrayBuffer {
-  const b64 = pem.replace(/-----[^-]+-----/g, "").replace(/\s+/g, "");
-  const binary = atob(b64);
-  const bytes = new Uint8Array(binary.length);
-  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
-  return bytes.buffer;
-}
+import { pemToArrayBuffer } from "../../shared/crypto.ts";
 
 function encodeBase64Url(buf: ArrayBuffer | Uint8Array): string {
   const bytes = buf instanceof ArrayBuffer ? new Uint8Array(buf) : buf;

--- a/app/api/utils/activitypub.ts
+++ b/app/api/utils/activitypub.ts
@@ -1,5 +1,6 @@
 import { createDB } from "../DB/mod.ts";
 import { getEnv } from "../../shared/config.ts";
+import { pemToArrayBuffer } from "../../shared/crypto.ts";
 import { getSystemKey } from "../services/system_actor.ts";
 import type { Context } from "hono";
 
@@ -8,11 +9,6 @@ function base64ToArrayBuffer(base64: string): ArrayBuffer {
   const bytes = new Uint8Array(binary.length);
   for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
   return bytes.buffer;
-}
-
-function pemToArrayBuffer(pem: string): ArrayBuffer {
-  const b64 = pem.replace(/-----[^-]+-----/g, "").replace(/\s+/g, "");
-  return base64ToArrayBuffer(b64);
 }
 
 function arrayBufferToBase64(buf: ArrayBuffer): string {

--- a/app/shared/crypto.ts
+++ b/app/shared/crypto.ts
@@ -15,6 +15,14 @@ export function bufferToPem(
   return `-----BEGIN ${type}-----\n${lines}\n-----END ${type}-----`;
 }
 
+export function pemToArrayBuffer(pem: string): ArrayBuffer {
+  const b64 = pem.replace(/-----[^-]+-----/g, "").replace(/\s+/g, "");
+  const binary = atob(b64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return bytes.buffer;
+}
+
 export async function generateKeyPair() {
   const pair = await crypto.subtle.generateKey(
     {


### PR DESCRIPTION
## Summary
- 共有の暗号ユーティリティに `pemToArrayBuffer()` を追加
- ActivityPub ユーティリティと FCM サービスで共通関数を利用するよう修正

## Testing
- `deno fmt app/api/services/fcm.ts app/api/utils/activitypub.ts app/shared/crypto.ts`
- `deno lint app/api/services/fcm.ts app/api/utils/activitypub.ts app/shared/crypto.ts`


------
https://chatgpt.com/codex/tasks/task_e_68884652e6b883288c84ef3557d98e43