### PR TITLE
Implement Pixelfed Stories basic support

### DIFF
--- a/app/api/utils/bearcap.ts
+++ b/app/api/utils/bearcap.ts
@@ -1,0 +1,31 @@
+export interface BearcapInfo {
+  url: string;
+  token: string;
+}
+
+export function parseBearcap(uri: string): BearcapInfo | null {
+  if (!uri.startsWith("bear:")) return null;
+  const query = uri.slice(5).replace(/^\/+/, "");
+  const params = new URLSearchParams(
+    query.startsWith("?") ? query.slice(1) : query,
+  );
+  const url = params.get("u");
+  const token = params.get("t") ?? "";
+  if (!url) return null;
+  return { url: decodeURIComponent(url), token };
+}
+
+export async function fetchBearcap(uri: string): Promise<Uint8Array | null> {
+  const info = parseBearcap(uri);
+  if (!info) return null;
+  try {
+    const res = await fetch(info.url, {
+      headers: info.token ? { Authorization: `Bearer ${info.token}` } : {},
+    });
+    if (!res.ok) return null;
+    const buf = await res.arrayBuffer();
+    return new Uint8Array(buf);
+  } catch {
+    return null;
+  }
+}

--- a/app/client/src/components/Microblog.tsx
+++ b/app/client/src/components/Microblog.tsx
@@ -186,7 +186,10 @@ export function Microblog() {
     return user ? fetchFollowingPosts(user.userName) : Promise.resolve([]);
   });
 
-  const [stories, { refetch: refetchStories }] = createResource(fetchStories);
+  const [stories, { refetch: refetchStories }] = createResource(() => {
+    const user = account();
+    return user ? fetchStories(user.userName) : Promise.resolve([]);
+  });
   const [selectedStory, setSelectedStory] = createSignal<Story | null>(null);
   const [showStoryViewer, setShowStoryViewer] = createSignal(false);
   const [currentStoryIndex, setCurrentStoryIndex] = createSignal(0);

--- a/app/client/src/components/microblog/api.ts
+++ b/app/client/src/components/microblog/api.ts
@@ -283,9 +283,11 @@ export const _replyToPost = async (
   }
 };
 
-export const fetchStories = async (): Promise<Story[]> => {
+export const fetchStories = async (username: string): Promise<Story[]> => {
   try {
-    const response = await apiFetch("/api/stories");
+    const response = await apiFetch(
+      `/api/stories/${encodeURIComponent(username)}`,
+    );
     if (!response.ok) {
       throw new Error("Failed to fetch stories");
     }


### PR DESCRIPTION
## Summary
- add bearcap utility for media fetching
- handle Add/Delete Story activities
- expose story list per actor and deliver Add activity when creating
- adapt frontend to new API

## Testing
- `deno fmt`
- `deno lint`


------
https://chatgpt.com/codex/tasks/task_e_6888bb884b8c8328b1ac21e976ffa777