### PR TITLE
Add story API routes and documentation

### DIFF
--- a/app/api/server.ts
+++ b/app/api/server.ts
@@ -9,6 +9,7 @@ import accounts from "./routes/accounts.ts";
 import notifications from "./routes/notifications.ts";
 import activitypub from "./routes/activitypub.ts";
 import posts from "./routes/posts.ts";
+import stories from "./routes/stories.ts";
 import search from "./routes/search.ts";
 import users from "./routes/users.ts";
 import follow from "./routes/follow.ts";
@@ -56,6 +57,7 @@ export async function createTakosApp(env?: Record<string, string>) {
     follow,
     notifications,
     posts,
+    stories,
     config,
     fcm,
     setupUI,

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -414,6 +414,69 @@ paths:
       responses:
         "200":
           description: 再生数
+  /api/stories:
+    get:
+      summary: ストーリー一覧取得
+      responses:
+        "200":
+          description: ストーリーの配列
+    post:
+      summary: ストーリー作成
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                author:
+                  type: string
+                content:
+                  type: string
+                mediaUrl:
+                  type: string
+                mediaType:
+                  type: string
+                backgroundColor:
+                  type: string
+                textColor:
+                  type: string
+              required:
+                - author
+                - content
+      responses:
+        "201":
+          description: 作成されたストーリー
+  /api/stories/{id}/view:
+    post:
+      summary: ストーリー閲覧
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: 閲覧後のストーリー
+  /api/stories/{id}:
+    delete:
+      summary: ストーリー削除
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: 成功
+  /api/stories/cleanup:
+    delete:
+      summary: 期限切れストーリー削除
+      responses:
+        "200":
+          description: 削除件数を含むメッセージ
   /api/search:
     get:
       summary: 検索


### PR DESCRIPTION
## Summary
- サーバーにストーリー用ルートを組み込み
- Story API を OpenAPI 仕様に追記

## Testing
- `deno fmt app/api/server.ts`
- `deno lint app/api/server.ts`

------
https://chatgpt.com/codex/tasks/task_e_688853a8daa48328bc12a0e539e1c9ca