### PR TITLE
Update keyPackage route path

### DIFF
--- a/app/api/routes/activitypub.ts
+++ b/app/api/routes/activitypub.ts
@@ -122,7 +122,7 @@ app.get("/users/:username", async (c) => {
     id: `https://${domain}/users/${username}/keyPackages`,
     totalItems: packages.length,
     items: packages.map((p) =>
-      `https://${domain}/users/${username}/keyPackage/${p._id}`
+      `https://${domain}/users/${username}/keyPackages/${p._id}`
     ),
   };
   return jsonResponse(c, actor, 200, "application/activity+json");

--- a/app/api/routes/e2ee.ts
+++ b/app/api/routes/e2ee.ts
@@ -111,7 +111,7 @@ app.get("/users/:user/keyPackages", async (c) => {
     const db = createDB(getEnv(c));
     const list = await db.listKeyPackages(username) as KeyPackageDoc[];
     const items = list.map((doc) => ({
-      id: `https://${domain}/users/${username}/keyPackage/${doc._id}`,
+      id: `https://${domain}/users/${username}/keyPackages/${doc._id}`,
       type: "KeyPackage",
       content: doc.content,
       mediaType: doc.mediaType,
@@ -148,7 +148,7 @@ app.get("/users/:user/keyPackages", async (c) => {
   }
 });
 
-app.get("/users/:user/keyPackage/:keyId", async (c) => {
+app.get("/users/:user/keyPackages/:keyId", async (c) => {
   const user = c.req.param("user");
   const keyId = c.req.param("keyId");
   const domain = getDomain(c);
@@ -160,7 +160,7 @@ app.get("/users/:user/keyPackage/:keyId", async (c) => {
       "https://www.w3.org/ns/activitystreams",
       "https://purl.archive.org/socialweb/mls",
     ],
-    id: `https://${domain}/users/${user}/keyPackage/${keyId}`,
+    id: `https://${domain}/users/${user}/keyPackages/${keyId}`,
     type: "KeyPackage",
     attributedTo: `https://${domain}/users/${user}`,
     to: ["https://www.w3.org/ns/activitystreams#Public"],
@@ -191,7 +191,7 @@ app.post("/users/:user/keyPackages", authRequired, async (c) => {
       "https://www.w3.org/ns/activitystreams",
       "https://purl.archive.org/socialweb/mls",
     ],
-    id: `https://${domain}/users/${user}/keyPackage/${pkg._id}`,
+    id: `https://${domain}/users/${user}/keyPackages/${pkg._id}`,
     type: "KeyPackage",
     attributedTo: actorId,
     to: ["https://www.w3.org/ns/activitystreams#Public"],
@@ -214,12 +214,12 @@ app.delete("/users/:user/keyPackages/:keyId", authRequired, async (c) => {
   const removeActivity = createRemoveActivity(
     domain,
     actorId,
-    `https://${domain}/users/${user}/keyPackage/${keyId}`,
+    `https://${domain}/users/${user}/keyPackages/${keyId}`,
   );
   const deleteActivity = createDeleteActivity(
     domain,
     actorId,
-    `https://${domain}/users/${user}/keyPackage/${keyId}`,
+    `https://${domain}/users/${user}/keyPackages/${keyId}`,
   );
   await deliverToFollowers(getEnv(c), user, removeActivity, domain);
   await deliverToFollowers(getEnv(c), user, deleteActivity, domain);
@@ -262,12 +262,12 @@ app.post("/users/:user/resetKeys", authRequired, async (c) => {
     const removeActivity = createRemoveActivity(
       domain,
       actorId,
-      `https://${domain}/users/${user}/keyPackage/${pkg._id}`,
+      `https://${domain}/users/${user}/keyPackages/${pkg._id}`,
     );
     const deleteActivity = createDeleteActivity(
       domain,
       actorId,
-      `https://${domain}/users/${user}/keyPackage/${pkg._id}`,
+      `https://${domain}/users/${user}/keyPackages/${pkg._id}`,
     );
     await deliverToFollowers(getEnv(c), user, removeActivity, domain);
     await deliverToFollowers(getEnv(c), user, deleteActivity, domain);


### PR DESCRIPTION
## Summary
- `/users/:user/keyPackage/:keyId` を `/users/:user/keyPackages/:keyId` に変更
- 関連するURL生成箇所を修正
- ActivityPub 用 actor 情報内の KeyPackage URL を更新

## Testing
- `deno fmt app/api/routes/e2ee.ts app/api/routes/activitypub.ts app/client/src/components/e2ee/api.ts`
- `deno lint app/api/routes/e2ee.ts app/api/routes/activitypub.ts app/client/src/components/e2ee/api.ts`

------
https://chatgpt.com/codex/tasks/task_e_688853925db4832880c971be4ad5fcbe