### PR TITLE
Update AP follow URIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,9 +107,10 @@ deno task build
 - `/.well-known/nodeinfo` – NodeInfo へのリンクを返します
 - `/nodeinfo/2.0` – NodeInfo 本体を返します
 - `/.well-known/x-nodeinfo2` – `/nodeinfo/2.0` へリダイレクト
-- `/api/v1/instance` – Mastodon 互換のインスタンス情報
-
-これらのルートは `/` 直下に配置されており、`/api` のルートとは競合しません。
+- `/api/v1/instance` – Mastodon 互換のインスタンス情報 これらのルートは `/`
+  直下に配置されており、`/api` のルートとは競合しません。
+  フォロー一覧用のコレクションは `/ap/users/:username/followers` や
+  `/ap/users/:username/following` から取得できます。
 
 `outbox` へ `POST` すると以下の形式でノートを作成できます。
 
@@ -127,9 +128,9 @@ deno task build
 - `GET /api/users/:username/followers` – フォロワー一覧を JSON で取得
 - `GET /api/users/:username/following` – フォロー中ユーザー一覧を JSON で取得
 
-ActivityPub 形式の一覧が必要な場合は、`/activitypub/users/:username/followers`
-や `/activitypub/users/:username/following` を利用します。こちらは
-`OrderedCollection` 形式で返され、ページングに対応しています。
+ActivityPub 形式の一覧が必要な場合は、`/ap/users/:username/followers` や
+`/ap/users/:username/following` を利用します。こちらは `OrderedCollection`
+形式で返され、ページングに対応しています。
 
 ## JSON 投稿 API
 

--- a/activitypub-e2ee/mls.html
+++ b/activitypub-e2ee/mls.html
@@ -1478,8 +1478,8 @@
               "name": "Alyssa P. Hacker",
               "inbox": "https://example.com/users/alyssa/inbox",
               "outbox": "https://example.com/users/alyssa/outbox",
-              "followers": "https://example.com/users/alyssa/followers",
-              "following": "https://example.com/users/alyssa/following",
+              "followers": "https://example.com/ap/users/alyssa/followers",
+              "following": "https://example.com/ap/users/alyssa/following",
               "liked": "https://example.com/users/alyssa/liked",
               "keyPackages": "https://example.com/users/alyssa/key"
             }

--- a/app/api/routes/activitypub.ts
+++ b/app/api/routes/activitypub.ts
@@ -284,11 +284,11 @@ app.post("/users/:username/inbox", async (c) => {
   return jsonResponse(c, { status: "ok" }, 200, "application/activity+json");
 });
 
-app.get("/users/:username/followers", async (c) => {
+app.get("/ap/users/:username/followers", async (c) => {
   const username = c.req.param("username");
   if (username === "system") {
     const domain = getDomain(c);
-    const baseId = `https://${domain}/users/system/followers`;
+    const baseId = `https://${domain}/ap/users/system/followers`;
     return jsonResponse(
       c,
       {
@@ -320,11 +320,11 @@ app.get("/users/:username/followers", async (c) => {
   return jsonResponse(c, data, 200, "application/activity+json");
 });
 
-app.get("/users/:username/following", async (c) => {
+app.get("/ap/users/:username/following", async (c) => {
   const username = c.req.param("username");
   if (username === "system") {
     const domain = getDomain(c);
-    const baseId = `https://${domain}/users/system/following`;
+    const baseId = `https://${domain}/ap/users/system/following`;
     return jsonResponse(
       c,
       {

--- a/app/api/services/follow-info.ts
+++ b/app/api/services/follow-info.ts
@@ -92,7 +92,7 @@ export async function buildActivityPubFollowCollection(
   dbInst?: DB,
 ): Promise<Record<string, unknown>> {
   const list = await getFollowList(username, type, env, dbInst);
-  const baseId = `https://${domain}/users/${username}/${type}`;
+  const baseId = `https://${domain}/ap/users/${username}/${type}`;
   if (page) {
     return {
       "@context": "https://www.w3.org/ns/activitystreams",

--- a/app/api/utils/activitypub.ts
+++ b/app/api/utils/activitypub.ts
@@ -535,8 +535,8 @@ export function createActor(
     },
     inbox: `https://${domain}/users/${account.userName}/inbox`,
     outbox: `https://${domain}/users/${account.userName}/outbox`,
-    followers: `https://${domain}/users/${account.userName}/followers`,
-    following: `https://${domain}/users/${account.userName}/following`,
+    followers: `https://${domain}/ap/users/${account.userName}/followers`,
+    following: `https://${domain}/ap/users/${account.userName}/following`,
     publicKey: {
       id: `https://${domain}/users/${account.userName}#main-key`,
       owner: `https://${domain}/users/${account.userName}`,
@@ -659,7 +659,7 @@ export function createCreateActivity(
     actor,
     object,
     to: ["https://www.w3.org/ns/activitystreams#Public"],
-    cc: [`https://${domain}/users/${actor.split("/").pop()}/followers`],
+    cc: [`https://${domain}/ap/users/${actor.split("/").pop()}/followers`],
   };
 }
 


### PR DESCRIPTION
## Summary
- ActivityPubのフォロー関連エンドポイントを `/ap` プレフィックスへ移動
- 各所のURI参照を更新
- ドキュメントも新しいURIに合わせて修正

## Testing
- `deno fmt`
- `deno lint`


------
https://chatgpt.com/codex/tasks/task_e_68885378071c8328aead7f1c0bb27109