### PR TITLE
Remove API route for story context

### DIFF
--- a/app/api/story-context-multi.jsonld
+++ b/app/api/story-context-multi.jsonld
@@ -1,0 +1,23 @@
+{
+  "@context": {
+    "sto": "https://github.com/takoserver/takos/ns/story#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "Story": { "@id": "sto:Story", "@type": "@id" },
+    "StoryElement": { "@id": "sto:StoryElement", "@type": "@id" },
+    "elements": { "@id": "sto:elements", "@type": "@set" },
+    "mediaUrl": { "@id": "sto:mediaUrl", "@type": "@id" },
+    "mediaType": { "@id": "sto:mediaType", "@type": "xsd:string" },
+    "expiresAt": { "@id": "sto:expiresAt", "@type": "xsd:dateTime" },
+    "backgroundColor": { "@id": "sto:backgroundColor", "@type": "xsd:string" },
+    "textColor": { "@id": "sto:textColor", "@type": "xsd:string" },
+    "viewCount": { "@id": "sto:viewCount", "@type": "xsd:integer" },
+    "x": { "@id": "sto:x", "@type": "xsd:double" },
+    "y": { "@id": "sto:y", "@type": "xsd:double" },
+    "width": { "@id": "sto:width", "@type": "xsd:double" },
+    "height": { "@id": "sto:height", "@type": "xsd:double" },
+    "start": { "@id": "sto:start", "@type": "xsd:double" },
+    "duration": { "@id": "sto:duration", "@type": "xsd:double" },
+    "text": { "@id": "sto:text", "@type": "xsd:string" },
+    "color": { "@id": "sto:color", "@type": "xsd:string" }
+  }
+}

--- a/docs/story.md
+++ b/docs/story.md
@@ -13,7 +13,7 @@ json
 編集する
 {
   "@context": {
-    "sto": "https://takos.dev/ns/story#",
+    "sto": "https://github.com/takoserver/takos/ns/story#",
     "xsd": "http://www.w3.org/2001/XMLSchema#",
     "Story": { "@id": "sto:Story", "@type": "@id" },
     "StoryElement": { "@id": "sto:StoryElement", "@type": "@id" },
@@ -43,7 +43,7 @@ json
 {
   "@context": [
     "https://www.w3.org/ns/activitystreams",
-    "https://github.com/takoserver/takos/blob/master/docs/story.md"
+    "https://raw.githubusercontent.com/takoserver/takos/master/app/api/story-context-multi.jsonld"
   ],
   "id": "https://example.com/story/456",
   "type": ["Story", "Image", "Object"],
@@ -92,7 +92,7 @@ json
 3. Takos への実装のポイント
 データ構造の変更 – Story オブジェクトに elements 配列を追加し、それぞれの要素を type・mediaUrl・text・位置情報とともに保存します。既存の content・mediaUrl・mediaType フィールドは廃止し、elements に統一することを推奨します。移行期は elements から mediaUrl などを生成する処理を入れても良いでしょう。
 
-JSON‑LD コンテキストの更新 – 新しいコンテキスト（例: story-context-multi.jsonld）を Takos サーバーに追加し、@context 配列で参照できるようにします。要素の type は ActivityStreams の Image や Video、Text にフォールバックさせることで互換性を保ちます
+JSON‑LD コンテキストの更新 – 新しいコンテキスト（例: story-context-multi.jsonld）を GitHub リポジトリに追加し、@context 配列で参照できるようにします。要素の type は ActivityStreams の Image や Video、Text にフォールバックさせることで互換性を保ちます
 w3.org
 。
 


### PR DESCRIPTION
## Summary
- Story コンテキスト定義の URL を `takos.dev` から GitHub へ変更
- ドキュメント中の参照先も `raw.githubusercontent.com` に更新

## Testing
- `deno fmt app/api/story-context-multi.jsonld docs/story.md`
- `deno lint app/api/server.ts`


------
https://chatgpt.com/codex/tasks/task_e_6888e273b2bc832894a7f8ec4998afb3