### PR TITLE
MLSメッセージのバイナリ化とBase64封入対応

### DIFF
--- a/app/api/activity_handlers.ts
+++ b/app/api/activity_handlers.ts
@@ -117,7 +117,9 @@ export const activityHandlers: Record<string, ActivityHandler> = {
         if (decoded) {
           let bodyObj: Record<string, unknown> | null = null;
           try {
-            bodyObj = JSON.parse(decoded.body) as Record<string, unknown>;
+            bodyObj = JSON.parse(
+              new TextDecoder().decode(decoded.body),
+            ) as Record<string, unknown>;
           } catch {
             bodyObj = null;
           }

--- a/app/api/routes/e2ee.ts
+++ b/app/api/routes/e2ee.ts
@@ -181,7 +181,9 @@ async function handleHandshake(
   let bodyObj: Record<string, unknown> | null = null;
   if (decoded) {
     try {
-      bodyObj = JSON.parse(decoded.body) as Record<string, unknown>;
+      bodyObj = JSON.parse(
+        new TextDecoder().decode(decoded.body),
+      ) as Record<string, unknown>;
     } catch {
       bodyObj = null;
     }
@@ -986,7 +988,13 @@ app.post(
         welcomeMap[acct] = selected.map((kp) =>
           encodeMLSMessage(
             "PrivateMessage",
-            JSON.stringify({ type: "welcome", roomId, deviceId: kp.deviceId }),
+            new TextEncoder().encode(
+              JSON.stringify({
+                type: "welcome",
+                roomId,
+                deviceId: kp.deviceId,
+              }),
+            ),
           )
         );
         for (const kp of selected) {
@@ -1005,7 +1013,9 @@ app.post(
     }
     const commit = encodeMLSMessage(
       "PublicMessage",
-      JSON.stringify({ type: "commit", adds: addList.map((k) => k._id) }),
+      new TextEncoder().encode(
+        JSON.stringify({ type: "commit", adds: addList.map((k) => k._id) }),
+      ),
     );
     for (const [acct, ws] of Object.entries(welcomeMap)) {
       for (const w of ws) {

--- a/app/client/src/components/e2ee/api.ts
+++ b/app/client/src/components/e2ee/api.ts
@@ -547,7 +547,7 @@ export const sendProposal = async (
 ): Promise<boolean> => {
   const content = encodeMLSMessage(
     "PublicMessage",
-    JSON.stringify(proposal),
+    new TextEncoder().encode(JSON.stringify(proposal)),
   );
   return await sendHandshake(roomId, from, content);
 };
@@ -559,7 +559,7 @@ export const sendCommit = async (
 ): Promise<boolean> => {
   const content = encodeMLSMessage(
     "PublicMessage",
-    JSON.stringify(commit),
+    new TextEncoder().encode(JSON.stringify(commit)),
   );
   const ok = await sendHandshake(roomId, from, content);
   if (!ok) return false;
@@ -567,7 +567,7 @@ export const sendCommit = async (
     for (const w of commit.welcomes) {
       const wContent = encodeMLSMessage(
         "PublicMessage",
-        JSON.stringify(w),
+        new TextEncoder().encode(JSON.stringify(w)),
       );
       const success = await sendHandshake(roomId, from, wContent);
       if (!success) return false;

--- a/app/shared/mls_message.ts
+++ b/app/shared/mls_message.ts
@@ -20,9 +20,11 @@ const byteToType: Record<number, MLSMessageType> = {
  */
 export function encodeMLSMessage(
   type: MLSMessageType,
-  body: string,
+  body: Uint8Array | string,
 ): string {
-  const bodyBuf = new TextEncoder().encode(body);
+  const bodyBuf = typeof body === "string"
+    ? new TextEncoder().encode(body)
+    : body;
   const u8 = new Uint8Array(bodyBuf.length + 1);
   u8[0] = typeToByte[type];
   u8.set(bodyBuf, 1);
@@ -34,13 +36,12 @@ export function encodeMLSMessage(
  */
 export function decodeMLSMessage(
   data: string,
-): { type: MLSMessageType; body: string } | null {
+): { type: MLSMessageType; body: Uint8Array } | null {
   try {
     const u8 = new Uint8Array(b64ToBuf(data));
     const type = byteToType[u8[0]];
     if (!type) return null;
-    const body = new TextDecoder().decode(u8.slice(1));
-    return { type, body };
+    return { type, body: u8.slice(1) };
   } catch {
     return null;
   }


### PR DESCRIPTION
## 概要
- MLSメッセージをバイナリ形式でシリアライズ／復号できるように変更
- サーバとクライアントで新しいエンコード／デコード関数を利用
- ActivityPubオブジェクトの `content` にMLSバイナリをBase64で格納

## テスト
- `deno fmt app/shared/mls_message.ts app/api/routes/e2ee.ts app/api/activity_handlers.ts app/client/src/components/e2ee/api.ts app/client/src/components/e2ee/mls.ts app/client/src/components/Chat.tsx`
- `deno lint app/shared/mls_message.ts app/api/routes/e2ee.ts app/api/activity_handlers.ts app/client/src/components/e2ee/api.ts app/client/src/components/e2ee/mls.ts app/client/src/components/Chat.tsx`


------
https://chatgpt.com/codex/tasks/task_e_689c8fa4a8048328a35f3a2fd1b368fd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* バグ修正
  * ハンドシェイク、招待、歓迎メッセージの処理を安定化し、復号失敗や文字化けを防止。
  * 受信/送信時の暗号化メッセージ処理を改善し、まれなデータ不整合によるエラーを解消。

* リファクタリング
  * メッセージを文字列ではなくバイナリとして一貫処理するよう変更し、暗号化通信の信頼性を向上。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->