### PR TITLE
ハンドシェイクメッセージでroomIdを任意化

### DIFF
--- a/app/api/activity_handlers.ts
+++ b/app/api/activity_handlers.ts
@@ -8,6 +8,18 @@ import {
 } from "./utils/activitypub.ts";
 import { broadcast, sendToUser } from "./routes/ws.ts";
 import { formatUserInfoForPost, getUserInfo } from "./services/user-info.ts";
+import { decodeMLSMessage } from "../shared/mls_message.ts";
+
+function iriToHandle(iri: string): string {
+  try {
+    const u = new URL(iri);
+    const segments = u.pathname.split("/").filter(Boolean);
+    const name = segments[segments.length - 1];
+    return `${name}@${u.hostname}`;
+  } catch {
+    return iri;
+  }
+}
 
 export type ActivityHandler = (
   activity: Record<string, unknown>,
@@ -68,6 +80,117 @@ export const activityHandlers: Record<string, ActivityHandler> = {
     c: unknown,
   ) {
     if (typeof activity.object === "object" && activity.object !== null) {
+      const obj = activity.object as Record<string, unknown>;
+      const objTypes = Array.isArray(obj.type) ? obj.type : [obj.type];
+      const isMLS = objTypes.includes("PublicMessage") ||
+        objTypes.includes("PrivateMessage");
+      if (isMLS && typeof obj.content === "string") {
+        const mediaType = typeof obj.mediaType === "string"
+          ? obj.mediaType
+          : "message/mls";
+        const encoding = typeof obj.encoding === "string"
+          ? obj.encoding
+          : "base64";
+        const toRaw = Array.isArray(activity.to)
+          ? activity.to
+          : activity.to
+          ? [activity.to]
+          : [];
+        const objToRaw = Array.isArray(obj.to)
+          ? obj.to
+          : obj.to
+          ? [obj.to]
+          : [];
+        const recipients = [...toRaw, ...objToRaw]
+          .filter((v): v is string => typeof v === "string")
+          .map(iriToHandle);
+        const from = typeof activity.actor === "string"
+          ? iriToHandle(activity.actor)
+          : username;
+        const env = (c as { get: (k: string) => unknown }).get(
+          "env",
+        ) as Record<string, string>;
+        const db = createDB(env);
+        const domain = getDomain(c as Context);
+        const selfHandle = `${username}@${domain}`;
+        const decoded = decodeMLSMessage(obj.content);
+        if (decoded) {
+          let bodyObj: Record<string, unknown> | null = null;
+          try {
+            bodyObj = JSON.parse(decoded.body) as Record<string, unknown>;
+          } catch {
+            bodyObj = null;
+          }
+          if (
+            bodyObj &&
+            (bodyObj.type === "remove" || bodyObj.type === "welcome")
+          ) {
+            const msg = await db.createHandshakeMessage({
+              sender: from,
+              recipients,
+              message: obj.content,
+            }) as {
+              _id: unknown;
+              roomId?: string;
+              sender: string;
+              recipients: string[];
+              message: string;
+              createdAt: unknown;
+            };
+            const newMsg = {
+              id: String(msg._id),
+              roomId: msg.roomId,
+              sender: from,
+              recipients,
+              message: obj.content,
+              createdAt: msg.createdAt,
+            };
+            sendToUser(selfHandle, { type: "publicMessage", payload: newMsg });
+            return;
+          }
+        }
+        const msg = await db.createEncryptedMessage({
+          from,
+          to: recipients,
+          content: obj.content,
+          mediaType,
+          encoding,
+        }) as {
+          _id: unknown;
+          roomId?: string;
+          from: string;
+          to: string[];
+          content: string;
+          mediaType: string;
+          encoding: string;
+          createdAt: unknown;
+        };
+        const newMsg = {
+          id: String(msg._id),
+          roomId: msg.roomId,
+          from,
+          to: recipients,
+          content: obj.content,
+          mediaType: msg.mediaType,
+          encoding: msg.encoding,
+          createdAt: msg.createdAt,
+        };
+        if (
+          bodyObj &&
+          bodyObj.type === "joinAck" &&
+          typeof bodyObj.roomId === "string" &&
+          typeof bodyObj.deviceId === "string"
+        ) {
+          await db.markInviteAcked(
+            bodyObj.roomId,
+            from,
+            bodyObj.deviceId,
+          );
+        }
+        sendToUser(selfHandle, { type: "encryptedMessage", payload: newMsg });
+        return;
+      }
+
       const actor = typeof activity.actor === "string"
         ? activity.actor
         : username;
@@ -77,7 +200,7 @@ export const activityHandlers: Record<string, ActivityHandler> = {
       >;
       const saved = await saveObject(
         env,
-        activity.object as Record<string, unknown>,
+        obj,
         actor,
       );
       const domain = getDomain(c as Context);
@@ -131,5 +254,109 @@ export const activityHandlers: Record<string, ActivityHandler> = {
         console.error("Delivery failed:", err);
       },
     );
+  },
+
+  async Add(
+    activity: Record<string, unknown>,
+    username: string,
+    c: unknown,
+  ) {
+    if (typeof activity.object !== "object" || activity.object === null) {
+      return;
+    }
+    const obj = activity.object as Record<string, unknown>;
+    const objTypes = Array.isArray(obj.type) ? obj.type : [obj.type];
+    if (!objTypes.includes("KeyPackage") || typeof obj.content !== "string") {
+      return;
+    }
+    const env = (c as { get: (k: string) => unknown }).get("env") as Record<
+      string,
+      string
+    >;
+    const db = createDB(env);
+    const actor = typeof activity.actor === "string"
+      ? iriToHandle(activity.actor)
+      : username;
+    const mediaType = typeof obj.mediaType === "string"
+      ? obj.mediaType
+      : "message/mls";
+    const encoding = typeof obj.encoding === "string" ? obj.encoding : "base64";
+    const groupInfo = typeof obj.groupInfo === "string"
+      ? obj.groupInfo
+      : undefined;
+    const expiresAt = typeof obj.expiresAt === "string"
+      ? new Date(obj.expiresAt)
+      : obj.expiresAt instanceof Date
+      ? obj.expiresAt
+      : undefined;
+    const deviceId = typeof obj.deviceId === "string"
+      ? obj.deviceId
+      : undefined;
+    const version = typeof obj.version === "string" ? obj.version : undefined;
+    const cipherSuite = typeof obj.cipherSuite === "number"
+      ? obj.cipherSuite
+      : typeof (obj as { cipher_suite?: number }).cipher_suite === "number"
+      ? (obj as { cipher_suite: number }).cipher_suite
+      : undefined;
+    const generator = typeof obj.generator === "string"
+      ? obj.generator
+      : undefined;
+    const keyId = typeof obj.id === "string"
+      ? obj.id.split("/").pop()
+      : undefined;
+    await db.createKeyPackage(
+      actor,
+      obj.content,
+      mediaType,
+      encoding,
+      groupInfo,
+      expiresAt,
+      deviceId,
+      version,
+      cipherSuite,
+      generator,
+      keyId,
+    );
+    await db.cleanupKeyPackages(actor);
+  },
+
+  async Remove(
+    activity: Record<string, unknown>,
+    username: string,
+    c: unknown,
+  ) {
+    if (typeof activity.object !== "string") return;
+    const keyId = activity.object.split("/").pop();
+    if (!keyId) return;
+    const env = (c as { get: (k: string) => unknown }).get("env") as Record<
+      string,
+      string
+    >;
+    const db = createDB(env);
+    const actor = typeof activity.actor === "string"
+      ? iriToHandle(activity.actor)
+      : username;
+    await db.deleteKeyPackage(actor, keyId);
+    await db.cleanupKeyPackages(actor);
+  },
+
+  async Delete(
+    activity: Record<string, unknown>,
+    username: string,
+    c: unknown,
+  ) {
+    if (typeof activity.object !== "string") return;
+    const keyId = activity.object.split("/").pop();
+    if (!keyId) return;
+    const env = (c as { get: (k: string) => unknown }).get("env") as Record<
+      string,
+      string
+    >;
+    const db = createDB(env);
+    const actor = typeof activity.actor === "string"
+      ? iriToHandle(activity.actor)
+      : username;
+    await db.deleteKeyPackage(actor, keyId);
+    await db.cleanupKeyPackages(actor);
   },
 };

--- a/app/api/models/takos/handshake_message.ts
+++ b/app/api/models/takos/handshake_message.ts
@@ -2,7 +2,7 @@ import mongoose from "mongoose";
 import tenantScope from "../plugins/tenant_scope.ts";
 
 const handshakeMessageSchema = new mongoose.Schema({
-  roomId: { type: String, required: true, index: true },
+  roomId: { type: String, index: true },
   sender: { type: String, required: true },
   recipients: { type: [String], required: true },
   message: { type: String, required: true },

--- a/app/api/models/takos/key_package.ts
+++ b/app/api/models/takos/key_package.ts
@@ -2,11 +2,19 @@ import mongoose from "mongoose";
 import tenantScope from "../plugins/tenant_scope.ts";
 
 const keyPackageSchema = new mongoose.Schema({
+  _id: {
+    type: String,
+    default: () => new mongoose.Types.ObjectId().toString(),
+  },
   userName: { type: String, required: true, index: true },
+  deviceId: { type: String },
   content: { type: String, required: true },
   mediaType: { type: String, default: "message/mls" },
   encoding: { type: String, default: "base64" },
   groupInfo: { type: String },
+  version: { type: String },
+  cipherSuite: { type: Number },
+  generator: { type: String },
   used: { type: Boolean, default: false },
   expiresAt: { type: Date },
   tenant_id: { type: String, index: true },
@@ -14,7 +22,7 @@ const keyPackageSchema = new mongoose.Schema({
 });
 
 keyPackageSchema.plugin(tenantScope, { envKey: "ACTIVITYPUB_DOMAIN" });
-keyPackageSchema.index({ userName: 1, tenant_id: 1 });
+keyPackageSchema.index({ userName: 1, deviceId: 1, tenant_id: 1 });
 
 const KeyPackage = mongoose.models.KeyPackage ??
   mongoose.model("KeyPackage", keyPackageSchema);

--- a/app/api/models/takos/pending_invite.ts
+++ b/app/api/models/takos/pending_invite.ts
@@ -1,0 +1,31 @@
+import mongoose from "mongoose";
+import tenantScope from "../plugins/tenant_scope.ts";
+
+const pendingInviteSchema = new mongoose.Schema({
+  _id: {
+    type: String,
+    default: () => new mongoose.Types.ObjectId().toString(),
+  },
+  roomId: { type: String, required: true, index: true },
+  userName: { type: String, required: true, index: true },
+  deviceId: { type: String, required: true },
+  expiresAt: { type: Date, required: true },
+  retries: { type: Number, default: 0 },
+  acked: { type: Boolean, default: false },
+  tenant_id: { type: String, index: true },
+  createdAt: { type: Date, default: Date.now },
+});
+
+pendingInviteSchema.plugin(tenantScope, { envKey: "ACTIVITYPUB_DOMAIN" });
+pendingInviteSchema.index({
+  roomId: 1,
+  userName: 1,
+  deviceId: 1,
+  tenant_id: 1,
+});
+
+const PendingInvite = mongoose.models.PendingInvite ??
+  mongoose.model("PendingInvite", pendingInviteSchema);
+
+export default PendingInvite;
+export { pendingInviteSchema };

--- a/app/shared/db.ts
+++ b/app/shared/db.ts
@@ -119,7 +119,7 @@ export interface DB {
   findAccountsByUserNames(usernames: string[]): Promise<AccountDoc[]>;
   countAccounts(): Promise<number>;
   createEncryptedMessage(data: {
-    roomId: string;
+    roomId?: string;
     from: string;
     to: string[];
     content: string;
@@ -131,7 +131,7 @@ export interface DB {
     opts?: { before?: string; after?: string; limit?: number },
   ): Promise<unknown[]>;
   createHandshakeMessage(data: {
-    roomId: string;
+    roomId?: string;
     sender: string;
     recipients: string[];
     message: string;
@@ -152,11 +152,27 @@ export interface DB {
     encoding?: string,
     groupInfo?: string,
     expiresAt?: Date,
+    deviceId?: string,
+    version?: string,
+    cipherSuite?: number,
+    generator?: string,
+    id?: string,
   ): Promise<unknown>;
   markKeyPackageUsed(userName: string, id: string): Promise<void>;
   cleanupKeyPackages(userName: string): Promise<void>;
   deleteKeyPackage(userName: string, id: string): Promise<void>;
   deleteKeyPackagesByUser(userName: string): Promise<void>;
+  savePendingInvite(
+    roomId: string,
+    userName: string,
+    deviceId: string,
+    expiresAt: Date,
+  ): Promise<void>;
+  markInviteAcked(
+    roomId: string,
+    userName: string,
+    deviceId: string,
+  ): Promise<void>;
   listNotifications(): Promise<unknown[]>;
   createNotification(
     title: string,


### PR DESCRIPTION
## 概要
- HandshakeMessageスキーマからroomId必須制約を除去
- DBインターフェースとMongo実装を更新しroomId省略に対応
- ActivityPubハンドラでroomId未指定のハンドシェイクを保存

## テスト
- `deno fmt app/api/DB/mongo.ts app/api/activity_handlers.ts app/api/models/takos/handshake_message.ts app/shared/db.ts`
- `deno lint app/api/DB/mongo.ts app/api/activity_handlers.ts app/api/models/takos/handshake_message.ts app/shared/db.ts`
- `deno check app/api/DB/mongo.ts app/api/activity_handlers.ts app/api/models/takos/handshake_message.ts app/shared/db.ts` *(証明書エラー: UnknownIssuer)*

------
https://chatgpt.com/codex/tasks/task_e_689c6f42cf30832889aaf70a5f3a32ee

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* 新機能
  * MLSベースのルーム招待APIを追加し、招待先デバイスごとに歓迎メッセージを配信。
  * 暗号化MLSメッセージの保存・配信に対応（join/welcome/removeのハンドシェイク処理を含む）。
  * キーパッケージAPIを拡張し、deviceId/version/cipherSuite/generator を登録・取得・選択で扱えるように改善（重複除外し最大M件を返却）。

* 変更
  * ハンドシェイク/暗号化メッセージで roomId を省略可能に。
  * 招待の保留・受領済み管理を追加し、招待フローを強化。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->