### PR TITLE
MLSのキー管理とグループ状態更新を実装

### DIFF
--- a/app/client/src/components/e2ee/api.ts
+++ b/app/client/src/components/e2ee/api.ts
@@ -404,3 +404,86 @@ export const removeDm = async (
     return false;
   }
 };
+
+// MLS関連のサーバ通信
+export interface MLSProposalPayload {
+  type: "add" | "remove";
+  member: string;
+  keyPackage?: string;
+}
+
+export interface MLSCommitPayload {
+  epoch: number;
+  proposals: MLSProposalPayload[];
+}
+
+export interface MLSWelcomePayload {
+  epoch: number;
+  tree: Record<string, string>;
+  secret: string;
+}
+
+export const sendProposal = async (
+  user: string,
+  groupId: string,
+  proposal: MLSProposalPayload,
+): Promise<boolean> => {
+  try {
+    const res = await apiFetch(
+      `/api/users/${encodeURIComponent(user)}/groups/${
+        encodeURIComponent(groupId)
+      }/proposals`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(proposal),
+      },
+    );
+    return res.ok;
+  } catch (err) {
+    console.error("Error sending proposal:", err);
+    return false;
+  }
+};
+
+export const sendCommit = async (
+  user: string,
+  groupId: string,
+  commit: MLSCommitPayload,
+): Promise<boolean> => {
+  try {
+    const res = await apiFetch(
+      `/api/users/${encodeURIComponent(user)}/groups/${
+        encodeURIComponent(groupId)
+      }/commit`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(commit),
+      },
+    );
+    return res.ok;
+  } catch (err) {
+    console.error("Error sending commit:", err);
+    return false;
+  }
+};
+
+export const fetchWelcome = async (
+  user: string,
+  groupId: string,
+): Promise<MLSWelcomePayload | null> => {
+  try {
+    const res = await apiFetch(
+      `/api/users/${encodeURIComponent(user)}/groups/${
+        encodeURIComponent(groupId)
+      }/welcome`,
+    );
+    if (!res.ok) return null;
+    const data = await res.json();
+    return data as MLSWelcomePayload;
+  } catch (err) {
+    console.error("Error fetching welcome:", err);
+    return null;
+  }
+};

--- a/app/client/src/components/e2ee/storage.ts
+++ b/app/client/src/components/e2ee/storage.ts
@@ -2,7 +2,8 @@ import type { StoredMLSGroupState, StoredMLSKeyPair } from "./mls.ts";
 import { load as loadStore, type Store } from "@tauri-apps/plugin-store";
 import { isTauri } from "../../utils/config.ts";
 
-const DB_VERSION = 4;
+// グループ状態の構造が変わったためバージョンを更新
+const DB_VERSION = 5;
 const STORE_NAME = "mlsGroups";
 const KEY_STORE = "mlsKeyPairs";
 const CACHE_STORE = "cache";


### PR DESCRIPTION
## 概要
- KeyPackage生成処理を追加し保存形式に対応
- グループ状態にMLSツリーとepochを保持
- Proposal/Commit/Welcome送受信のAPIを追加
- 永続化用DBのバージョン更新

## テスト
- `deno fmt app/client/src/components/e2ee/mls.ts app/client/src/components/e2ee/storage.ts app/client/src/components/e2ee/api.ts`
- `deno lint app/client/src/components/e2ee/mls.ts app/client/src/components/e2ee/storage.ts app/client/src/components/e2ee/api.ts`


------
https://chatgpt.com/codex/tasks/task_e_68974b0ffd008328951630158e981da3