### PR TITLE
トークルーム検索APIにグループ情報を統合

### DIFF
--- a/app/api/DB/host.ts
+++ b/app/api/DB/host.ts
@@ -20,7 +20,7 @@ import Instance from "../../takos_host/models/instance.ts";
 import OAuthClient from "../../takos_host/models/oauth_client.ts";
 import HostDomain from "../../takos_host/models/domain.ts";
 import mongoose from "mongoose";
-import type { DB, ListOpts } from "../../shared/db.ts";
+import type { DB, GroupInfo, ListOpts } from "../../shared/db.ts";
 import type { AccountDoc, SessionDoc } from "../../shared/types.ts";
 import type { SortOrder } from "mongoose";
 import type { Db } from "mongodb";
@@ -264,14 +264,14 @@ export class MongoDBHost implements DB {
       _id: id,
       tenant_id: this.tenantId,
     }).lean<
-      { groups?: { id: string; name: string; members: string[] }[] } | null
+      { groups?: GroupInfo[] } | null
     >();
     return acc?.groups ?? [];
   }
 
   async addGroup(
     id: string,
-    group: { id: string; name: string; members: string[] },
+    group: GroupInfo,
   ) {
     const acc = await HostAccount.findOneAndUpdate({
       _id: id,
@@ -299,7 +299,7 @@ export class MongoDBHost implements DB {
     }).lean<
       | {
         _id: unknown;
-        groups: { id: string; name: string; members: string[] }[];
+        groups: GroupInfo[];
       }
       | null
     >();
@@ -310,7 +310,7 @@ export class MongoDBHost implements DB {
 
   async updateGroup(
     owner: string,
-    group: { id: string; name: string; members: string[] },
+    group: GroupInfo,
   ) {
     await HostAccount.updateOne({
       _id: owner,

--- a/app/api/DB/local.ts
+++ b/app/api/DB/local.ts
@@ -20,7 +20,7 @@ import OAuthClient from "../../takos_host/models/oauth_client.ts";
 import HostDomain from "../../takos_host/models/domain.ts";
 import Tenant from "../models/takos/tenant.ts";
 import mongoose from "mongoose";
-import type { DB, ListOpts } from "../../shared/db.ts";
+import type { DB, GroupInfo, ListOpts } from "../../shared/db.ts";
 import type { AccountDoc, SessionDoc } from "../../shared/types.ts";
 import type { SortOrder } from "mongoose";
 import type { Db } from "mongodb";
@@ -226,14 +226,14 @@ export class MongoDBLocal implements DB {
 
   async listGroups(id: string) {
     const acc = await Account.findOne({ _id: id }).lean<
-      { groups?: { id: string; name: string; members: string[] }[] } | null
+      { groups?: GroupInfo[] } | null
     >();
     return acc?.groups ?? [];
   }
 
   async addGroup(
     id: string,
-    group: { id: string; name: string; members: string[] },
+    group: GroupInfo,
   ) {
     const acc = await Account.findOneAndUpdate({ _id: id }, {
       $push: { groups: group },
@@ -252,7 +252,7 @@ export class MongoDBLocal implements DB {
     const acc = await Account.findOne({ "groups.id": groupId }).lean<
       | {
         _id: unknown;
-        groups: { id: string; name: string; members: string[] }[];
+        groups: GroupInfo[];
       }
       | null
     >();
@@ -263,7 +263,7 @@ export class MongoDBLocal implements DB {
 
   async updateGroup(
     owner: string,
-    group: { id: string; name: string; members: string[] },
+    group: GroupInfo,
   ) {
     await Account.updateOne({ _id: owner, "groups.id": group.id }, {
       $set: { "groups.$": group },

--- a/app/shared/db.ts
+++ b/app/shared/db.ts
@@ -9,6 +9,15 @@ export interface ListOpts {
   before?: Date;
 }
 
+/** グループ情報 */
+export interface GroupInfo {
+  id: string;
+  name: string;
+  icon?: string;
+  userSet?: { name?: boolean; icon?: boolean };
+  members: string[];
+}
+
 /** DB 抽象インターフェース */
 export interface DB {
   getObject(id: string): Promise<unknown | null>;
@@ -31,26 +40,26 @@ export interface DB {
   removeFollowing(id: string, target: string): Promise<string[]>;
   listGroups(
     id: string,
-  ): Promise<{ id: string; name: string; members: string[] }[]>;
+  ): Promise<GroupInfo[]>;
   addGroup(
     id: string,
-    group: { id: string; name: string; members: string[] },
-  ): Promise<{ id: string; name: string; members: string[] }[]>;
+    group: GroupInfo,
+  ): Promise<GroupInfo[]>;
   removeGroup(
     id: string,
     groupId: string,
-  ): Promise<{ id: string; name: string; members: string[] }[]>;
+  ): Promise<GroupInfo[]>;
   findGroup(
     groupId: string,
   ): Promise<
     {
       owner: string;
-      group: { id: string; name: string; members: string[] };
+      group: GroupInfo;
     } | null
   >;
   updateGroup(
     owner: string,
-    group: { id: string; name: string; members: string[] },
+    group: GroupInfo,
   ): Promise<void>;
   saveNote(
     domain: string,


### PR DESCRIPTION
## 概要
- DBインターフェースにグループの名前・アイコン設定情報を追加
- `/api/rooms` でグループメタデータを統合し、友だち/グループ判定に対応
- ルーム一覧取得時に最終メッセージ時刻を反映

## テスト
- `deno fmt app/api/routes/groups.ts app/client/src/components/Chat.tsx app/api/DB/local.ts app/api/DB/host.ts app/shared/db.ts`
- `deno lint`

------
https://chatgpt.com/codex/tasks/task_e_6899483d21ec8328937e78dbc6bd236c