### PR TITLE
友だちとのDM作成ボタンを実装

### DIFF
--- a/app/client/src/components/Chat.tsx
+++ b/app/client/src/components/Chat.tsx
@@ -450,11 +450,10 @@ export function Chat(props: ChatProps) {
   const [showGroupDialog, setShowGroupDialog] = createSignal(false);
   const [groupDialogMode, setGroupDialogMode] = createSignal<
     "create" | "invite" | "dm"
-  >("create");
+  >("dm");
   const [segment, setSegment] = createSignal<"all" | "people" | "groups">(
     "all",
   );
-  const [friendGroupTarget, setFriendGroupTarget] = createSignal<string | null>(null);
 
   // ルーム重複防止ユーティリティ
   function upsertRooms(next: Room[]) {
@@ -701,19 +700,30 @@ export function Chat(props: ChatProps) {
           data?: string;
           url?: string;
           mediaType: string;
-          preview?: { url?: string; data?: string; mediaType?: string; key?: string; iv?: string };
+          preview?: {
+            url?: string;
+            data?: string;
+            mediaType?: string;
+            key?: string;
+            iv?: string;
+          };
         }[]
         | undefined;
       if (Array.isArray(listAtt)) {
         attachments = [];
         for (const at of listAtt) {
           if (typeof at.url === "string") {
-            const attachmentItem = at as typeof at & { preview?: ActivityPubPreview };
+            const attachmentItem = at as typeof at & {
+              preview?: ActivityPubPreview;
+            };
             const mt = typeof attachmentItem.mediaType === "string"
               ? attachmentItem.mediaType
               : "application/octet-stream";
             let preview;
-            if (attachmentItem.preview && typeof attachmentItem.preview.url === "string") {
+            if (
+              attachmentItem.preview &&
+              typeof attachmentItem.preview.url === "string"
+            ) {
               const previewItem = attachmentItem.preview;
               const pmt = typeof previewItem.mediaType === "string"
                 ? previewItem.mediaType
@@ -725,7 +735,11 @@ export function Chat(props: ChatProps) {
                   typeof previewItem.key === "string" &&
                   typeof previewItem.iv === "string"
                 ) {
-                  pbuf = await decryptFile(pbuf, previewItem.key, previewItem.iv);
+                  pbuf = await decryptFile(
+                    pbuf,
+                    previewItem.key,
+                    previewItem.iv,
+                  );
                 }
                 preview = { url: bufToUrl(pbuf, pmt), mediaType: pmt };
               } catch {
@@ -735,8 +749,15 @@ export function Chat(props: ChatProps) {
             try {
               const res = await fetch(attachmentItem.url);
               let buf = await res.arrayBuffer();
-              if (typeof attachmentItem.key === "string" && typeof attachmentItem.iv === "string") {
-                buf = await decryptFile(buf, attachmentItem.key, attachmentItem.iv);
+              if (
+                typeof attachmentItem.key === "string" &&
+                typeof attachmentItem.iv === "string"
+              ) {
+                buf = await decryptFile(
+                  buf,
+                  attachmentItem.key,
+                  attachmentItem.iv,
+                );
               }
               if (
                 mt.startsWith("video/") ||
@@ -756,7 +777,11 @@ export function Chat(props: ChatProps) {
                 });
               }
             } catch {
-              attachments.push({ url: attachmentItem.url, mediaType: mt, preview });
+              attachments.push({
+                url: attachmentItem.url,
+                mediaType: mt,
+                preview,
+              });
             }
           }
         }
@@ -846,9 +871,13 @@ export function Chat(props: ChatProps) {
         hasName: r.hasName,
         hasIcon: r.hasIcon,
         lastMessage: "...",
-        lastMessageTime: (r as RoomsSearchItem & { lastMessageAt?: string }).lastMessageAt
-          ? new Date((r as RoomsSearchItem & { lastMessageAt?: string }).lastMessageAt!)
-          : undefined,
+        lastMessageTime:
+          (r as RoomsSearchItem & { lastMessageAt?: string }).lastMessageAt
+            ? new Date(
+              (r as RoomsSearchItem & { lastMessageAt?: string })
+                .lastMessageAt!,
+            )
+            : undefined,
       });
     }
 
@@ -950,45 +979,6 @@ export function Chat(props: ChatProps) {
     await sendHandshake(me, toList, ccList, "hi");
     setSelectedRoom(partner);
     setShowGroupDialog(false);
-  };
-
-  // 友達との新しいグループルーム作成
-  const startFriendGroup = async (groupName: string, membersInput: string) => {
-    const user = account();
-    const friendId = friendGroupTarget();
-    if (!user || !friendId) return;
-
-    // 友達を含むメンバーリストを作成
-    const inputMembers = membersInput ? membersInput.split(",").map(m => m.trim()).filter(Boolean) : [];
-    const allMembers = [friendId, ...inputMembers.filter(m => m !== friendId)];
-
-    if (allMembers.length === 1) {
-      // 友達のみの場合はDMとして作成
-      await startDm("", friendId);
-      return;
-    }
-
-    // グループルーム作成の実装（実際のAPIコールは省略）
-    const groupId = crypto.randomUUID();
-    const room: Room = {
-      id: groupId,
-      name: groupName || `${allMembers.slice(0, 2).map(m => m.split('@')[0]).join("、")}${allMembers.length > 2 ? ` ほか${allMembers.length - 2}名` : ""}`,
-      userName: user.userName,
-      domain: getDomain(),
-      avatar: "👥",
-      unreadCount: 0,
-      type: "group",
-      members: allMembers,
-      hasName: !!groupName,
-      hasIcon: false,
-      lastMessage: "...",
-      lastMessageTime: undefined,
-    };
-
-    upsertRoom(room);
-    setSelectedRoom(groupId);
-    setShowGroupDialog(false);
-    setFriendGroupTarget(null);
   };
 
   const sendMessage = async () => {
@@ -1542,10 +1532,8 @@ export function Chat(props: ChatProps) {
               onCreateDm={openDmDialog}
               segment={segment()}
               onSegmentChange={setSegment}
-              onCreateFriendGroup={(friendId: string) => {
-                setFriendGroupTarget(friendId);
-                setGroupDialogMode("create");
-                setShowGroupDialog(true);
+              onCreateFriendDm={(friendId: string) => {
+                startDm("", friendId);
               }}
             />
           </div>
@@ -1624,15 +1612,8 @@ export function Chat(props: ChatProps) {
         mode={groupDialogMode()}
         onClose={() => {
           setShowGroupDialog(false);
-          setFriendGroupTarget(null);
         }}
-        onCreate={(name: string, members: string) => {
-          if (friendGroupTarget()) {
-            return startFriendGroup(name, members);
-          } else {
-            return startDm(name, members);
-          }
-        }}
+        onCreate={startDm}
       />
     </>
   );

--- a/app/client/src/components/Chat.tsx
+++ b/app/client/src/components/Chat.tsx
@@ -946,7 +946,7 @@ export function Chat(props: ChatProps) {
   };
 
   const startDm = async (
-    _name: string,
+    name: string,
     membersInput: string,
     autoOpen = true,
   ) => {
@@ -965,14 +965,14 @@ export function Chat(props: ChatProps) {
     }
     const room: Room = {
       id: partner,
-      name: "",
+      name: name || "",
       userName: user.userName,
       domain: getDomain(),
       avatar: "",
       unreadCount: 0,
       type: "group",
       members: [partner],
-      hasName: false,
+      hasName: Boolean(name),
       hasIcon: false,
       lastMessage: "...",
       lastMessageTime: undefined,
@@ -1644,10 +1644,10 @@ export function Chat(props: ChatProps) {
           setShowFriendDmDialog(false);
           setFriendDmTarget(null);
         }}
-        onCreate={() => {
+        onCreate={(name) => {
           const target = friendDmTarget();
           if (target) {
-            startDm("", target.id, false);
+            startDm(name, target.id, false);
           }
           setShowFriendDmDialog(false);
           setFriendDmTarget(null);

--- a/app/client/src/components/Chat.tsx
+++ b/app/client/src/components/Chat.tsx
@@ -968,15 +968,23 @@ export function Chat(props: ChatProps) {
       lastMessage: "...",
       lastMessageTime: undefined,
     };
-    await applyDisplayFallback([room]);
+    try {
+      await applyDisplayFallback([room]);
+    } catch (e) {
+      console.error("相手の表示情報取得に失敗しました", e);
+    }
     upsertRoom(room);
     const me = `${user.userName}@${getDomain()}`;
     const { to: toList, cc: ccList } = expandMembers([
       me as ActorID,
       partner as ActorID,
     ]);
-    // 軽量なハンドシェイクでサーバ派生ビューに登場させる
-    await sendHandshake(me, toList, ccList, "hi");
+    try {
+      // 軽量なハンドシェイクでサーバ派生ビューに登場させる
+      await sendHandshake(me, toList, ccList, "hi");
+    } catch (e) {
+      console.error("ハンドシェイク送信に失敗しました", e);
+    }
     setSelectedRoom(partner);
     setShowGroupDialog(false);
   };

--- a/app/client/src/components/chat/ChatRoomList.tsx
+++ b/app/client/src/components/chat/ChatRoomList.tsx
@@ -1,4 +1,11 @@
-import { For, Show, createEffect, createMemo, createSignal, onMount } from "solid-js";
+import {
+  createEffect,
+  createMemo,
+  createSignal,
+  For,
+  onMount,
+  Show,
+} from "solid-js";
 import { GoogleAd } from "../GoogleAd.tsx";
 import { isUrl } from "../../utils/url.ts";
 import type { Room } from "./types.ts";
@@ -14,7 +21,7 @@ interface ChatRoomListProps {
   onCreateDm: () => void;
   segment: "all" | "people" | "groups";
   onSegmentChange: (seg: "all" | "people" | "groups") => void;
-  onCreateFriendGroup?: (friendId: string) => void;
+  onCreateFriendDm?: (friendId: string) => void;
 }
 
 export function ChatRoomList(props: ChatRoomListProps) {
@@ -46,7 +53,8 @@ export function ChatRoomList(props: ChatRoomListProps) {
     }
     if (!q) return base;
     return base.filter((r) =>
-      r.name.toLowerCase().includes(q) || (r.lastMessage ?? "").toLowerCase().includes(q)
+      r.name.toLowerCase().includes(q) ||
+      (r.lastMessage ?? "").toLowerCase().includes(q)
     );
   });
 
@@ -59,10 +67,10 @@ export function ChatRoomList(props: ChatRoomListProps) {
   });
 
   const getFriendName = (friendId: string) => {
-    const room = props.rooms.find((r) => 
+    const room = props.rooms.find((r) =>
       isFriendRoom(r) && r.members.includes(friendId)
     );
-    return room?.name || friendId.split('@')[0] || friendId;
+    return room?.name || friendId.split("@")[0] || friendId;
   };
 
   const changeSeg = (seg: "all" | "people" | "groups") => {
@@ -76,7 +84,11 @@ export function ChatRoomList(props: ChatRoomListProps) {
   const onKeyDownTabs = (e: KeyboardEvent) => {
     if (e.key === "ArrowLeft" || e.key === "ArrowRight") {
       e.preventDefault();
-      const order: ("all" | "people" | "groups")[] = ["all", "people", "groups"];
+      const order: ("all" | "people" | "groups")[] = [
+        "all",
+        "people",
+        "groups",
+      ];
       const idx = order.indexOf(props.segment);
       const next = e.key === "ArrowLeft"
         ? order[(idx + order.length - 1) % order.length]
@@ -115,11 +127,17 @@ export function ChatRoomList(props: ChatRoomListProps) {
             aria-selected={props.segment === seg}
             aria-controls={`panel-${seg}`}
             class={`flex-1 px-2 py-1 rounded ${
-              props.segment === seg ? "bg-[#4a4a4a] text-white" : "bg-[#2b2b2b] text-gray-300"
+              props.segment === seg
+                ? "bg-[#4a4a4a] text-white"
+                : "bg-[#2b2b2b] text-gray-300"
             }`}
             onClick={() => changeSeg(seg)}
           >
-            {seg === "all" ? "すべて" : seg === "people" ? "友だち" : "グループ"}
+            {seg === "all"
+              ? "すべて"
+              : seg === "people"
+              ? "友だち"
+              : "グループ"}
             <Show when={(segUnread()[seg] ?? 0) > 0}>
               <span class="ml-1 inline-block text-xs px-1.5 py-0.5 rounded-full bg-blue-600 text-white">
                 {segUnread()[seg]}
@@ -142,9 +160,9 @@ export function ChatRoomList(props: ChatRoomListProps) {
           </div>
         </Show>
       </div>
-      
+
       {/* 友達タブの場合は専用UI、それ以外は従来のリスト表示 */}
-      <Show 
+      <Show
         when={props.segment === "people"}
         fallback={
           <div class="my-[10px] overflow-y-auto overflow-x-hidden w-full pb-14 scrollbar">
@@ -186,7 +204,9 @@ export function ChatRoomList(props: ChatRoomListProps) {
                           : (
                             <span
                               class={`w-[40px] h-[40px] flex items-center justify-center rounded-full text-white text-[20px] ${
-                                room.type === "memo" ? "bg-green-600" : "bg-[#444]"
+                                room.type === "memo"
+                                  ? "bg-green-600"
+                                  : "bg-[#444]"
                               }`}
                             >
                               {room.avatar}
@@ -239,7 +259,7 @@ export function ChatRoomList(props: ChatRoomListProps) {
             selectedRoom={props.selectedRoom}
             onSelectRoom={props.onSelect}
             onBack={() => setSelectedFriend(null)}
-            onCreateRoom={() => props.onCreateFriendGroup?.(selectedFriend()!)}
+            onCreateRoom={() => props.onCreateFriendDm?.(selectedFriend()!)}
           />
         </Show>
       </Show>

--- a/app/client/src/components/chat/FriendDmDialog.tsx
+++ b/app/client/src/components/chat/FriendDmDialog.tsx
@@ -1,0 +1,41 @@
+import { Show } from "solid-js";
+
+interface FriendDmDialogProps {
+  isOpen: boolean;
+  friendName: string;
+  onClose: () => void;
+  onCreate: () => void;
+}
+
+export function FriendDmDialog(props: FriendDmDialogProps) {
+  return (
+    <Show when={props.isOpen}>
+      <div class="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-80">
+        <div class="bg-[#1e1e1e] rounded-lg w-80 p-4">
+          <h2 class="text-white text-lg font-bold mb-2">
+            {props.friendName}との新しいトーク
+          </h2>
+          <p class="text-gray-300 text-sm mb-4">
+            2人だけのトークルームを作成しますか？
+          </p>
+          <div class="flex justify-end gap-2">
+            <button
+              type="button"
+              class="px-3 py-1 rounded bg-[#555] text-white text-sm hover:bg-[#666]"
+              onClick={props.onClose}
+            >
+              キャンセル
+            </button>
+            <button
+              type="button"
+              class="px-3 py-1 rounded bg-blue-600 text-white text-sm hover:bg-blue-700"
+              onClick={props.onCreate}
+            >
+              作成
+            </button>
+          </div>
+        </div>
+      </div>
+    </Show>
+  );
+}

--- a/app/client/src/components/chat/FriendDmDialog.tsx
+++ b/app/client/src/components/chat/FriendDmDialog.tsx
@@ -1,13 +1,19 @@
-import { Show } from "solid-js";
+import { createEffect, createSignal, Show } from "solid-js";
 
 interface FriendDmDialogProps {
   isOpen: boolean;
   friendName: string;
   onClose: () => void;
-  onCreate: () => void;
+  onCreate: (name: string) => void;
 }
 
 export function FriendDmDialog(props: FriendDmDialogProps) {
+  const [name, setName] = createSignal("");
+
+  createEffect(() => {
+    if (props.isOpen) setName("");
+  });
+
   return (
     <Show when={props.isOpen}>
       <div class="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-80">
@@ -15,6 +21,18 @@ export function FriendDmDialog(props: FriendDmDialogProps) {
           <h2 class="text-white text-lg font-bold mb-2">
             {props.friendName}との新しいトーク
           </h2>
+          <div class="mb-4">
+            <label class="block text-sm font-medium text-gray-300 mb-2">
+              トーク名（任意）
+            </label>
+            <input
+              type="text"
+              value={name()}
+              onInput={(e) => setName(e.currentTarget.value)}
+              placeholder={`${props.friendName}とのトーク`}
+              class="w-full px-3 py-2 bg-[#2a2a2a] border border-[#4a4a4a] rounded text-white placeholder-gray-500 focus:outline-none focus:border-blue-500"
+            />
+          </div>
           <p class="text-gray-300 text-sm mb-4">
             2人だけのトークルームを作成しますか？
           </p>
@@ -29,7 +47,7 @@ export function FriendDmDialog(props: FriendDmDialogProps) {
             <button
               type="button"
               class="px-3 py-1 rounded bg-blue-600 text-white text-sm hover:bg-blue-700"
-              onClick={props.onCreate}
+              onClick={() => props.onCreate(name())}
             >
               作成
             </button>

--- a/app/client/src/components/chat/FriendRoomList.tsx
+++ b/app/client/src/components/chat/FriendRoomList.tsx
@@ -1,4 +1,4 @@
-import { createSignal, Show, For, createMemo } from "solid-js";
+import { createMemo, createSignal, For, Show } from "solid-js";
 import { isUrl } from "../../utils/url.ts";
 import type { Room } from "./types.ts";
 
@@ -17,16 +17,15 @@ export function FriendRoomList(props: FriendRoomListProps) {
 
   // 選択された友達とのトークルームを取得
   const friendRooms = createMemo(() => {
-    return props.rooms.filter((room) => 
-      room.members.includes(props.friendId)
-    );
+    return props.rooms.filter((room) => room.members.includes(props.friendId));
   });
 
   const filteredRooms = createMemo(() => {
     const q = query().toLowerCase().trim();
     if (!q) return friendRooms();
     return friendRooms().filter((r) =>
-      r.name.toLowerCase().includes(q) || (r.lastMessage ?? "").toLowerCase().includes(q)
+      r.name.toLowerCase().includes(q) ||
+      (r.lastMessage ?? "").toLowerCase().includes(q)
     );
   });
 
@@ -61,7 +60,7 @@ export function FriendRoomList(props: FriendRoomListProps) {
           class="px-2 py-1 rounded bg-blue-600 text-white text-sm hover:bg-blue-700"
           onClick={props.onCreateRoom}
         >
-          ＋ 新規
+          ＋ 新しいトーク
         </button>
       </div>
 
@@ -95,7 +94,9 @@ export function FriendRoomList(props: FriendRoomListProps) {
                 />
               </svg>
             </div>
-            <h3 class="text-lg font-medium text-white mb-2">トークがありません</h3>
+            <h3 class="text-lg font-medium text-white mb-2">
+              トークがありません
+            </h3>
             <p class="text-gray-400 text-sm mb-4">
               {props.friendName}との新しいトークを始めましょう
             </p>
@@ -122,8 +123,8 @@ export function FriendRoomList(props: FriendRoomListProps) {
               >
                 <div class="relative w-10 h-10 flex items-center justify-center">
                   {isUrl(room.avatar) ||
-                    (typeof room.avatar === "string" &&
-                      room.avatar.startsWith("data:image/"))
+                      (typeof room.avatar === "string" &&
+                        room.avatar.startsWith("data:image/"))
                     ? (
                       <img
                         src={room.avatar}
@@ -132,14 +133,13 @@ export function FriendRoomList(props: FriendRoomListProps) {
                       />
                     )
                     : (
-                      <div
-                        class="w-10 h-10 flex items-center justify-center rounded-full text-white bg-[#444]"
-                      >
-                        {room.avatar || room.name.charAt(0).toUpperCase() || "👥"}
+                      <div class="w-10 h-10 flex items-center justify-center rounded-full text-white bg-[#444]">
+                        {room.avatar || room.name.charAt(0).toUpperCase() ||
+                          "👥"}
                       </div>
                     )}
                 </div>
-                
+
                 <div class="ml-3 flex-1 min-w-0">
                   <div class="flex justify-between items-center w-full">
                     <p class="text-white text-sm font-medium truncate flex-1">


### PR DESCRIPTION
## 概要
- 友だち詳細画面の「新規」ボタンで直接1対1トークを開始
- ボタン文言を「＋ 新しいトーク」に変更
- グループ作成用の処理を削除し、シンプルなDM作成に統一

## テスト
- `deno fmt app/client/src/components/chat/ChatRoomList.tsx app/client/src/components/chat/FriendRoomList.tsx app/client/src/components/Chat.tsx`
- `deno lint app/client/src/components/chat/ChatRoomList.tsx app/client/src/components/chat/FriendRoomList.tsx app/client/src/components/Chat.tsx`


------
https://chatgpt.com/codex/tasks/task_e_689958eb5fd08328a99ae10ba0a37fa2