### PR TITLE
Service Actor にフォロワー配信機能を追加

### DIFF
--- a/app/takos_host/root_activitypub.ts
+++ b/app/takos_host/root_activitypub.ts
@@ -17,6 +17,7 @@ import {
   parseActivityRequest,
   storeCreateActivity,
 } from "../api/utils/inbox.ts";
+import { announceToFollowers } from "./service_actor.ts";
 export function createRootActivityPubApp(env: Record<string, string>) {
   const app = new Hono();
   app.use("/*", async (c, next) => {
@@ -81,6 +82,10 @@ export function createRootActivityPubApp(env: Record<string, string>) {
           payload: { timeline: "following", post: formatted },
         });
       }
+      const objectUrl = `https://${domain}/objects/${
+        (stored as { _id?: unknown })._id
+      }`;
+      announceToFollowers(env, objectUrl);
     }
     return jsonResponse(c, { status: "ok" }, 200, "application/activity+json");
   }


### PR DESCRIPTION
## Summary
- Service Actor がフォロワーの inbox を保存し、配信キューを使って Announce を送信
- 公開コンテンツ保存時に Announce Activity を生成し Service Actor の鍵でフォロワーへ配信

## Testing
- `deno fmt app/takos_host/service_actor.ts app/takos_host/root_activitypub.ts`
- `deno lint app/takos_host/service_actor.ts app/takos_host/root_activitypub.ts`


------
https://chatgpt.com/codex/tasks/task_e_68971cc4acf0832890648595a98906a2