### PR TITLE
動画投稿のActivityPub情報を整備

### DIFF
--- a/app/api/DB/host.ts
+++ b/app/api/DB/host.ts
@@ -365,7 +365,7 @@ export class MongoDBHost implements DB {
     const actor = `https://${domain}/users/${author}`;
     const doc = new HostVideo({
       _id: id,
-      attributedTo: author,
+      attributedTo: actor,
       actor_id: actor,
       content,
       extra,

--- a/app/api/DB/local.ts
+++ b/app/api/DB/local.ts
@@ -311,7 +311,7 @@ export class MongoDBLocal implements DB {
     const actor = `https://${domain}/users/${author}`;
     const doc = new Video({
       _id: id,
-      attributedTo: author,
+      attributedTo: actor,
       actor_id: actor,
       content,
       extra,

--- a/app/api/routes/videos.ts
+++ b/app/api/routes/videos.ts
@@ -210,10 +210,12 @@ app.get("/videos", async (c) => {
   const result = list.map((doc, idx) => {
     const info = infos[idx];
     const extra = doc.extra;
+    const acct = `${info.userName}@${info.domain}`;
     return {
       id: String(doc._id),
       title: (extra.title as string) ?? "",
       author: info.displayName,
+      authorAcct: acct,
       authorAvatar: info.authorAvatar,
       thumbnail: (extra.thumbnail as string) ?? "",
       duration: (extra.duration as string) ?? "",
@@ -268,11 +270,13 @@ app.post("/videos", rateLimit({ windowMs: 60_000, limit: 5 }), async (c) => {
 
   const env = getEnv(c);
   const info = await getUserInfo(video.attributedTo as string, domain, env);
+  const acct = `${info.userName}@${info.domain}`;
 
   return c.json({
     id: String(video._id),
     title,
     author: info.displayName,
+    authorAcct: acct,
     authorAvatar: info.authorAvatar,
     thumbnail: video.extra.thumbnail,
     duration: video.extra.duration,

--- a/app/client/src/components/Videos.tsx
+++ b/app/client/src/components/Videos.tsx
@@ -149,10 +149,10 @@ export function Videos() {
     }
   };
 
-  const navigateToProfile = (author: string) => {
+  const navigateToProfile = (acct: string) => {
     // This is a placeholder for navigation.
     // In a real app, you would use a router like solid-router.
-    alert(`Navigate to profile for user: ${author}`);
+    alert(`Navigate to profile for user: ${acct}`);
   };
 
   // ショート動画のスクロール処理
@@ -495,9 +495,7 @@ export function Videos() {
               <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
                 <For each={longVideos()}>
                   {(video) => (
-                    <div
-                      class="group"
-                    >
+                    <div class="group">
                       <div
                         class="relative aspect-video rounded-lg overflow-hidden mb-3 group-hover:scale-105 transition-transform duration-200 cursor-pointer"
                         onClick={() => playVideo(video)}
@@ -520,10 +518,12 @@ export function Videos() {
                       <div class="flex space-x-3">
                         <div
                           class="flex-shrink-0 cursor-pointer"
-                          onClick={() => navigateToProfile(video.author)}
+                          onClick={() => navigateToProfile(video.authorAcct)}
                         >
                           <div class="w-10 h-10 bg-gradient-to-br from-blue-400 to-purple-500 rounded-full flex items-center justify-center">
-                            <span class="text-white text-sm">{video.authorAvatar}</span>
+                            <span class="text-white text-sm">
+                              {video.authorAvatar}
+                            </span>
                           </div>
                         </div>
                         <div class="flex-1 min-w-0">
@@ -535,7 +535,7 @@ export function Videos() {
                           </h3>
                           <p
                             class="text-sm text-gray-400 mb-1 cursor-pointer hover:underline"
-                            onClick={() => navigateToProfile(video.author)}
+                            onClick={() => navigateToProfile(video.authorAcct)}
                           >
                             {video.author}
                           </p>
@@ -591,13 +591,18 @@ export function Videos() {
                         <div class="flex items-center justify-between mb-3">
                           <div
                             class="flex items-center space-x-3 cursor-pointer"
-                            onClick={() => navigateToProfile(currentShort.author)}
+                            onClick={() =>
+                              navigateToProfile(currentShort.authorAcct)}
                           >
                             <div class="w-10 h-10 bg-gradient-to-br from-blue-500 to-purple-600 rounded-full flex items-center justify-center">
-                              <span class="text-white text-sm">{currentShort.authorAvatar}</span>
+                              <span class="text-white text-sm">
+                                {currentShort.authorAvatar}
+                              </span>
                             </div>
                             <div class="flex-1">
-                              <p class="text-white font-semibold">{currentShort.author}</p>
+                              <p class="text-white font-semibold">
+                                {currentShort.author}
+                              </p>
                             </div>
                           </div>
                           <button
@@ -693,7 +698,8 @@ export function Videos() {
                   <div class="flex items-center justify-between mb-4">
                     <div
                       class="flex items-center space-x-4 cursor-pointer"
-                      onClick={() => navigateToProfile(openedVideo()!.author)}
+                      onClick={() =>
+                        navigateToProfile(openedVideo()!.authorAcct)}
                     >
                       <div class="w-12 h-12 bg-gradient-to-br from-blue-500 to-purple-600 rounded-full flex items-center justify-center">
                         <span class="text-white font-semibold">

--- a/app/client/src/components/videos/types.ts
+++ b/app/client/src/components/videos/types.ts
@@ -2,6 +2,7 @@ export interface Video {
   id: string;
   title: string;
   author: string;
+  authorAcct: string;
   authorAvatar: string;
   thumbnail: string;
   duration: string;


### PR DESCRIPTION
## 概要
- 動画保存時の `attributedTo` を ActivityPub 形式の URL に統一
- 動画 API に `authorAcct` を追加しプロフィール遷移に `username@domain` を利用
- フロントエンドで `authorAcct` を扱いプロフィール遷移に使用

## テスト
- `deno fmt app/api/DB/local.ts app/api/DB/host.ts app/api/routes/videos.ts app/client/src/components/Videos.tsx app/client/src/components/videos/types.ts`
- `deno lint app/api/DB/local.ts app/api/DB/host.ts app/api/routes/videos.ts app/client/src/components/Videos.tsx app/client/src/components/videos/types.ts`


------
https://chatgpt.com/codex/tasks/task_e_6890832f4fe48328ae681b03b058c17f