### PR TITLE
ActivityPub グループAPIの追加

### DIFF
--- a/app/api/DB/local.ts
+++ b/app/api/DB/local.ts
@@ -269,6 +269,28 @@ export class MongoDBLocal implements DB {
     return acc?.groups ?? [];
   }
 
+  async findGroup(groupId: string) {
+    const acc = await Account.findOne({ "groups.id": groupId }).lean<
+      | {
+        _id: unknown;
+        groups: { id: string; name: string; members: string[] }[];
+      }
+      | null
+    >();
+    const group = acc?.groups.find((g) => g.id === groupId);
+    if (!group || !acc?._id) return null;
+    return { owner: String(acc._id), group };
+  }
+
+  async updateGroup(
+    owner: string,
+    group: { id: string; name: string; members: string[] },
+  ) {
+    await Account.updateOne({ _id: owner, "groups.id": group.id }, {
+      $set: { "groups.$": group },
+    });
+  }
+
   async saveNote(
     domain: string,
     author: string,

--- a/app/api/routes/groups.ts
+++ b/app/api/routes/groups.ts
@@ -2,19 +2,148 @@ import { Hono } from "hono";
 import { createDB } from "../DB/mod.ts";
 import authRequired from "../utils/auth.ts";
 import { getEnv } from "../../shared/config.ts";
-import { jsonResponse } from "../utils/activitypub.ts";
+import {
+  deliverActivityPubObject,
+  getDomain,
+  jsonResponse,
+} from "../utils/activitypub.ts";
 
-// グループ管理 API
+// グループ管理 API (ActivityPub 対応)
 const app = new Hono();
-app.use("/accounts/*", authRequired);
 
-app.get("/accounts/:id/groups", async (c) => {
+// ActivityPub グループ一覧取得
+app.get("/ap/groups", async (c) => {
+  const owner = c.req.query("owner");
+  if (!owner) return jsonResponse(c, { error: "missing owner" }, 400);
+  const db = createDB(getEnv(c));
+  const account = await db.findAccountById(owner);
+  if (!account) return jsonResponse(c, { error: "Account not found" }, 404);
+  const groups = await db.listGroups(owner);
+  return jsonResponse(c, { groups });
+});
+
+// グループアクター取得
+app.get("/ap/groups/:id", async (c) => {
   const id = c.req.param("id");
   const db = createDB(getEnv(c));
-  const account = await db.findAccountById(id);
+  const result = await db.findGroup(id);
+  if (!result) return jsonResponse(c, { error: "Group not found" }, 404);
+  const domain = getDomain(c);
+  const actor = {
+    "@context": "https://www.w3.org/ns/activitystreams",
+    id: `https://${domain}/ap/groups/${id}`,
+    type: "Group",
+    name: result.group.name,
+    members: result.group.members,
+  };
+  return jsonResponse(c, actor, 200, "application/activity+json");
+});
+
+// グループ作成
+app.post("/ap/groups", authRequired, async (c) => {
+  const body = await c.req.json();
+  if (
+    typeof body !== "object" ||
+    typeof body.owner !== "string" ||
+    typeof body.name !== "string" ||
+    !Array.isArray(body.members)
+  ) {
+    return jsonResponse(c, { error: "invalid group" }, 400);
+  }
+  const group = {
+    id: typeof body.id === "string" ? body.id : crypto.randomUUID(),
+    name: body.name,
+    members: body.members.filter((m: unknown) => typeof m === "string"),
+  };
+  const db = createDB(getEnv(c));
+  const account = await db.findAccountById(body.owner);
   if (!account) return jsonResponse(c, { error: "Account not found" }, 404);
-  const groups = await db.listGroups(id);
-  return jsonResponse(c, { groups });
+  await db.addGroup(body.owner, group);
+  const domain = getDomain(c);
+  const actor = {
+    "@context": "https://www.w3.org/ns/activitystreams",
+    id: `https://${domain}/ap/groups/${group.id}`,
+    type: "Group",
+    name: group.name,
+    members: group.members,
+  };
+  return jsonResponse(c, actor, 201, "application/activity+json");
+});
+
+// メンバー変更 (Add/Remove または MLS Proposal)
+app.post("/ap/groups/:id/members", authRequired, async (c) => {
+  const id = c.req.param("id");
+  const body = await c.req.json();
+  const db = createDB(getEnv(c));
+  const result = await db.findGroup(id);
+  if (!result) return jsonResponse(c, { error: "Group not found" }, 404);
+  const { owner, group } = result;
+  const account = await db.findAccountById(owner);
+  if (!account) return jsonResponse(c, { error: "Account not found" }, 404);
+  const domain = getDomain(c);
+
+  if (body.type === "Add" && typeof body.object === "string") {
+    if (!group.members.includes(body.object)) {
+      group.members.push(body.object);
+      await db.updateGroup(owner, group);
+    }
+    const activity = {
+      "@context": "https://www.w3.org/ns/activitystreams",
+      type: "Add",
+      actor: `https://${domain}/ap/groups/${id}`,
+      object: body.object,
+      target: `https://${domain}/ap/groups/${id}`,
+    };
+    deliverActivityPubObject(
+      group.members,
+      activity,
+      account.userName,
+      domain,
+      getEnv(c),
+    ).catch((err) => console.error("Delivery failed:", err));
+    return jsonResponse(c, { members: group.members });
+  }
+
+  if (body.type === "Remove" && typeof body.object === "string") {
+    group.members = group.members.filter((m) => m !== body.object);
+    await db.updateGroup(owner, group);
+    const activity = {
+      "@context": "https://www.w3.org/ns/activitystreams",
+      type: "Remove",
+      actor: `https://${domain}/ap/groups/${id}`,
+      object: body.object,
+      target: `https://${domain}/ap/groups/${id}`,
+    };
+    deliverActivityPubObject(
+      group.members,
+      activity,
+      account.userName,
+      domain,
+      getEnv(c),
+    ).catch((err) => console.error("Delivery failed:", err));
+    return jsonResponse(c, { members: group.members });
+  }
+
+  if (body.type === "Proposal") {
+    deliverActivityPubObject(
+      group.members,
+      body,
+      account.userName,
+      domain,
+      getEnv(c),
+    ).catch((err) => console.error("Delivery failed:", err));
+    return jsonResponse(c, { members: group.members });
+  }
+
+  return jsonResponse(c, { error: "invalid activity" }, 400);
+});
+
+// --- 旧API 互換レイヤー ---
+app.use("/accounts/*", authRequired);
+
+app.get("/accounts/:id/groups", (c) => {
+  const id = c.req.param("id");
+  return c.redirect(`/ap/groups?owner=${id}`, 307);
 });
 
 app.post("/accounts/:id/groups", async (c) => {

--- a/app/shared/db.ts
+++ b/app/shared/db.ts
@@ -43,6 +43,18 @@ export interface DB {
     id: string,
     groupId: string,
   ): Promise<{ id: string; name: string; members: string[] }[]>;
+  findGroup(
+    groupId: string,
+  ): Promise<
+    {
+      owner: string;
+      group: { id: string; name: string; members: string[] };
+    } | null
+  >;
+  updateGroup(
+    owner: string,
+    group: { id: string; name: string; members: string[] },
+  ): Promise<void>;
   saveNote(
     domain: string,
     author: string,

--- a/docs/activitypub-e2ee/README.md
+++ b/docs/activitypub-e2ee/README.md
@@ -13,3 +13,17 @@ Text and code in this repository is licensed under the
 
 Work by Evan Prodromou and Tom Coates is also licensed under the
 [CC+ License](https://summerofprotocols.com/ccplus-license-2023).
+
+## グループAPIの利用方法
+
+ActivityPub 経由でグループを管理するためのエンドポイントを提供します。
+
+- `POST /ap/groups` でグループアクターを作成します。パラメーターは
+  `owner`（アカウントID）、`name`、`members`（メンバーの配列）です。
+- `GET /ap/groups/:id` で作成したグループアクターを取得できます。
+- メンバーの追加や削除は `POST /ap/groups/:id/members` に ActivityPub の `Add` /
+  `Remove` アクティビティ、または MLS `Proposal`
+  を送信して行います。変更は連合先にも配信されます。
+
+従来の `/accounts/:id/groups` エンドポイントは互換レイヤーとして残されており、
+新しい API へリダイレクトされます。


### PR DESCRIPTION
## 概要
- Group アクターを作成・取得する ActivityPub エンドポイントを追加
- Add/Remove や MLS Proposal によるメンバー変更と連合配信に対応
- 旧 `/accounts/:id/groups` エンドポイントを互換レイヤーとしてリダイレクト
- グループAPIの利用方法をドキュメントに追記

## テスト
- `deno fmt app/shared/db.ts app/api/DB/local.ts app/api/DB/host.ts app/api/routes/groups.ts docs/activitypub-e2ee/README.md`
- `deno lint app/shared/db.ts app/api/DB/local.ts app/api/DB/host.ts app/api/routes/groups.ts docs/activitypub-e2ee/README.md`


------
https://chatgpt.com/codex/tasks/task_e_68974b16fdac8328b1ff7f2789905af4