### PR TITLE
DBを型別コレクションに分割

### DIFF
--- a/app/api/models/takos/story.ts
+++ b/app/api/models/takos/story.ts
@@ -1,0 +1,23 @@
+import mongoose from "mongoose";
+
+const storySchema = new mongoose.Schema({
+  _id: { type: String },
+  attributedTo: { type: String, required: true },
+  actor_id: { type: String, required: true, index: true },
+  content: { type: String, default: "" },
+  extra: { type: mongoose.Schema.Types.Mixed, default: {} },
+  published: { type: Date, default: Date.now },
+  created_at: { type: Date, default: Date.now },
+  updated_at: { type: Date, default: Date.now },
+  deleted_at: { type: Date },
+  aud: {
+    to: { type: [String], default: [] },
+    cc: { type: [String], default: [] },
+  },
+});
+
+const Story = mongoose.models.Story ??
+  mongoose.model("Story", storySchema, "stories");
+
+export default Story;
+export { storySchema };

--- a/app/api/models/takos_host/message.ts
+++ b/app/api/models/takos_host/message.ts
@@ -1,0 +1,27 @@
+import mongoose from "mongoose";
+
+const messageSchema = new mongoose.Schema({
+  _id: {
+    type: String,
+    default: () => new mongoose.Types.ObjectId().toString(),
+  },
+  attributedTo: { type: String, required: true },
+  actor_id: { type: String, required: true, index: true },
+  content: { type: String, default: "" },
+  extra: { type: mongoose.Schema.Types.Mixed, default: {} },
+  published: { type: Date, default: Date.now },
+  tenant_id: { type: String, index: true },
+  created_at: { type: Date, default: Date.now },
+  updated_at: { type: Date, default: Date.now },
+  deleted_at: { type: Date },
+  aud: {
+    to: { type: [String], default: [] },
+    cc: { type: [String], default: [] },
+  },
+});
+
+const HostMessage = mongoose.models.HostMessage ??
+  mongoose.model("HostMessage", messageSchema);
+
+export default HostMessage;
+export { messageSchema };

--- a/app/api/models/takos_host/note.ts
+++ b/app/api/models/takos_host/note.ts
@@ -1,0 +1,27 @@
+import mongoose from "mongoose";
+
+const noteSchema = new mongoose.Schema({
+  _id: {
+    type: String,
+    default: () => new mongoose.Types.ObjectId().toString(),
+  },
+  attributedTo: { type: String, required: true },
+  actor_id: { type: String, required: true, index: true },
+  content: { type: String, default: "" },
+  extra: { type: mongoose.Schema.Types.Mixed, default: {} },
+  published: { type: Date, default: Date.now },
+  tenant_id: { type: String, index: true },
+  created_at: { type: Date, default: Date.now },
+  updated_at: { type: Date, default: Date.now },
+  deleted_at: { type: Date },
+  aud: {
+    to: { type: [String], default: [] },
+    cc: { type: [String], default: [] },
+  },
+});
+
+const HostNote = mongoose.models.HostNote ??
+  mongoose.model("HostNote", noteSchema);
+
+export default HostNote;
+export { noteSchema };

--- a/app/api/models/takos_host/story.ts
+++ b/app/api/models/takos_host/story.ts
@@ -1,0 +1,27 @@
+import mongoose from "mongoose";
+
+const storySchema = new mongoose.Schema({
+  _id: {
+    type: String,
+    default: () => new mongoose.Types.ObjectId().toString(),
+  },
+  attributedTo: { type: String, required: true },
+  actor_id: { type: String, required: true, index: true },
+  content: { type: String, default: "" },
+  extra: { type: mongoose.Schema.Types.Mixed, default: {} },
+  published: { type: Date, default: Date.now },
+  tenant_id: { type: String, index: true },
+  created_at: { type: Date, default: Date.now },
+  updated_at: { type: Date, default: Date.now },
+  deleted_at: { type: Date },
+  aud: {
+    to: { type: [String], default: [] },
+    cc: { type: [String], default: [] },
+  },
+});
+
+const HostStory = mongoose.models.HostStory ??
+  mongoose.model("HostStory", storySchema);
+
+export default HostStory;
+export { storySchema };

--- a/app/api/models/takos_host/video.ts
+++ b/app/api/models/takos_host/video.ts
@@ -1,0 +1,27 @@
+import mongoose from "mongoose";
+
+const videoSchema = new mongoose.Schema({
+  _id: {
+    type: String,
+    default: () => new mongoose.Types.ObjectId().toString(),
+  },
+  attributedTo: { type: String, required: true },
+  actor_id: { type: String, required: true, index: true },
+  content: { type: String, default: "" },
+  extra: { type: mongoose.Schema.Types.Mixed, default: {} },
+  published: { type: Date, default: Date.now },
+  tenant_id: { type: String, index: true },
+  created_at: { type: Date, default: Date.now },
+  updated_at: { type: Date, default: Date.now },
+  deleted_at: { type: Date },
+  aud: {
+    to: { type: [String], default: [] },
+    cc: { type: [String], default: [] },
+  },
+});
+
+const HostVideo = mongoose.models.HostVideo ??
+  mongoose.model("HostVideo", videoSchema);
+
+export default HostVideo;
+export { videoSchema };


### PR DESCRIPTION
## Summary
- Note/Message/Video/Story を個別のコレクションとして保存
- takos host 側の DB 実装をそれぞれのモデルに対応
- Story 用モデルを追加

## Testing
- `deno fmt app/api/models/takos/story.ts app/api/models/takos_host/story.ts app/api/models/takos_host/note.ts app/api/models/takos_host/message.ts app/api/models/takos_host/video.ts app/api/DB/local.ts app/api/DB/host.ts`
- `deno lint app/api/models/takos/story.ts app/api/models/takos_host/story.ts app/api/models/takos_host/note.ts app/api/models/takos_host/message.ts app/api/models/takos_host/video.ts app/api/DB/local.ts app/api/DB/host.ts`


------
https://chatgpt.com/codex/tasks/task_e_6889c4d6ab9c8328af956886793ecc1e