### PR TITLE
StoryエディターのDOMレイヤ化

### DIFF
--- a/app/client/src/components/microblog/Stage.tsx
+++ b/app/client/src/components/microblog/Stage.tsx
@@ -127,10 +127,11 @@ export function Stage(props: {
         {(item) => {
           const box = item().bbox;
           const rot = item().rotation ?? 0;
-          const trans = `translate(${box.x * 100}%, ${
-            box.y * 100
-          }%) rotate(${rot}deg) scale(${box.w}, ${box.h})`;
-          const boxStyle = `transform:${trans};transform-origin:0 0;opacity:${
+          const boxStyle = `left:${box.x * 100}%;top:${box.y * 100}%;width:${
+            box.w * 100
+          }%;height:${
+            box.h * 100
+          }%;transform:rotate(${rot}deg);transform-origin:center;opacity:${
             item().opacity ?? 1
           }`;
           return (

--- a/app/client/src/components/microblog/Stage.tsx
+++ b/app/client/src/components/microblog/Stage.tsx
@@ -1,8 +1,8 @@
-import { createSignal, onCleanup, Show } from "solid-js";
+import { type Accessor, createSignal, onCleanup, Show } from "solid-js";
 import type { ImageItem, StoryItem, TextItem, VideoItem } from "./types.ts";
 
 export function Stage(props: {
-  item: StoryItem | null;
+  item: Accessor<StoryItem | null>;
   width: number;
   height: number;
   onChange: (item: StoryItem) => void;
@@ -33,11 +33,12 @@ export function Stage(props: {
 
   const onMove = (e: PointerEvent) => {
     const d = drag();
-    if (!d || !props.item) return;
+    const current = props.item();
+    if (!d || !current) return;
     const p = toPoint(e);
     const dx = p.x - d.startX;
     const dy = p.y - d.startY;
-    const item = props.item;
+    const item = current;
     if (d.mode === "move") {
       const nx = clamp(d.box.x + dx, 0, 1 - d.box.w);
       const ny = clamp(d.box.y + dy, 0, 1 - d.box.h);
@@ -74,9 +75,9 @@ export function Stage(props: {
     e.preventDefault();
     const tgt = e.currentTarget as HTMLElement;
     tgt.setPointerCapture?.(e.pointerId);
-    if (!props.item) return;
+    const it = props.item();
+    if (!it) return;
     const p = toPoint(e);
-    const it = props.item;
     setDrag({
       mode,
       startX: p.x,
@@ -133,7 +134,7 @@ export function Stage(props: {
       style={`width:${props.width}px;height:${props.height}px;background:#000;touch-action:none`}
       onPointerDown={(e) => startDrag(e, "move")}
     >
-      <Show when={props.item}>
+      <Show when={props.item()}>
         {(item) => {
           const box = item().bbox;
           const rot = item().rotation ?? 0;

--- a/app/client/src/components/microblog/Stage.tsx
+++ b/app/client/src/components/microblog/Stage.tsx
@@ -66,6 +66,7 @@ export function Stage(props: {
   ) => {
     e.stopPropagation();
     e.preventDefault();
+    (e.currentTarget as HTMLElement).setPointerCapture?.(e.pointerId);
     if (!props.item) return;
     const p = toPoint(e);
     const it = props.item;
@@ -119,7 +120,7 @@ export function Stage(props: {
   return (
     <div
       ref={container}
-      class="relative"
+      class="relative cursor-move"
       style={`width:${props.width}px;height:${props.height}px;background:#000;touch-action:none`}
       onPointerDown={(e) => startDrag(e, "move")}
     >
@@ -144,6 +145,7 @@ export function Stage(props: {
                 style={`left:${box.x * 100}%;top:${box.y * 100}%;width:${
                   box.w * 100
                 }%;height:${box.h * 100}%;transform:rotate(${rot}deg)`}
+                onPointerDown={(e) => startDrag(e, "move")}
               />
               <button
                 type="button"
@@ -155,14 +157,14 @@ export function Stage(props: {
                 ×
               </button>
               <div
-                class="absolute w-4 h-4 bg-white border border-black rounded-full"
+                class="absolute w-4 h-4 bg-white border border-black rounded-full cursor-nwse-resize"
                 style={`left:${(box.x + box.w) * 100 - 2}%;top:${
                   (box.y + box.h) * 100 - 2
                 }%`}
                 onPointerDown={(e) => startDrag(e, "resize")}
               />
               <div
-                class="absolute w-4 h-4 bg-white border border-black rounded-full"
+                class="absolute w-4 h-4 bg-white border border-black rounded-full cursor-crosshair"
                 style={`left:${box.x * 100 + box.w * 50 - 2}%;top:${
                   box.y * 100 - 4
                 }%`}

--- a/app/client/src/components/microblog/Stage.tsx
+++ b/app/client/src/components/microblog/Stage.tsx
@@ -65,6 +65,7 @@ export function Stage(props: {
     mode: "move" | "resize" | "rotate",
   ) => {
     e.stopPropagation();
+    e.preventDefault();
     if (!props.item) return;
     const p = toPoint(e);
     const it = props.item;
@@ -108,7 +109,7 @@ export function Stage(props: {
           (style?.fontSize ?? 0.06) * 100
         }vmin;display:flex;align-items:center;justify-content:center;text-align:${
           style?.align || "center"
-        }`}
+        };overflow:hidden;word-break:break-word;`}
       >
         {t.text}
       </div>
@@ -133,7 +134,9 @@ export function Stage(props: {
           }`;
           return (
             <>
-              <div class="absolute" style={style}>{renderItem(item())}</div>
+              <div class="absolute overflow-hidden" style={style}>
+                {renderItem(item())}
+              </div>
               <div
                 class="absolute border border-white/50 border-dashed box-border"
                 style={`left:${box.x * 100}%;top:${box.y * 100}%;width:${

--- a/app/client/src/components/microblog/Stage.tsx
+++ b/app/client/src/components/microblog/Stage.tsx
@@ -130,35 +130,41 @@ export function Stage(props: {
     >
       <Show when={props.item()}>
         {(it) => {
-          const box = it().bbox;
-          const rot = it().rotation ?? 0;
-          const style = {
-            left: `${box.x * 100}%`,
-            top: `${box.y * 100}%`,
-            width: `${box.w * 100}%`,
-            height: `${box.h * 100}%`,
-            transform: `rotate(${rot}deg)`,
-            "transform-origin": "center",
-          } as const;
+          const box = () => it().bbox;
+          const rot = () => it().rotation ?? 0;
           return (
             <>
               <div
                 class="absolute overflow-hidden pointer-events-none"
-                style={style}
+                style={{
+                  left: () => `${box().x * 100}%`,
+                  top: () => `${box().y * 100}%`,
+                  width: () => `${box().w * 100}%`,
+                  height: () => `${box().h * 100}%`,
+                  transform: () => `rotate(${rot()}deg)`,
+                  "transform-origin": "center",
+                }}
               >
                 {renderItem(it())}
               </div>
               <div
                 class="absolute border border-white/50 border-dashed box-border"
-                style={style}
+                style={{
+                  left: () => `${box().x * 100}%`,
+                  top: () => `${box().y * 100}%`,
+                  width: () => `${box().w * 100}%`,
+                  height: () => `${box().h * 100}%`,
+                  transform: () => `rotate(${rot()}deg)`,
+                  "transform-origin": "center",
+                }}
                 onPointerDown={(e) => startDrag(e, "move")}
               />
               <button
                 type="button"
                 class="absolute w-5 h-5 text-white bg-black/50 flex items-center justify-center rounded-full"
                 style={{
-                  left: `${box.x * 100 - 2.5}%`,
-                  top: `${box.y * 100 - 2.5}%`,
+                  left: () => `${box().x * 100 - 2.5}%`,
+                  top: () => `${box().y * 100 - 2.5}%`,
                 }}
                 onPointerDown={(e) => e.stopPropagation()}
                 onClick={() => props.onRemove?.()}
@@ -168,16 +174,16 @@ export function Stage(props: {
               <div
                 class="absolute w-4 h-4 bg-white border border-black rounded-full cursor-nwse-resize"
                 style={{
-                  left: `${(box.x + box.w) * 100 - 2}%`,
-                  top: `${(box.y + box.h) * 100 - 2}%`,
+                  left: () => `${(box().x + box().w) * 100 - 2}%`,
+                  top: () => `${(box().y + box().h) * 100 - 2}%`,
                 }}
                 onPointerDown={(e) => startDrag(e, "resize")}
               />
               <div
                 class="absolute w-4 h-4 bg-white border border-black rounded-full cursor-crosshair"
                 style={{
-                  left: `${box.x * 100 + box.w * 50 - 2}%`,
-                  top: `${box.y * 100 - 4}%`,
+                  left: () => `${box().x * 100 + box().w * 50 - 2}%`,
+                  top: () => `${box().y * 100 - 4}%`,
                 }}
                 onPointerDown={(e) => startDrag(e, "rotate")}
               />

--- a/app/client/src/components/microblog/Stage.tsx
+++ b/app/client/src/components/microblog/Stage.tsx
@@ -6,6 +6,7 @@ export function Stage(props: {
   width: number;
   height: number;
   onChange: (item: StoryItem) => void;
+  onRemove?: () => void;
 }) {
   let container!: HTMLDivElement;
   const [drag, setDrag] = createSignal<
@@ -134,22 +135,31 @@ export function Stage(props: {
             <>
               <div class="absolute" style={style}>{renderItem(item())}</div>
               <div
-                class="absolute border border-green-400 box-border"
+                class="absolute border border-white/50 border-dashed box-border"
                 style={`left:${box.x * 100}%;top:${box.y * 100}%;width:${
                   box.w * 100
                 }%;height:${box.h * 100}%;transform:rotate(${rot}deg)`}
               />
+              <button
+                type="button"
+                class="absolute w-5 h-5 text-white bg-black/50 flex items-center justify-center rounded-full"
+                style={`left:${box.x * 100 - 2.5}%;top:${box.y * 100 - 2.5}%`}
+                onPointerDown={(e) => e.stopPropagation()}
+                onClick={() => props.onRemove?.()}
+              >
+                ×
+              </button>
               <div
-                class="absolute w-3 h-3 bg-green-400"
-                style={`left:${(box.x + box.w) * 100 - 1.5}%;top:${
-                  (box.y + box.h) * 100 - 1.5
+                class="absolute w-4 h-4 bg-white border border-black rounded-full"
+                style={`left:${(box.x + box.w) * 100 - 2}%;top:${
+                  (box.y + box.h) * 100 - 2
                 }%`}
                 onPointerDown={(e) => startDrag(e, "resize")}
               />
               <div
-                class="absolute w-3 h-3 bg-green-400"
-                style={`left:${box.x * 100 + box.w * 50 - 1.5}%;top:${
-                  box.y * 100 - 3
+                class="absolute w-4 h-4 bg-white border border-black rounded-full"
+                style={`left:${box.x * 100 + box.w * 50 - 2}%;top:${
+                  box.y * 100 - 4
                 }%`}
                 onPointerDown={(e) => startDrag(e, "rotate")}
               />

--- a/app/client/src/components/microblog/Stage.tsx
+++ b/app/client/src/components/microblog/Stage.tsx
@@ -128,29 +128,41 @@ export function Stage(props: {
         {(item) => {
           const box = item().bbox;
           const rot = item().rotation ?? 0;
-          const boxStyle = `left:${box.x * 100}%;top:${box.y * 100}%;width:${
-            box.w * 100
-          }%;height:${
-            box.h * 100
-          }%;transform:rotate(${rot}deg);transform-origin:center;opacity:${
-            item().opacity ?? 1
-          }`;
+          const boxStyle = {
+            left: `${box.x * 100}%`,
+            top: `${box.y * 100}%`,
+            width: `${box.w * 100}%`,
+            height: `${box.h * 100}%`,
+            transform: `rotate(${rot}deg)`,
+            "transform-origin": "center",
+            opacity: item().opacity ?? 1,
+          } as const;
           return (
             <>
-              <div class="absolute overflow-hidden" style={boxStyle}>
+              <div
+                class="absolute overflow-hidden pointer-events-none"
+                style={boxStyle}
+              >
                 {renderItem(item())}
               </div>
               <div
                 class="absolute border border-white/50 border-dashed box-border"
-                style={`left:${box.x * 100}%;top:${box.y * 100}%;width:${
-                  box.w * 100
-                }%;height:${box.h * 100}%;transform:rotate(${rot}deg)`}
+                style={{
+                  left: `${box.x * 100}%`,
+                  top: `${box.y * 100}%`,
+                  width: `${box.w * 100}%`,
+                  height: `${box.h * 100}%`,
+                  transform: `rotate(${rot}deg)`,
+                }}
                 onPointerDown={(e) => startDrag(e, "move")}
               />
               <button
                 type="button"
                 class="absolute w-5 h-5 text-white bg-black/50 flex items-center justify-center rounded-full"
-                style={`left:${box.x * 100 - 2.5}%;top:${box.y * 100 - 2.5}%`}
+                style={{
+                  left: `${box.x * 100 - 2.5}%`,
+                  top: `${box.y * 100 - 2.5}%`,
+                }}
                 onPointerDown={(e) => e.stopPropagation()}
                 onClick={() => props.onRemove?.()}
               >
@@ -158,16 +170,18 @@ export function Stage(props: {
               </button>
               <div
                 class="absolute w-4 h-4 bg-white border border-black rounded-full cursor-nwse-resize"
-                style={`left:${(box.x + box.w) * 100 - 2}%;top:${
-                  (box.y + box.h) * 100 - 2
-                }%`}
+                style={{
+                  left: `${(box.x + box.w) * 100 - 2}%`,
+                  top: `${(box.y + box.h) * 100 - 2}%`,
+                }}
                 onPointerDown={(e) => startDrag(e, "resize")}
               />
               <div
                 class="absolute w-4 h-4 bg-white border border-black rounded-full cursor-crosshair"
-                style={`left:${box.x * 100 + box.w * 50 - 2}%;top:${
-                  box.y * 100 - 4
-                }%`}
+                style={{
+                  left: `${box.x * 100 + box.w * 50 - 2}%`,
+                  top: `${box.y * 100 - 4}%`,
+                }}
                 onPointerDown={(e) => startDrag(e, "rotate")}
               />
             </>

--- a/app/client/src/components/microblog/Stage.tsx
+++ b/app/client/src/components/microblog/Stage.tsx
@@ -16,6 +16,8 @@ export function Stage(props: {
       startY: number;
       box: { x: number; y: number; w: number; h: number };
       rot: number;
+      id: number;
+      target: HTMLElement | null;
     } | null
   >(null);
 
@@ -55,6 +57,10 @@ export function Stage(props: {
   };
 
   const onUp = () => {
+    const d = drag();
+    if (d?.target) {
+      d.target.releasePointerCapture?.(d.id);
+    }
     setDrag(null);
     document.removeEventListener("pointermove", onMove);
     document.removeEventListener("pointerup", onUp);
@@ -66,7 +72,8 @@ export function Stage(props: {
   ) => {
     e.stopPropagation();
     e.preventDefault();
-    (e.currentTarget as HTMLElement).setPointerCapture?.(e.pointerId);
+    const tgt = e.currentTarget as HTMLElement;
+    tgt.setPointerCapture?.(e.pointerId);
     if (!props.item) return;
     const p = toPoint(e);
     const it = props.item;
@@ -76,6 +83,8 @@ export function Stage(props: {
       startY: p.y,
       box: { ...it.bbox },
       rot: it.rotation ?? 0,
+      id: e.pointerId,
+      target: tgt,
     });
     document.addEventListener("pointermove", onMove);
     document.addEventListener("pointerup", onUp);

--- a/app/client/src/components/microblog/Stage.tsx
+++ b/app/client/src/components/microblog/Stage.tsx
@@ -127,14 +127,15 @@ export function Stage(props: {
         {(item) => {
           const box = item().bbox;
           const rot = item().rotation ?? 0;
-          const style = `left:${box.x * 100}%;top:${box.y * 100}%;width:${
-            box.w * 100
-          }%;height:${box.h * 100}%;transform:rotate(${rot}deg);opacity:${
+          const trans = `translate(${box.x * 100}%, ${
+            box.y * 100
+          }%) rotate(${rot}deg) scale(${box.w}, ${box.h})`;
+          const boxStyle = `transform:${trans};transform-origin:0 0;opacity:${
             item().opacity ?? 1
           }`;
           return (
             <>
-              <div class="absolute overflow-hidden" style={style}>
+              <div class="absolute overflow-hidden" style={boxStyle}>
                 {renderItem(item())}
               </div>
               <div

--- a/app/client/src/components/microblog/Stage.tsx
+++ b/app/client/src/components/microblog/Stage.tsx
@@ -128,7 +128,7 @@ export function Stage(props: {
 
   return (
     <div
-      ref={container}
+      ref={(el) => (container = el)}
       class="relative cursor-move"
       style={`width:${props.width}px;height:${props.height}px;background:#000;touch-action:none`}
       onPointerDown={(e) => startDrag(e, "move")}

--- a/app/client/src/components/microblog/StoryEditor.tsx
+++ b/app/client/src/components/microblog/StoryEditor.tsx
@@ -95,7 +95,7 @@ export function StoryEditor(
           </button>
         </div>
         <Stage
-          item={item()}
+          item={item}
           width={300}
           height={500}
           onChange={updateItem}

--- a/app/client/src/components/microblog/StoryEditor.tsx
+++ b/app/client/src/components/microblog/StoryEditor.tsx
@@ -99,6 +99,7 @@ export function StoryEditor(
           width={300}
           height={500}
           onChange={updateItem}
+          onRemove={removeItem}
         />
         <div class="flex space-x-2">
           <button


### PR DESCRIPTION
## 概要
Story編集用の `Stage` コンポーネントを SVG ベースから DOM を重ねる方式へ変更しました。これにより Instagram の Story 編集のように各要素を DOM レイヤとして扱い、表示と操作を統一しています。

## 変更点
- `Stage.tsx` を全面的に書き換え、画像・動画・テキストを絶対配置する DOM レイヤとして描画
- 移動・リサイズ・回転操作を DOM 上で処理するよう更新

`deno fmt` と `deno lint` を実行済みです。

------
https://chatgpt.com/codex/tasks/task_e_688a4388ad748328b5b26dd4156563d9