### PR TITLE
PrivateMessage/PublicMessage の MLS バイナリ対応

### DIFF
--- a/app/api/routes/e2ee.ts
+++ b/app/api/routes/e2ee.ts
@@ -17,7 +17,7 @@ import {
 } from "../utils/activitypub.ts";
 import { deliverToFollowers } from "../utils/deliver.ts";
 import { sendToUser } from "./ws.ts";
-import { b64ToBuf } from "../../shared/buffer.ts";
+import { decodeMLSMessage } from "../../shared/mls_message.ts";
 
 interface ActivityPubActivity {
   [key: string]: unknown;
@@ -298,14 +298,9 @@ app.post(
     const db = createDB(env);
 
     let msgType = "PrivateMessage";
-    try {
-      const decoded = new TextDecoder().decode(b64ToBuf(content));
-      const obj = JSON.parse(decoded) as { type?: unknown };
-      if (obj && typeof obj.type === "string" && obj.type === "PublicMessage") {
-        msgType = "PublicMessage";
-      }
-    } catch {
-      /* ignore */
+    const decoded = decodeMLSMessage(content);
+    if (decoded && decoded.type === "PublicMessage") {
+      msgType = "PublicMessage";
     }
     const isPublic = msgType === "PublicMessage";
 

--- a/app/shared/mls_message.ts
+++ b/app/shared/mls_message.ts
@@ -1,0 +1,47 @@
+// MLSメッセージのエンコードとデコード
+// activitypub-e2ee仕様に沿ってメッセージタイプを1バイトで表現する
+
+import { b64ToBuf, bufToB64 } from "./buffer.ts";
+
+export type MLSMessageType = "PublicMessage" | "PrivateMessage";
+
+const typeToByte: Record<MLSMessageType, number> = {
+  PublicMessage: 1,
+  PrivateMessage: 2,
+};
+
+const byteToType: Record<number, MLSMessageType> = {
+  1: "PublicMessage",
+  2: "PrivateMessage",
+};
+
+/**
+ * MLSMessageをBase64文字列に変換
+ */
+export function encodeMLSMessage(
+  type: MLSMessageType,
+  body: string,
+): string {
+  const bodyBuf = new TextEncoder().encode(body);
+  const u8 = new Uint8Array(bodyBuf.length + 1);
+  u8[0] = typeToByte[type];
+  u8.set(bodyBuf, 1);
+  return bufToB64(u8);
+}
+
+/**
+ * Base64文字列からMLSMessageを復元
+ */
+export function decodeMLSMessage(
+  data: string,
+): { type: MLSMessageType; body: string } | null {
+  try {
+    const u8 = new Uint8Array(b64ToBuf(data));
+    const type = byteToType[u8[0]];
+    if (!type) return null;
+    const body = new TextDecoder().decode(u8.slice(1));
+    return { type, body };
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- MLSメッセージをバイナリ化するユーティリティを追加
- クライアントでMLSバイナリを用いた送受信処理に変更
- サーバーでMLSメッセージを解析して種別を判定

## Testing
- `deno fmt app/shared/mls_message.ts app/client/src/components/Chat.tsx app/api/routes/e2ee.ts`
- `deno lint app/shared/mls_message.ts app/client/src/components/Chat.tsx app/api/routes/e2ee.ts`


------
https://chatgpt.com/codex/tasks/task_e_688e51900cb88328bc733c06ad5dfc00