### PR TITLE
OAuthログイン時のテナントID設定を修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ deno run -A setup.ts
 フィールドが追加され、複数インスタンスで同じ MongoDB を共有しても
 互いのデータが混在しません。
 
+`tenant_id` は `tenantScope` プラグインにより自動的に付与され、セッションなど
+他のドキュメントも同様にテナントごとに分離されます。
+
 `ACTIVITYPUB_DOMAIN` がテナント ID を兼ねており、ドメインごとにフォロー情報を
 `follow_edge` コレクションで管理します。
 

--- a/app/api/DB/mongo.ts
+++ b/app/api/DB/mongo.ts
@@ -916,15 +916,16 @@ export class MongoDB implements DB {
     }
   }
 
+  /**
+   * セッションを保存します。tenant_id はプラグインで自動付与されます。
+   */
   async createSession(
     sessionId: string,
     expiresAt: Date,
-    tenantId: string,
   ): Promise<SessionDoc> {
     const doc = new Session({
       sessionId,
       expiresAt,
-      tenant_id: tenantId,
     });
     (doc as unknown as { $locals?: { env?: Record<string, string> } }).$locals =
       {

--- a/app/api/routes/login.ts
+++ b/app/api/routes/login.ts
@@ -42,7 +42,7 @@ app.post(
       const user = data.user;
       if (!user || !user.id) return c.json({ error: "Invalid user" }, 401);
 
-      await issueSession(c, user.id);
+      await issueSession(c);
       return c.json({ success: true, message: "Login successful" });
     }
 
@@ -57,7 +57,7 @@ app.post(
         return c.json({ error: "Invalid password" }, 401);
       }
 
-      await issueSession(c, env["ACTIVITYPUB_DOMAIN"] ?? "");
+      await issueSession(c);
 
       return c.json({ success: true, message: "Login successful" });
     } catch (error) {

--- a/app/api/routes/posts.ts
+++ b/app/api/routes/posts.ts
@@ -45,7 +45,6 @@ app.use("/posts/*", authRequired);
 app.get("/posts", async (c) => {
   const domain = getDomain(c);
   const env = getEnv(c);
-  const tenantId = env["ACTIVITYPUB_DOMAIN"] ?? "";
   const actor = c.req.query("actor");
   const timeline = c.req.query("timeline") ?? "latest";
   const limit = Math.min(
@@ -55,7 +54,7 @@ app.get("/posts", async (c) => {
   const before = c.req.query("before");
   const db = createDB(env);
   let list: ActivityPubObjectType[];
-  if (timeline === "following" && actor && tenantId) {
+  if (timeline === "following" && actor) {
     list = await db.listTimeline(actor, {
       limit,
       before: before ? new Date(before) : undefined,

--- a/app/api/utils/session.ts
+++ b/app/api/utils/session.ts
@@ -3,15 +3,12 @@ import type { Context } from "hono";
 import { createDB } from "../DB/mod.ts";
 import { getEnv } from "../../shared/config.ts";
 
-export async function issueSession(
-  c: Context,
-  tenantId: string,
-): Promise<void> {
+export async function issueSession(c: Context): Promise<void> {
   const env = getEnv(c);
   const sessionId = crypto.randomUUID();
   const expiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
   const db = createDB(env);
-  await db.createSession(sessionId, expiresAt, tenantId);
+  await db.createSession(sessionId, expiresAt);
   setCookie(c, "sessionId", sessionId, {
     path: "/",
     httpOnly: true,

--- a/app/shared/db.ts
+++ b/app/shared/db.ts
@@ -252,10 +252,12 @@ export interface DB {
     icon: unknown;
     summary: string;
   }): Promise<void>;
+  /**
+   * セッションを作成します。
+   */
   createSession(
     sessionId: string,
     expiresAt: Date,
-    tenantId: string,
   ): Promise<SessionDoc>;
   findSessionById(sessionId: string): Promise<SessionDoc | null>;
   deleteSessionById(sessionId: string): Promise<void>;


### PR DESCRIPTION
## Summary
- createSession から tenantId 引数を削除し、tenantScope プラグインでセッション作成時に自動付与
- issueSession のドメイン依存を排除し、テナント ID を意識せずセッションを発行
- posts ルートから ACTIVITYPUB_DOMAIN によるテナント判定を削除し、テナントIDの扱いをモデル・DBに限定
- README に tenantScope プラグインの説明を追記
- 使われていない tenant_id に関するコメントを削除

## Testing
- `deno fmt app/shared/db.ts app/api/utils/session.ts`
- `deno lint app/shared/db.ts app/api/utils/session.ts`


------
https://chatgpt.com/codex/tasks/task_e_6899a280e51c832892945f0c35562362