### PR TITLE
FASP capability activation API 呼び出しを実装

### DIFF
--- a/app/api/services/fasp.ts
+++ b/app/api/services/fasp.ts
@@ -67,3 +67,20 @@ export async function getFaspBaseUrl(
   if (!rec?.baseUrl) return null;
   return String(rec.baseUrl).replace(/\/$/, "");
 }
+
+// FASP へ capability の有効化/無効化を通知する
+export async function notifyCapabilityActivation(
+  baseUrl: string,
+  identifier: string,
+  version: string,
+  enabled: boolean,
+): Promise<void> {
+  const url = `${
+    baseUrl.replace(/\/$/, "")
+  }/capabilities/${identifier}/${version}/activation`;
+  try {
+    await fetch(url, { method: enabled ? "POST" : "DELETE" });
+  } catch {
+    // エラーは無視
+  }
+}


### PR DESCRIPTION
## 概要
- FASP の `/capabilities/<id>/<version>/activation` を呼び出す関数を追加
- capability 設定ルートで FASP へ有効化/無効化を通知

## テスト
- `deno fmt app/api/services/fasp.ts app/api/routes/fasp.ts`
- `deno lint app/api/services/fasp.ts app/api/routes/fasp.ts`


------
https://chatgpt.com/codex/tasks/task_e_68971cbf4dc48328b4d4fa534703bfbd