### PR TITLE
SSL証明書を環境変数から読み込むよう変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ takosは、ActivityPubに追加で、以下の機能を提供します。
 環境変数を設定したら、`app/api` ディレクトリからサーバーを起動します。
 特定のインターフェースのみで待ち受けたい場合は `SERVER_HOST`
 を、ポート番号を変更したい場合は `SERVER_PORT` を設定してください。HTTPS
-を利用する場合は `SERVER_CERT_FILE` と `SERVER_KEY_FILE` を指定します。
+を利用する場合は `SERVER_CERT` と `SERVER_KEY`
+に証明書と秘密鍵の内容を直接指定します。
 開発環境で自己署名証明書を使用する際は、起動時に
 `--unsafely-ignore-certificate-errors` を付けると SSL エラーを無視できます。
 

--- a/app/api/.env.example
+++ b/app/api/.env.example
@@ -4,11 +4,11 @@ DB_MODE=local
 SERVER_HOST=
 # サーバーのポート番号 (省略時は 80)
 SERVER_PORT=80
-# HTTPS を有効にする場合は証明書と鍵ファイルを指定
-# 例: SERVER_CERT_FILE=./cert.pem
-SERVER_CERT_FILE=
-# 例: SERVER_KEY_FILE=./key.pem
-SERVER_KEY_FILE=
+# HTTPS を有効にする場合は証明書と鍵の内容を直接指定
+# 例: SERVER_CERT="-----BEGIN CERTIFICATE-----\\n...\\n-----END CERTIFICATE-----\\n"
+SERVER_CERT=
+# 例: SERVER_KEY="-----BEGIN PRIVATE KEY-----\\n...\\n-----END PRIVATE KEY-----\\n"
+SERVER_KEY=
 hashedPassword=$2a$10$KpzI70.g4V42p7KczcR.jeFayt7mL1rCFgX37IqY1V9PDzHSglPWW
 salt=
 ACTIVITYPUB_DOMAIN=dev.takos.jp

--- a/app/api/index.ts
+++ b/app/api/index.ts
@@ -17,22 +17,9 @@ if (env["ACTIVITYPUB_DOMAIN"]) {
 const app = await createTakosApp(env);
 const hostname = env["SERVER_HOST"];
 const port = Number(env["SERVER_PORT"] ?? "80");
-const certFile = env["SERVER_CERT_FILE"];
-const keyFile = env["SERVER_KEY_FILE"];
-let options: Deno.ServeTlsOptions | Deno.ServeOptions = {
-  port,
-  hostname,
-};
-if (certFile && keyFile) {
-  try {
-    options = {
-      port,
-      hostname,
-      cert: await Deno.readTextFile(certFile),
-      key: await Deno.readTextFile(keyFile),
-    };
-  } catch (e) {
-    console.error("SSL証明書を読み込めませんでした:", e);
-  }
-}
+const cert = env["SERVER_CERT"]?.replace(/\\n/g, "\n");
+const key = env["SERVER_KEY"]?.replace(/\\n/g, "\n");
+const options = cert && key
+  ? { hostname, port, cert, key }
+  : { hostname, port };
 Deno.serve(options, app.fetch);

--- a/app/api/server.ts
+++ b/app/api/server.ts
@@ -135,19 +135,16 @@ if (import.meta.main) {
   const app = await createTakosApp(env);
   const hostname = env["SERVER_HOST"];
   const port = Number(env["SERVER_PORT"] ?? "80");
-  const certFile = env["SERVER_CERT_FILE"];
-  const keyFile = env["SERVER_KEY_FILE"];
+  const cert = env["SERVER_CERT"]?.replace(/\\n/g, "\n");
+  const key = env["SERVER_KEY"]?.replace(/\\n/g, "\n");
 
   // Deno.serve のオプションは top-level に port, hostname を直接渡す
   // TLS の場合は cert/key を追加で渡す
   // Deno.serve は options として { hostname, port, cert, key } を受け取るが、
   // 型名はバージョンにより変動するため型注釈を外して実行時に渡す。
-  const options = {
-    hostname,
-    port,
-    cert: certFile ? await Deno.readTextFile(certFile) : undefined,
-    key: keyFile ? await Deno.readTextFile(keyFile) : undefined,
-  };
+  const options = cert && key
+    ? { hostname, port, cert, key }
+    : { hostname, port };
 
   Deno.serve(options, app.fetch);
 }

--- a/app/takos_host/.env.example
+++ b/app/takos_host/.env.example
@@ -14,11 +14,11 @@ SERVER_HOST=
 # サーバーのポート番号 (省略時は 80)
 SERVER_PORT=80
 
-# HTTPS を有効にする場合は証明書と鍵ファイルを指定
-# 例: SERVER_CERT_FILE=./cert.pem
-SERVER_CERT_FILE=
-# 例: SERVER_KEY_FILE=./key.pem
-SERVER_KEY_FILE=
+# HTTPS を有効にする場合は証明書と鍵の内容を直接指定
+# 例: SERVER_CERT="-----BEGIN CERTIFICATE-----\\n...\\n-----END CERTIFICATE-----\\n"
+SERVER_CERT=
+# 例: SERVER_KEY="-----BEGIN PRIVATE KEY-----\\n...\\n-----END PRIVATE KEY-----\\n"
+SERVER_KEY=
 
 # マルチテナント用のデフォルトルートドメイン
 ROOT_DOMAIN=takos.jp

--- a/app/takos_host/README.md
+++ b/app/takos_host/README.md
@@ -108,8 +108,9 @@ OAuth ボタンを表示します。
 2. `deno run -A app/takos_host/main.ts` でサーバーを起動します。
    特定のインターフェースのみで待ち受けたい場合は `SERVER_HOST`、
    ポート番号を変更したい場合は `SERVER_PORT` を設定してください。 HTTPS
-   で待ち受けるには `SERVER_CERT_FILE` と `SERVER_KEY_FILE`
-   を指定します。開発モードでは `--unsafely-ignore-certificate-errors`
+   で待ち受けるには `SERVER_CERT` と `SERVER_KEY`
+   に証明書と秘密鍵の内容を直接指定します。開発モードでは
+   `--unsafely-ignore-certificate-errors`
    を付けて起動することで自己署名証明書などの SSL エラーを無視します。
 
 ## CLI 管理ツール

--- a/app/takos_host/main.ts
+++ b/app/takos_host/main.ts
@@ -179,7 +179,10 @@ if (isDev) {
     root.use(async (c, next) => {
       const host = getRealHost(c);
       if (host === rootDomain) {
-        if (serviceActorApp && /^(\/actor|\/inbox|\/outbox)(\/|$)?/.test(c.req.path)) {
+        if (
+          serviceActorApp &&
+          /^(\/actor|\/inbox|\/outbox)(\/|$)?/.test(c.req.path)
+        ) {
           const resSvc = await serviceActorApp.fetch(c.req.raw);
           if (resSvc.status !== 404) return resSvc;
         }
@@ -198,7 +201,10 @@ if (isDev) {
     root.use(async (c, next) => {
       const host = getRealHost(c);
       if (host === rootDomain) {
-        if (serviceActorApp && /^(\/actor|\/inbox|\/outbox)(\/|$)?/.test(c.req.path)) {
+        if (
+          serviceActorApp &&
+          /^(\/actor|\/inbox|\/outbox)(\/|$)?/.test(c.req.path)
+        ) {
           const resSvc = await serviceActorApp.fetch(c.req.raw);
           if (resSvc.status !== 404) return resSvc;
         }
@@ -261,30 +267,14 @@ root.use(logger());
 const hostname = hostEnv["SERVER_HOST"];
 // サーバーのポート番号 (未指定時は 80)
 const port = Number(hostEnv["SERVER_PORT"] ?? "80");
+const cert = hostEnv["SERVER_CERT"]?.replace(/\\n/g, "\n");
+const key = hostEnv["SERVER_KEY"]?.replace(/\\n/g, "\n");
 
-const certFile = hostEnv["SERVER_CERT_FILE"];
-const keyFile = hostEnv["SERVER_KEY_FILE"];
-
-if (certFile && keyFile) {
+if (cert && key) {
   try {
-    const moduleDir = dirname(fromFileUrl(import.meta.url));
-    const projectRoot = join(moduleDir, "..", "..");
-    const cert = await Deno.readTextFile(
-      join(
-        projectRoot,
-        certFile.startsWith("../") ? certFile.substring(3) : certFile,
-      ),
-    );
-    const key = await Deno.readTextFile(
-      join(
-        projectRoot,
-        keyFile.startsWith("../") ? keyFile.substring(3) : keyFile,
-      ),
-    );
-    // hostname を追加
     Deno.serve({ hostname, port, cert, key }, root.fetch);
   } catch (e) {
-    console.error("SSL証明書を読み込めませんでした:", e);
+    console.error("SSL証明書の設定に失敗しました:", e);
     Deno.serve({ hostname, port }, root.fetch);
   }
 } else {


### PR DESCRIPTION
## 概要
- TLS設定をファイルパスではなく環境変数に直接記述する方式へ変更
- READMEと各.env.exampleを更新

## テスト
- `deno fmt README.md app/api/.env.example app/api/index.ts app/api/server.ts app/takos_host/.env.example app/takos_host/README.md app/takos_host/main.ts`
- `deno lint app/api/index.ts app/api/server.ts app/takos_host/main.ts`


------
https://chatgpt.com/codex/tasks/task_e_6898a2e2e5488328994dfb051fa9ecef