### PR TITLE
統一されたSHA-256ハッシュ処理

### DIFF
--- a/app/api/routes/setup_ui.ts
+++ b/app/api/routes/setup_ui.ts
@@ -5,7 +5,7 @@ import { join } from "jsr:@std/path";
 import { createDB } from "../DB/mod.ts";
 import { getEnv } from "../../shared/config.ts";
 import authRequired from "../utils/auth.ts";
-import { generateKeyPair, sha256Hex } from "../../shared/crypto.ts";
+import { generateKeyPair, hashSha256 } from "../../shared/crypto.ts";
 
 const app = new Hono();
 app.use("/setup", authRequired);
@@ -28,7 +28,7 @@ app.post("/setup", async (c) => {
   }
 
   const salt = crypto.randomUUID().replace(/-/g, "");
-  const hashed = await sha256Hex(password + salt);
+  const hashed = await hashSha256(password + salt);
   env.hashedPassword = hashed;
   env.salt = salt;
 

--- a/app/client/src/utils/crypto.ts
+++ b/app/client/src/utils/crypto.ts
@@ -1,4 +1,5 @@
 import { hashSync } from "bcryptjs";
+import { hashSha256 } from "../../../shared/crypto.ts";
 
 export const encryptWithPassword = async (
   data: string,
@@ -68,14 +69,6 @@ export const decryptWithPassword = async (
   }
 };
 
-export const sha256 = async (text: string): Promise<string> => {
-  const data = new TextEncoder().encode(text);
-  const hash = await crypto.subtle.digest("SHA-256", data);
-  return Array.from(new Uint8Array(hash))
-    .map((b) => b.toString(16).padStart(2, "0"))
-    .join("");
-};
-
 const ENCRYPTION_PASS_SALT = "takos";
 const BCRYPT_SALT = "$2b$10$GxW5ntweCe9L1LiK1roc/3";
 
@@ -88,3 +81,5 @@ export const hashEncryptionPassword = (
 ): string => {
   return hashSync(ENCRYPTION_PASS_SALT + password, BCRYPT_SALT);
 };
+
+export { hashSha256 };

--- a/app/shared/crypto.ts
+++ b/app/shared/crypto.ts
@@ -1,4 +1,4 @@
-export async function sha256Hex(text: string): Promise<string> {
+export async function hashSha256(text: string): Promise<string> {
   const buf = new TextEncoder().encode(text);
   const hash = await crypto.subtle.digest("SHA-256", buf);
   return Array.from(new Uint8Array(hash))


### PR DESCRIPTION
## 概要
- 共有モジュールのハッシュ関数を `hashSha256` に変更
- クライアント側から独自実装を削除し、共有関数を再利用
- ルートセットアップ処理の呼び出しを修正

## テスト
- `deno fmt` を実行しフォーマットを確認
- `deno lint` を実行し警告がないことを確認

------
https://chatgpt.com/codex/tasks/task_e_6888465ff7588328a5a686e840712c97