### PR TITLE
docs: ActivityStreams Actor Types の参照を追加

### DIFF
--- a/docs/FASP.md
+++ b/docs/FASP.md
@@ -2,57 +2,75 @@
 
 ## 0. 目的と範囲
 
-* **目的**
+- **目的**
 
-  * takos に Fediscovery（FASP）を接続し、検索・発見（Discovery）機能を強化。
-  * takos host に **Service Actor** を実装し、従来のリレーサーバー代替として「フォロー可能な配信ハブ」を提供。
+  - takos に Fediscovery（FASP）を接続し、検索・発見（Discovery）機能を強化。
+  - takos host に **Service Actor**
+    を実装し、従来のリレーサーバー代替として「フォロー可能な配信ハブ」を提供。
 
-* **スコープ**
+- **スコープ**
 
-  * FASP **General**（登録・認証・プロバイダ情報・capability選択）の実装。
-  * FASP **Discovery**のうち **data\_sharing** / **trends** / **account\_search** 対応。
-  * takos host の **Service Actor**（ActivityStreamsの`Service`/`Application`）を公開し、**フォロー/Accept/配信**を行う。
+  - FASP **General**（登録・認証・プロバイダ情報・capability選択）の実装。
+  - FASP **Discovery**のうち **data\_sharing** / **trends** /
+    **account\_search** 対応。
+  - takos host の **Service
+    Actor**（ActivityStreamsの`Service`/`Application`）を公開し、**フォロー/Accept/配信**を行う。
 
 ---
 
 ## 1. 用語
 
-* **FASP**: Fediverse Auxiliary Service Provider。外部の補助サービス（検索、スパム対策など）。
-* **Capability**: FASPが提供する機能単位（例：`data_sharing`, `trends`, `account_search`, `debug`）。
-* **Service Actor**: ActivityStreamsのActor型の一つ。サーバ側ソフトやボット等に用いられる。takos hostでは**フォロー可能なサービス用Actor**として公開する。 ([W3C][1])
+- **FASP**: Fediverse Auxiliary Service
+  Provider。外部の補助サービス（検索、スパム対策など）。
+- **Capability**: FASPが提供する機能単位（例：`data_sharing`, `trends`,
+  `account_search`, `debug`）。
+- **Service Actor**:
+  ActivityStreamsのActor型の一つ。サーバ側ソフトやボット等に用いられる。takos
+  hostでは**フォロー可能なサービス用Actor**として公開する。 ([W3C][1])
 
 ---
 
 ## 2. 全体アーキテクチャ
 
-* **構成要素**
+- **構成要素**
 
-  * **takos Core**：既存アプリケーション。
-  * **takos FASP-Adapter**：FASP General実装（登録・認証・プロバイダ情報取得・capability管理）。
-  * **takos Discovery Module**：`data_sharing`（サブスクリプション受理・バックフィル対応・アナウンス送信）、`trends` / `account_search`（FASP検索APIクライアント）。
-  * **takos Service Actor**：`https://{takos-host}/actor` に公開。inbox/outbox、公開鍵、フォロー受付、配信制御。
-  * **FASP（Discovery Provider）**：外部サービス。
+  - **takos Core**：既存アプリケーション。
+  - **takos FASP-Adapter**：FASP
+    General実装（登録・認証・プロバイダ情報取得・capability管理）。
+  - **takos Discovery
+    Module**：`data_sharing`（サブスクリプション受理・バックフィル対応・アナウンス送信）、`trends`
+    / `account_search`（FASP検索APIクライアント）。
+  - **takos Service Actor**：`https://{takos-host}/actor`
+    に公開。inbox/outbox、公開鍵、フォロー受付、配信制御。
+  - **FASP（Discovery Provider）**：外部サービス。
 
-* **ベースURLの取り決め**
+- **ベースURLの取り決め**
 
-  * takos は `.well-known/nodeinfo` の `metadata.faspBaseUrl` に takos 側FASPサーバAPIのベースURLを掲載。例：`"faspBaseUrl": "https://{takos-host}/fasp"`。
+  - takos は `.well-known/nodeinfo` の `metadata.faspBaseUrl` に takos
+    側FASPサーバAPIのベースURLを掲載。例：`"faspBaseUrl": "https://{takos-host}/fasp"`。
 
 ---
 
 ## 3. セキュリティ / 認証
 
-* **メッセージ完全性**
+- **メッセージ完全性**
 
-  * すべてのリクエストに `Content-Digest`（RFC 9530, SHA-256）を付与。受信側は検証必須。
-* **相互認証**
+  - すべてのリクエストに `Content-Digest`（RFC 9530,
+    SHA-256）を付与。受信側は検証必須。
+- **相互認証**
 
-  * **HTTP Message Signatures（RFC 9421）**、アルゴリズム **ed25519** を使用。`@method`,`@target-uri`,`content-digest` をカバー。レスポンス署名では `@status` を使用。`keyid` は登録時に交換したID。
-* **ダブルノッキング（取得系互換性）**
+  - **HTTP Message Signatures（RFC 9421）**、アルゴリズム **ed25519**
+    を使用。`@method`,`@target-uri`,`content-digest`
+    をカバー。レスポンス署名では `@status` を使用。`keyid`
+    は登録時に交換したID。
+- **ダブルノッキング（取得系互換性）**
 
-  * FASP/Service Actor が外部のAPサーバからオブジェクト取得を行う場合、まず RFC 9421 で試行し、401/403なら旧 **draft-cavage HTTP Signatures** で再試行（互換性確保）。実装はサーバごとに結果をキャッシュ。
-* **レート制限**
+  - FASP/Service Actor が外部のAPサーバからオブジェクト取得を行う場合、まず RFC
+    9421 で試行し、401/403なら旧 **draft-cavage HTTP Signatures**
+    で再試行（互換性確保）。実装はサーバごとに結果をキャッシュ。
+- **レート制限**
 
-  * 429 + `Retry-After` を使用。クライアントは尊重する。
+  - 429 + `Retry-After` を使用。クライアントは尊重する。
 
 ---
 
@@ -60,21 +78,30 @@
 
 ### 4.1 登録フロー（FASP ↔ takos）
 
-1. 管理者がFASP上でtakosを登録（FASPが takos の `.well-known/nodeinfo` を参照して `faspBaseUrl` を把握）。
+1. 管理者がFASP上でtakosを登録（FASPが takos の `.well-known/nodeinfo`
+   を参照して `faspBaseUrl` を把握）。
 2. FASP → takos：`POST /registration`
 
    ```json
-   { "name":"Example FASP","baseUrl":"https://fasp.example.com","serverId":"b2ks…","publicKey":"Base64-Ed25519-PubKey" }
+   {
+     "name": "Example FASP",
+     "baseUrl": "https://fasp.example.com",
+     "serverId": "b2ks…",
+     "publicKey": "Base64-Ed25519-PubKey"
+   }
    ```
 
-   takosは FASP登録要求を保存し、自身の公開鍵と `faspId`、`registrationCompletionUri` を返す。
-3. 管理者は takos 管理UIで\*\*指紋（FASP公開鍵のSHA-256 Base64）\*\*を確認し、受理/拒否を決定。
+   takosは FASP登録要求を保存し、自身の公開鍵と
+   `faspId`、`registrationCompletionUri` を返す。
+3. 管理者は takos 管理UIで\*\*指紋（FASP公開鍵のSHA-256
+   Base64）\*\*を確認し、受理/拒否を決定。
 4. 受理後、能力（capability）選択へ。
 
 ### 4.2 Capability 選択
 
-* takos → FASP：`GET /provider_info` で capabilities を取得し、管理UIでON/OFF。
-* ON時：takos → FASP：`POST /capabilities/<identifier>/<version>/activation`。OFF時：`DELETE`。
+- takos → FASP：`GET /provider_info` で capabilities を取得し、管理UIでON/OFF。
+- ON時：takos →
+  FASP：`POST /capabilities/<identifier>/<version>/activation`。OFF時：`DELETE`。
 
 ---
 
@@ -84,23 +111,25 @@
 
 **役割分担**
 
-* **FASP ⇒ takos（受信）**
+- **FASP ⇒ takos（受信）**
 
-  * `POST /data_sharing/v0/event_subscriptions`
+  - `POST /data_sharing/v0/event_subscriptions`
 
-    * body: `{category: "content"|"account", subscriptionType: "lifecycle"|"trends", maxBatchSize?, threshold?}`
-    * 201で `{"subscription": {"id": "…" }}` を返す。
-  * `POST /data_sharing/v0/backfill_requests`（ヒストリ取得要求）
+    - body:
+      `{category: "content"|"account", subscriptionType: "lifecycle"|"trends", maxBatchSize?, threshold?}`
+    - 201で `{"subscription": {"id": "…" }}` を返す。
+  - `POST /data_sharing/v0/backfill_requests`（ヒストリ取得要求）
 
-    * body: `{category, maxCount}` → 201で `{"backfillRequest":{"id":"…"}}`。
-  * `POST /data_sharing/v0/backfill_requests/{id}/continuation`（more 指示に応じて）→ 204/404。
-  * `DELETE /data_sharing/v0/event_subscriptions/{id}` → 204。
+    - body: `{category, maxCount}` → 201で `{"backfillRequest":{"id":"…"}}`。
+  - `POST /data_sharing/v0/backfill_requests/{id}/continuation`（more
+    指示に応じて）→ 204/404。
+  - `DELETE /data_sharing/v0/event_subscriptions/{id}` → 204。
 
-* **takos ⇒ FASP（送信）**
+- **takos ⇒ FASP（送信）**
 
-  * **アナウンス**：`POST {FASP}/data_sharing/v0/announcements`
+  - **アナウンス**：`POST {FASP}/data_sharing/v0/announcements`
 
-    * body:
+    - body:
 
       ```json
       {
@@ -111,36 +140,41 @@
         "moreObjectsAvailable": true|false  // backfill時
       }
       ```
-    * 204 を期待。
+    - 204 を期待。
 
 **制約**
 
-* 送信は **URIのみ**（本体は送らない）。FASP側が取得する。
-* takos は \*\*公開・検索許可（discoverable）\*\*のみ共有。**非公開・未許可**は共有禁止。
-* FASP側は `to:` を確認し公開対象のみ処理。
-* 検索許可の判定は **FEP-5feb** に従う。
+- 送信は **URIのみ**（本体は送らない）。FASP側が取得する。
+- takos は
+  \*\*公開・検索許可（discoverable）\*\*のみ共有。**非公開・未許可**は共有禁止。
+- FASP側は `to:` を確認し公開対象のみ処理。
+- 検索許可の判定は **FEP-5feb** に従う。
 
 **FASPによる取得（参照）**
 
-* FASPは受け取ったURIに対し `Accept: application/ld+json; profile="https://www.w3.org/ns/activitystreams"` でGET。
-* 署名は RFC 9421（必要に応じ cavage-12）で、**FASPは「サーバ/インスタンスActor」として署名**（`/actor`に公開鍵）。
+- FASPは受け取ったURIに対し
+  `Accept: application/ld+json; profile="https://www.w3.org/ns/activitystreams"`
+  でGET。
+- 署名は RFC 9421（必要に応じ
+  cavage-12）で、**FASPは「サーバ/インスタンスActor」として署名**（`/actor`に公開鍵）。
 
 ### 5.2 `trends v0.1`（takos ⇒ FASP）
 
-* **エンドポイント例**（FASP側）
+- **エンドポイント例**（FASP側）
 
-  * `GET /trends/v0/content?withinLastHours=1..168&maxCount&language`
-  * `GET /trends/v0/hashtags?...` / `GET /trends/v0/links?...`（同様の共通パラメータ）
-* **応答**
+  - `GET /trends/v0/content?withinLastHours=1..168&maxCount&language`
+  - `GET /trends/v0/hashtags?...` /
+    `GET /trends/v0/links?...`（同様の共通パラメータ）
+- **応答**
 
-  * `content`: `[{uri, rank}]`（`rank`は1..100、降順）。
-  * ハッシュタグ/リンクは正規化はFASP側裁量、takos側は自サーバ内の既存ロジックと同等に処理。
+  - `content`: `[{uri, rank}]`（`rank`は1..100、降順）。
+  - ハッシュタグ/リンクは正規化はFASP側裁量、takos側は自サーバ内の既存ロジックと同等に処理。
 
 ### 5.3 `account_search v0.1`（takos ⇒ FASP）
 
-* `GET /account_search/v0/search?term=...&limit=...`
-* 200で **Actor URI配列**を返す。`Link: rel="next"` によるページング可。
-* takosは返却URIをキャッシュし、必要に応じフォロー/プロフィール取得を行う。
+- `GET /account_search/v0/search?term=...&limit=...`
+- 200で **Actor URI配列**を返す。`Link: rel="next"` によるページング可。
+- takosは返却URIをキャッシュし、必要に応じフォロー/プロフィール取得を行う。
 
 ---
 
@@ -148,15 +182,18 @@
 
 ### 6.1 公開エンドポイント
 
-* **Actor**：`GET https://{takos-host}/actor`
+- **Actor**：`GET https://{takos-host}/actor`
 
-  * 例（最小構成）：
+  - 例（最小構成）：
 
     ```json
     {
-      "@context": ["https://www.w3.org/ns/activitystreams","https://w3id.org/security/v1"],
+      "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1"
+      ],
       "id": "https://{takos-host}/actor",
-      "type": "Service",             // or "Application"
+      "type": "Service", // or "Application"
       "preferredUsername": "takos",
       "inbox": "https://{takos-host}/inbox",
       "outbox": "https://{takos-host}/outbox",
@@ -167,33 +204,39 @@
       }
     }
     ```
-  * `type` は AS2の**Service**（サービス用途）または **Application**（アプリケーション用途）を選択可。用途上は **Service** 推奨。 ([W3C][1])
+  - `type` は AS2の**Service**（サービス用途）または
+    **Application**（アプリケーション用途）を選択可。用途上は **Service** 推奨。
+    ([W3C][1])
 
-* **inbox/outbox**
+- **inbox/outbox**
 
-  * `inbox`：受信（Follow、Undo、Block等）を処理。
-  * `outbox`：配信（Accept、Announce/Forward等）を発行。
+  - `inbox`：受信（Follow、Undo、Block等）を処理。
+  - `outbox`：配信（Accept、Announce/Forward等）を発行。
 
 ### 6.2 フォロー/配信（リレー相当）
 
-* **Follow受付**
+- **Follow受付**
 
-  * 受領：`Follow{ actor: <follower>, object: <takos-actor> }`
-  * 応答：`Accept(Follow)` を outbox から配信。
-* **配信方針（“リレー代替”）**
+  - 受領：`Follow{ actor: <follower>, object: <takos-actor> }`
+  - 応答：`Accept(Follow)` を outbox から配信。
+- **配信方針（“リレー代替”）**
 
-  * takos が把握する **公開・discoverable** な新規/更新コンテンツの **URI** を、フォロワーへ **Announce**（または必要に応じて元オブジェクトの配信）
+  - takos が把握する **公開・discoverable** な新規/更新コンテンツの **URI**
+    を、フォロワーへ **Announce**（または必要に応じて元オブジェクトの配信）
 
-    * フィルタ：ローカル投稿＋連合経由で知り得たリモート投稿のうち、公開・許可済のみ。
-    * バッチ/しきい値：FASP `data_sharing` の `trends`/しきい値と整合性あるバッチングを推奨（過剰配信を回避）。
-* **ブロック/オプトアウト**
+    - フィルタ：ローカル投稿＋連合経由で知り得たリモート投稿のうち、公開・許可済のみ。
+    - バッチ/しきい値：FASP `data_sharing` の
+      `trends`/しきい値と整合性あるバッチングを推奨（過剰配信を回避）。
+- **ブロック/オプトアウト**
 
-  * サーバ単位・アカウント単位での除外リストを適用（inboxでのBlock/Undoを尊重）。
-* **レート制御**
+  - サーバ単位・アカウント単位での除外リストを適用（inboxでのBlock/Undoを尊重）。
+- **レート制御**
 
-  * outbox配送をQ化し、429/Retry-Afterを尊重。
+  - outbox配送をQ化し、429/Retry-Afterを尊重。
 
-> 補足：従来の“リレー”は投稿本文を転送する実装も存在しますが、本仕様では **URI中心** の共有を基本とし、本文取得はフォロワー側の既存APフェッチに委譲します（Fediscoveryの設計に整合）。
+> 補足：従来の“リレー”は投稿本文を転送する実装も存在しますが、本仕様では
+> **URI中心**
+> の共有を基本とし、本文取得はフォロワー側の既存APフェッチに委譲します（Fediscoveryの設計に整合）。
 
 ---
 
@@ -214,7 +257,7 @@ fasp:
 service_actor:
   enabled: true
   actor_url: https://{takos-host}/actor
-  type: Service   # または Application
+  type: Service # または Application
   deliver_batch_size: 20
   deliver_min_interval_ms: 200
   allow_instances:
@@ -224,22 +267,22 @@ service_actor:
 
 ### 7.2 takos サーバAPI（FASPから呼ばれる）
 
-* `POST /registration`
-* `GET /admin/fasps`（UI）
-* `POST /data_sharing/v0/event_subscriptions`
-* `DELETE /data_sharing/v0/event_subscriptions/{id}`
-* `POST /data_sharing/v0/backfill_requests`
-* `POST /data_sharing/v0/backfill_requests/{id}/continuation`
+- `POST /registration`
+- `GET /admin/fasps`（UI）
+- `POST /data_sharing/v0/event_subscriptions`
+- `DELETE /data_sharing/v0/event_subscriptions/{id}`
+- `POST /data_sharing/v0/backfill_requests`
+- `POST /data_sharing/v0/backfill_requests/{id}/continuation`
 
 （認証：RFC9421、`Content-Digest` 必須）
 
 ### 7.3 takos → FASP（クライアント）
 
-* `GET /provider_info`
-* `POST|DELETE /capabilities/<id>/<version>/activation`
-* `POST /data_sharing/v0/announcements`
-* `GET /trends/v0/content|hashtags|links`
-* `GET /account_search/v0/search`
+- `GET /provider_info`
+- `POST|DELETE /capabilities/<id>/<version>/activation`
+- `POST /data_sharing/v0/announcements`
+- `GET /trends/v0/content|hashtags|links`
+- `GET /account_search/v0/search`
 
 ### 7.4 Nodeinfo 例
 
@@ -259,31 +302,37 @@ service_actor:
 
 ## 8. プライバシー/コンプライアンス
 
-* **共有可能範囲**：公開かつ**discoverable**に同意済みのもののみ（未許可/非公開/Quiet Public/Unlistedは共有禁止）。FASP側も同条件で保存/索引。判定は **FEP-5feb** を使用。
-* **検索語の扱い**：`account_search` では、takosが**検索語**をFASPへ送る可能性があるため、プライバシーポリシーに明記。
+- **共有可能範囲**：公開かつ**discoverable**に同意済みのもののみ（未許可/非公開/Quiet
+  Public/Unlistedは共有禁止）。FASP側も同条件で保存/索引。判定は **FEP-5feb**
+  を使用。
+- **検索語の扱い**：`account_search`
+  では、takosが**検索語**をFASPへ送る可能性があるため、プライバシーポリシーに明記。
 
 ---
 
 ## 9. 運用
 
-* **監視**：署名検証失敗・429・タイムアウト・アナウンス配送遅延をメトリクス化。
-* **リトライ**：指数バックオフ。429は`Retry-After`準拠。
-* **互換性**：ダブルノッキング結果をサーバ単位でキャッシュし、一定期間で再検証。
+- **監視**：署名検証失敗・429・タイムアウト・アナウンス配送遅延をメトリクス化。
+- **リトライ**：指数バックオフ。429は`Retry-After`準拠。
+- **互換性**：ダブルノッキング結果をサーバ単位でキャッシュし、一定期間で再検証。
 
 ---
 
 ## 10. 実装メモ（最小プロトタイプ）
 
-* Actor公開（`/actor`）とinbox/outboxの実装。
-* Nodeinfoに `faspBaseUrl` を追加。
-* RegistrationとCapability有効化の往復。
-* `data_sharing`の event\_subscriptions/backfill 受理・`announcements`送信の最小フロー。
-* `trends`/`account_search` のクライアント呼び出しとUI表示。
+- Actor公開（`/actor`）とinbox/outboxの実装。
+- Nodeinfoに `faspBaseUrl` を追加。
+- RegistrationとCapability有効化の往復。
+- `data_sharing`の event\_subscriptions/backfill
+  受理・`announcements`送信の最小フロー。
+- `trends`/`account_search` のクライアント呼び出しとUI表示。
 
 ---
 
 ## 参考
 
-* FASP General（Intro/Protocol/Registration/Provider Info）
-* FASP Discovery: **data\_sharing** / **trends** / **account\_search**
-* ActivityStreams Actor Types（`Service` 含む） ([W3C][1])
+- FASP General（Intro/Protocol/Registration/Provider Info）
+- FASP Discovery: **data\_sharing** / **trends** / **account\_search**
+- ActivityStreams Actor Types（`Service` 含む） ([W3C][1])
+
+[1]: https://www.w3.org/TR/activitystreams-vocabulary/#actor-types


### PR DESCRIPTION
## Summary
- docs: ActivityStreams Actor Typesへの脚注リンク追加

## Testing
- `deno fmt docs/FASP.md`
- `deno lint`


------
https://chatgpt.com/codex/tasks/task_e_689077647e6083288d473a9e2700790e