### PR TITLE
TAKO KeepのURLを chat/memo に変更

### DIFF
--- a/app/client/src/components/Chat.tsx
+++ b/app/client/src/components/Chat.tsx
@@ -402,8 +402,9 @@ async function buildAttachment(file: File) {
   return att;
 }
 
-function getSelfRoomId(user: Account | null): string | null {
-  return user ? `${user.userName}@${getDomain()}` : null;
+function getSelfRoomId(_user: Account | null): string | null {
+  // セルフルーム（TAKO Keep）のIDは固定で "memo"
+  return _user ? "memo" : null;
 }
 
 interface ChatProps {
@@ -832,7 +833,7 @@ export function Chat(props: ChatProps) {
     if (!user) return;
     const rooms: Room[] = [
       {
-        id: `${user.userName}@${getDomain()}`,
+        id: "memo",
         name: "TAKO Keep",
         userName: user.userName,
         domain: getDomain(),


### PR DESCRIPTION
## 概要
- TAKO Keep のセルフルームIDを固定値 `memo` に変更
- チャット一覧の Keep ルームの URL が `#/chat/memo` となるよう修正

## テスト
- `deno fmt app/client/src/components/Chat.tsx`
- `deno lint app/client/src/components/Chat.tsx`


------
https://chatgpt.com/codex/tasks/task_e_689ae8a540448328b498f174a47ab344