### PR TITLE
公開・discoverable オブジェクトのみ FASP へ通知するよう調整

### DIFF
--- a/app/api/routes/accounts.ts
+++ b/app/api/routes/accounts.ts
@@ -8,7 +8,7 @@ import type { AccountDoc } from "../../shared/types.ts";
 import { b64ToBuf } from "../../shared/buffer.ts";
 import { isUrl } from "../../shared/url.ts";
 import { saveFile } from "../services/file.ts";
-import { sendAnnouncements } from "../services/fasp.ts";
+import { announceIfPublicAndDiscoverable } from "../services/fasp.ts";
 
 function formatAccount(doc: AccountDoc) {
   return {
@@ -104,11 +104,11 @@ app.post("/accounts", async (c) => {
     following: [],
     dms: [],
   });
-  await sendAnnouncements(env, {
+  await announceIfPublicAndDiscoverable(env, {
     category: "account",
     eventType: "new",
     objectUris: [`https://${domain}/users/${account.userName}`],
-  }).catch(() => {});
+  }, account);
   return jsonResponse(c, formatAccount(account));
 });
 
@@ -157,11 +157,11 @@ app.put("/accounts/:id", async (c) => {
 
   const account = await db.updateAccountById(id, data);
   if (!account) return jsonResponse(c, { error: "Account not found" }, 404);
-  await sendAnnouncements(env, {
+  await announceIfPublicAndDiscoverable(env, {
     category: "account",
     eventType: "update",
     objectUris: [`https://${domain}/users/${account.userName}`],
-  }).catch(() => {});
+  }, account);
   return jsonResponse(c, formatAccount(account));
 });
 
@@ -174,11 +174,11 @@ app.delete("/accounts/:id", async (c) => {
   if (!account) return jsonResponse(c, { error: "Account not found" }, 404);
   const deleted = await db.deleteAccountById(id);
   if (!deleted) return jsonResponse(c, { error: "Account not found" }, 404);
-  await sendAnnouncements(env, {
+  await announceIfPublicAndDiscoverable(env, {
     category: "account",
     eventType: "delete",
     objectUris: [`https://${domain}/users/${account.userName}`],
-  }).catch(() => {});
+  }, account);
   return jsonResponse(c, { success: true });
 });
 


### PR DESCRIPTION
## 概要
- FASP アナウンス送信前に公開/`discoverable` を確認する共通ヘルパーを追加
- アカウントと投稿のルートでヘルパーを利用し、非公開や `discoverable=false` の場合は送信しないよう変更

## テスト
- `deno fmt app/api/services/fasp.ts app/api/routes/accounts.ts app/api/routes/posts.ts`
- `deno lint app/api/services/fasp.ts app/api/routes/accounts.ts app/api/routes/posts.ts`


------
https://chatgpt.com/codex/tasks/task_e_68972fed72cc8328b521bffa8d0b66da