### PR TITLE
deno.serve のホスト名を環境変数で指定可能に

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ takosは、ActivityPubに追加で、以下の機能を提供します。
 ## 🚀 GET started(backend)
 
 環境変数を設定したら、`app/api` ディレクトリからサーバーを起動します。
+特定のインターフェースのみで待ち受けたい場合は `SERVER_HOST`
+を設定してください。
 
 MongoDB にはセッション自動削除用の TTL インデックスが必要です。初回起動前に
 `scripts/create_session_indexes.ts` を実行して `Session` と `HostSession`

--- a/app/api/.env.example
+++ b/app/api/.env.example
@@ -1,5 +1,7 @@
 MONGO_URI=mongodb://localhost:27017/takos-hono
 DB_MODE=local
+# サーバーの待ち受けアドレス (省略時は 0.0.0.0)
+SERVER_HOST=
 hashedPassword=$2a$10$KpzI70.g4V42p7KczcR.jeFayt7mL1rCFgX37IqY1V9PDzHSglPWW
 salt=
 ACTIVITYPUB_DOMAIN=dev.takos.jp

--- a/app/api/index.ts
+++ b/app/api/index.ts
@@ -12,4 +12,5 @@ if (env["ACTIVITYPUB_DOMAIN"]) {
   await ensureTenant(db, domain, domain);
 }
 const app = await createTakosApp(env);
-Deno.serve(app.fetch);
+const hostname = env["SERVER_HOST"];
+Deno.serve({ hostname }, app.fetch);

--- a/app/api/server.ts
+++ b/app/api/server.ts
@@ -134,5 +134,6 @@ if (import.meta.main) {
   const env = await loadConfig();
   await connectDatabase(env);
   const app = await createTakosApp(env);
-  Deno.serve(app.fetch);
+  const hostname = env["SERVER_HOST"];
+  Deno.serve({ hostname }, app.fetch);
 }

--- a/app/takos_host/.env.example
+++ b/app/takos_host/.env.example
@@ -8,6 +8,8 @@
 ############################
 MONGO_URI=mongodb://localhost:27017/takos-host
 DB_MODE=host
+# サーバーの待ち受けアドレス (省略時は 0.0.0.0)
+SERVER_HOST=
 
 # マルチテナント用のデフォルトルートドメイン
 ROOT_DOMAIN=takos.jp

--- a/app/takos_host/README.md
+++ b/app/takos_host/README.md
@@ -107,6 +107,8 @@ OAuth ボタンを表示します。
 - `SMTP_HOST` などを設定すると登録時に確認メールを送信します。
 
 2. `deno run -A app/takos_host/main.ts` でサーバーを起動します。
+   特定のインターフェースのみで待ち受けたい場合は `SERVER_HOST`
+   を設定してください。
 
 ## CLI 管理ツール
 

--- a/app/takos_host/main.ts
+++ b/app/takos_host/main.ts
@@ -217,5 +217,5 @@ root.all("/*", async (c) => {
 });
 
 root.use(logger());
-
-Deno.serve({ port: 8001 }, root.fetch);
+const hostname = hostEnv["SERVER_HOST"];
+Deno.serve({ port: 8001, hostname }, root.fetch);


### PR DESCRIPTION
## Summary
- `SERVER_HOST` を追加して takos と takos host の待ち受けアドレスを指定可能に
- `.env.example` と README を更新

## Testing
- `deno fmt README.md app/api/server.ts app/api/index.ts app/takos_host/main.ts app/api/.env.example app/takos_host/.env.example app/takos_host/README.md`
- `deno lint app/api/server.ts app/api/index.ts app/takos_host/main.ts`


------
https://chatgpt.com/codex/tasks/task_e_688c7472925c8328a08b8ef65ee6f9df