### PR TITLE
FASP登録APIのレスポンスを201に変更

### DIFF
--- a/app/api/routes/fasp.ts
+++ b/app/api/routes/fasp.ts
@@ -80,7 +80,7 @@ app.post("/fasp/registration", async (c) => {
     faspId,
     publicKey: takosPublicKey,
     registrationCompletionUri,
-  });
+  }, 201);
 });
 
 // data_sharing v0.1: event_subscriptions の受信（作成）


### PR DESCRIPTION
## Summary
- FASP登録APIで生成したfaspIdや鍵情報を201ステータスで返すように変更
- 仕様書の要求通り、faspId・publicKey・registrationCompletionUriを含むレスポンスを確認

## Testing
- `deno fmt app/api/routes/fasp.ts`
- `deno lint app/api/routes/fasp.ts`


------
https://chatgpt.com/codex/tasks/task_e_689739b6cb848328ab153679725d756f