### PR TITLE
Ed25519 署名対応

### DIFF
--- a/app/api/utils/activitypub.ts
+++ b/app/api/utils/activitypub.ts
@@ -68,12 +68,12 @@ async function applySignature(
   const cryptoKey = await crypto.subtle.importKey(
     "pkcs8",
     keyData,
-    { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256" },
+    { name: "Ed25519" },
     false,
     ["sign"],
   );
   const signature = await crypto.subtle.sign(
-    "RSASSA-PKCS1-v1_5",
+    "Ed25519",
     cryptoKey,
     encoder.encode(signingString),
   );
@@ -82,7 +82,7 @@ async function applySignature(
   if (style === "cavage" || style === "both") {
     headers.set(
       "Signature",
-      `keyId="${keyId}",algorithm="rsa-sha256",headers="${
+      `keyId="${keyId}",algorithm="ed25519",headers="${
         headersToSign.join(" ")
       }",signature="${signatureB64}"`,
     );
@@ -95,9 +95,7 @@ async function applySignature(
     }
     headers.set(
       "Signature-Input",
-      `sig1="${
-        headersToSign.join(" ")
-      }";keyid="${keyId}";alg="rsa-v1_5-sha256"`,
+      `sig1="${headersToSign.join(" ")}";keyid="${keyId}";alg="ed25519"`,
     );
   }
 }
@@ -349,7 +347,7 @@ export async function verifyHttpSignature(
     const key = await crypto.subtle.importKey(
       "spki",
       keyData,
-      { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256" },
+      { name: "Ed25519" },
       false,
       ["verify"],
     );
@@ -358,7 +356,7 @@ export async function verifyHttpSignature(
     const signingStringBytes = encoder.encode(signingString);
 
     const verified = await crypto.subtle.verify(
-      "RSASSA-PKCS1-v1_5",
+      "Ed25519",
       key,
       signatureBytes,
       signingStringBytes,

--- a/app/shared/crypto.ts
+++ b/app/shared/crypto.ts
@@ -24,12 +24,7 @@ export function pemToArrayBuffer(pem: string): ArrayBuffer {
 
 export async function generateKeyPair() {
   const pair = await crypto.subtle.generateKey(
-    {
-      name: "RSA-PSS",
-      modulusLength: 2048,
-      publicExponent: new Uint8Array([1, 0, 1]),
-      hash: "SHA-256",
-    },
+    { name: "Ed25519" },
     true,
     ["sign", "verify"],
   );


### PR DESCRIPTION
## 概要
- ActivityPub の署名処理を Ed25519 に変更
- FASP サービスの HTTP 署名を Ed25519 対応
- 鍵生成処理を Ed25519 鍵ペアへ更新

## テスト
- `deno fmt app/shared/crypto.ts app/api/utils/activitypub.ts app/api/services/fasp.ts`
- `deno lint app/shared/crypto.ts app/api/utils/activitypub.ts app/api/services/fasp.ts`


------
https://chatgpt.com/codex/tasks/task_e_68972fe8ea348328949a8488ef7995a3