### PR TITLE
URL 判定関数の共通化

### DIFF
--- a/app/api/services/user-info.ts
+++ b/app/api/services/user-info.ts
@@ -1,15 +1,7 @@
 import { createDB } from "../DB/mod.ts";
 import type { DB } from "../../shared/db.ts";
 import { resolveActor } from "../utils/activitypub.ts";
-
-function isUrl(value: string): boolean {
-  try {
-    new URL(value);
-    return true;
-  } catch {
-    return false;
-  }
-}
+import { isUrl } from "../../shared/url.ts";
 
 export interface UserInfo {
   userName: string;

--- a/app/client/src/utils/url.ts
+++ b/app/client/src/utils/url.ts
@@ -1,9 +1,1 @@
-export function isUrl(value?: string): boolean {
-  if (!value) return false;
-  try {
-    const url = new URL(value.trim());
-    return url.protocol === "http:" || url.protocol === "https:";
-  } catch {
-    return false;
-  }
-}
+export { isUrl } from "../../../shared/url.ts";

--- a/app/shared/url.ts
+++ b/app/shared/url.ts
@@ -1,0 +1,9 @@
+export function isUrl(value?: string): boolean {
+  if (!value) return false;
+  try {
+    const url = new URL(value.trim());
+    return url.protocol === "http:" || url.protocol === "https:";
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary
- `isUrl` 関数を `app/shared/url.ts` として追加
- `user-info.ts` とフロントエンドで共通モジュールを利用

## Testing
- `deno fmt --check app/shared/url.ts app/api/services/user-info.ts app/client/src/utils/url.ts`
- `deno lint app/shared/url.ts app/api/services/user-info.ts app/client/src/utils/url.ts`


------
https://chatgpt.com/codex/tasks/task_e_688856019c6883289896fdbba21bbcd4