### PR TITLE
Add shared Base64 helpers and refactor usage

### DIFF
--- a/app/api/routes/activitypub.ts
+++ b/app/api/routes/activitypub.ts
@@ -5,6 +5,7 @@ import { buildActivityPubFollowCollection } from "../services/follow-info.ts";
 
 import { activityHandlers } from "../activity_handlers.ts";
 import { getSystemKey } from "../services/system_actor.ts";
+import { b64ToBuf } from "../../shared/base64.ts";
 
 import {
   buildActivityFromStored,
@@ -146,9 +147,7 @@ app.get("/users/:username/avatar", async (c) => {
     const match = icon.match(/^data:(image\/[^;]+);base64,(.+)$/);
     if (match) {
       const [, type, data] = match;
-      const binary = atob(data);
-      const bytes = new Uint8Array(binary.length);
-      for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+      const bytes = b64ToBuf(data);
       return c.body(bytes, 200, { "content-type": type });
     }
   }

--- a/app/api/routes/files.ts
+++ b/app/api/routes/files.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 import { extname } from "@std/path";
 import authRequired from "../utils/auth.ts";
 import { getEnv } from "../../shared/config.ts";
+import { b64ToBuf } from "../../shared/base64.ts";
 import {
   getFile,
   getMessageAttachment,
@@ -46,10 +47,7 @@ app.post("/files", async (c) => {
     if (typeof content !== "string") {
       return c.json({ error: "invalid body" }, 400);
     }
-    const bin = atob(content);
-    const buf = new Uint8Array(bin.length);
-    for (let i2 = 0; i2 < bin.length; i2++) buf[i2] = bin.charCodeAt(i2);
-    bytes = buf;
+    bytes = b64ToBuf(content);
     mediaType = typeof mt === "string" ? mt : mediaType;
     key = typeof k === "string" ? k : undefined;
     iv = typeof i === "string" ? i : undefined;

--- a/app/api/services/file.ts
+++ b/app/api/services/file.ts
@@ -1,5 +1,6 @@
 import { createDB } from "../DB/mod.ts";
 import { createStorage, type ObjectStorage } from "./object-storage.ts";
+import { b64ToBuf } from "../../shared/base64.ts";
 
 let storage: ObjectStorage | undefined;
 
@@ -52,10 +53,7 @@ export async function getFile(
   if (storageKey) {
     data = await storage!.get(storageKey);
   } else if (typeof doc.content === "string") {
-    const bin = atob(doc.content);
-    const bytes = new Uint8Array(bin.length);
-    for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
-    data = bytes;
+    data = b64ToBuf(doc.content);
   }
   if (!data) return null;
   return { data, mediaType };
@@ -79,8 +77,6 @@ export async function getMessageAttachment(
   const mediaType = typeof att.mediaType === "string"
     ? att.mediaType
     : "application/octet-stream";
-  const bin = atob(content);
-  const bytes = new Uint8Array(bin.length);
-  for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+  const bytes = b64ToBuf(content);
   return { data: bytes, mediaType };
 }

--- a/app/api/utils/activitypub.ts
+++ b/app/api/utils/activitypub.ts
@@ -3,20 +3,7 @@ import { getEnv } from "../../shared/config.ts";
 import { pemToArrayBuffer } from "../../shared/crypto.ts";
 import { getSystemKey } from "../services/system_actor.ts";
 import type { Context } from "hono";
-
-function base64ToArrayBuffer(base64: string): ArrayBuffer {
-  const binary = atob(base64);
-  const bytes = new Uint8Array(binary.length);
-  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
-  return bytes.buffer;
-}
-
-function arrayBufferToBase64(buf: ArrayBuffer): string {
-  const bytes = new Uint8Array(buf);
-  let binary = "";
-  for (const b of bytes) binary += String.fromCharCode(b);
-  return btoa(binary);
-}
+import { b64ToBuf, bufToB64 } from "../../shared/base64.ts";
 
 async function applySignature(
   method: string,
@@ -35,7 +22,7 @@ async function applySignature(
 
   let digest = "";
   if (headersToSign.includes("digest")) {
-    const digestValue = arrayBufferToBase64(
+    const digestValue = bufToB64(
       await crypto.subtle.digest("SHA-256", encoder.encode(body)),
     );
     digest = `SHA-256=${digestValue}`;
@@ -69,7 +56,7 @@ async function applySignature(
     cryptoKey,
     encoder.encode(signingString),
   );
-  const signatureB64 = arrayBufferToBase64(signature);
+  const signatureB64 = bufToB64(signature);
   const keyId = `${key.id}#main-key`;
   headers.set(
     "Signature",
@@ -268,7 +255,7 @@ export async function verifyDigest(
   const digestHeader = req.headers.get("digest");
   if (!digestHeader) return true;
   const encoder = new TextEncoder();
-  const expectedDigest = arrayBufferToBase64(
+  const expectedDigest = bufToB64(
     await crypto.subtle.digest("SHA-256", encoder.encode(body)),
   );
   return digestHeader === `SHA-256=${expectedDigest}`;
@@ -333,7 +320,7 @@ export async function verifyHttpSignature(
       ["verify"],
     );
 
-    const signatureBytes = base64ToArrayBuffer(params.signature);
+    const signatureBytes = b64ToBuf(params.signature);
     const signingStringBytes = encoder.encode(signingString);
 
     const verified = await crypto.subtle.verify(

--- a/app/client/src/components/Chat.tsx
+++ b/app/client/src/components/Chat.tsx
@@ -53,6 +53,7 @@ import { ChatTitleBar } from "./chat/ChatTitleBar.tsx";
 import { ChatMessageList } from "./chat/ChatMessageList.tsx";
 import { ChatSendForm } from "./chat/ChatSendForm.tsx";
 import type { ActorID, ChatMessage, ChatRoom } from "./chat/types.ts";
+import { b64ToBuf, bufToB64 } from "../../../shared/base64.ts";
 
 function adjustHeight(el?: HTMLTextAreaElement) {
   if (el) {
@@ -61,19 +62,9 @@ function adjustHeight(el?: HTMLTextAreaElement) {
   }
 }
 
-function bufToB64(buf: ArrayBuffer): string {
-  const u8 = new Uint8Array(buf);
-  return btoa(String.fromCharCode(...u8));
-}
-
 function bufToUrl(buf: ArrayBuffer, type: string): string {
   const blob = new Blob([buf], { type });
   return URL.createObjectURL(blob);
-}
-
-function b64ToBuf(b64: string): Uint8Array {
-  const bin = atob(b64);
-  return Uint8Array.from(bin, (c) => c.charCodeAt(0));
 }
 
 // ActivityPub の Note 形式のテキストから content を取り出す

--- a/app/client/src/components/e2ee/mls.ts
+++ b/app/client/src/components/e2ee/mls.ts
@@ -1,4 +1,5 @@
 // MLSヘルパー関数の継続実装
+import { b64ToBuf, bufToB64 } from "../../../shared/base64.ts";
 
 type ActorID = string;
 
@@ -22,7 +23,7 @@ export const generateMLSKeyPair = async (): Promise<MLSKeyPair> => {
     ["deriveKey"],
   );
   const raw = await crypto.subtle.exportKey("raw", keyPair.publicKey);
-  const pub = btoa(String.fromCharCode(...new Uint8Array(raw)));
+  const pub = bufToB64(raw);
   return { publicKey: pub, privateKey: keyPair.privateKey };
 };
 
@@ -88,16 +89,6 @@ export const createMLSGroup = async (
 
 function strToBuf(str: string): Uint8Array {
   return new TextEncoder().encode(str);
-}
-
-function bufToB64(buf: ArrayBuffer): string {
-  const u8 = new Uint8Array(buf);
-  return btoa(String.fromCharCode(...u8));
-}
-
-function b64ToBuf(b64: string): Uint8Array {
-  const bin = atob(b64);
-  return Uint8Array.from(bin, (c) => c.charCodeAt(0));
 }
 
 /**

--- a/app/client/src/utils/crypto.ts
+++ b/app/client/src/utils/crypto.ts
@@ -1,4 +1,5 @@
 import { hashSync } from "bcryptjs";
+import { b64ToBuf, bufToB64 } from "../../shared/base64.ts";
 
 export const encryptWithPassword = async (
   data: string,
@@ -26,9 +27,8 @@ export const encryptWithPassword = async (
     key,
     enc.encode(data),
   );
-  const result = [salt, iv, new Uint8Array(encrypted)].map((u8) =>
-    btoa(String.fromCharCode(...u8))
-  ).join(":");
+  const result = [salt, iv, new Uint8Array(encrypted)].map((u8) => bufToB64(u8))
+    .join(":");
   return result;
 };
 
@@ -38,9 +38,9 @@ export const decryptWithPassword = async (
 ): Promise<string | null> => {
   const [s, i, d] = data.split(":");
   if (!s || !i || !d) return null;
-  const salt = Uint8Array.from(atob(s), (c) => c.charCodeAt(0));
-  const iv = Uint8Array.from(atob(i), (c) => c.charCodeAt(0));
-  const encData = Uint8Array.from(atob(d), (c) => c.charCodeAt(0));
+  const salt = b64ToBuf(s);
+  const iv = b64ToBuf(i);
+  const encData = b64ToBuf(d);
   const enc = new TextEncoder();
   const keyMaterial = await crypto.subtle.importKey(
     "raw",

--- a/app/client/src/utils/firebase.ts
+++ b/app/client/src/utils/firebase.ts
@@ -8,6 +8,7 @@ import {
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { apiFetch } from "./config.ts";
+import { b64ToBuf } from "../../shared/base64.ts";
 
 const swUrl = new URL("../firebase-messaging-sw.ts", import.meta.url).href;
 
@@ -19,7 +20,7 @@ function isValidVapidKey(key: string): boolean {
   try {
     const base64 = key.replace(/-/g, "+").replace(/_/g, "/");
     const padded = base64 + "=".repeat((4 - base64.length % 4) % 4);
-    const bin = atob(padded);
+    const bin = b64ToBuf(padded);
     return bin.length === 65;
   } catch {
     return false;

--- a/app/shared/base64.ts
+++ b/app/shared/base64.ts
@@ -1,0 +1,9 @@
+export function bufToB64(buf: ArrayBuffer | Uint8Array): string {
+  const bytes = buf instanceof ArrayBuffer ? new Uint8Array(buf) : buf;
+  return btoa(String.fromCharCode(...bytes));
+}
+
+export function b64ToBuf(b64: string): Uint8Array {
+  const bin = atob(b64);
+  return Uint8Array.from(bin, (c) => c.charCodeAt(0));
+}

--- a/app/shared/crypto.ts
+++ b/app/shared/crypto.ts
@@ -1,3 +1,5 @@
+import { b64ToBuf, bufToB64 } from "./base64.ts";
+
 export async function sha256Hex(text: string): Promise<string> {
   const buf = new TextEncoder().encode(text);
   const hash = await crypto.subtle.digest("SHA-256", buf);
@@ -10,17 +12,14 @@ export function bufferToPem(
   buffer: ArrayBuffer,
   type: "PRIVATE KEY" | "PUBLIC KEY",
 ) {
-  const b64 = btoa(String.fromCharCode(...new Uint8Array(buffer)));
+  const b64 = bufToB64(buffer);
   const lines = b64.match(/.{1,64}/g)?.join("\n") ?? b64;
   return `-----BEGIN ${type}-----\n${lines}\n-----END ${type}-----`;
 }
 
 export function pemToArrayBuffer(pem: string): ArrayBuffer {
   const b64 = pem.replace(/-----[^-]+-----/g, "").replace(/\s+/g, "");
-  const binary = atob(b64);
-  const bytes = new Uint8Array(binary.length);
-  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
-  return bytes.buffer;
+  return b64ToBuf(b64).buffer;
 }
 
 export async function generateKeyPair() {


### PR DESCRIPTION
## Summary
- 共通モジュール `app/shared/base64.ts` を新設し `bufToB64`・`b64ToBuf` を追加
- 既存の重複実装を削除し新モジュールをインポート
- ファイル送受信やMLS処理など他の箇所も同様の変換処理を共通化

## Testing
- `deno fmt`
- `deno lint`

------
https://chatgpt.com/codex/tasks/task_e_6888492cb7308328857c49a31bed64c0