### PR TITLE
MLS 暗号メッセージの送受信を改善

### DIFF
--- a/app/client/src/components/e2ee/api.ts
+++ b/app/client/src/components/e2ee/api.ts
@@ -25,6 +25,16 @@ export interface EncryptedMessage {
   }[];
 }
 
+export interface EncryptedMessagePayload {
+  "@context"?: string | string[];
+  type?: string;
+  to: string[];
+  content: string;
+  mediaType?: string;
+  encoding?: string;
+  attachments?: unknown[];
+}
+
 export const fetchKeyPackages = async (
   user: string,
   domain?: string,
@@ -87,13 +97,7 @@ export const deleteKeyPackage = async (
 
 export const sendEncryptedMessage = async (
   user: string,
-  data: {
-    to: string[];
-    content: string;
-    mediaType?: string;
-    encoding?: string;
-    attachments?: unknown[];
-  },
+  data: EncryptedMessagePayload,
 ): Promise<boolean> => {
   try {
     const res = await apiFetch(


### PR DESCRIPTION
## 概要
- EncryptedMessage オブジェクトを生成し `application/mls+json` として送信
- MLS メッセージの復号失敗時に暗号化データを表示するフォールバックを追加
- `sendEncryptedMessage` の型定義を拡張

## テスト
- `deno fmt app/client/src/components/e2ee/api.ts app/client/src/components/Chat.tsx`
- `deno lint app/client/src/components/e2ee/api.ts app/client/src/components/Chat.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68974b1da7f88328abb1746c687d4b4d