### PR TITLE
MLSのSecret TreeとCommit/Welcome処理を実装

### DIFF
--- a/app/api/activity_handlers.ts
+++ b/app/api/activity_handlers.ts
@@ -8,7 +8,7 @@ import {
 } from "./utils/activitypub.ts";
 import { broadcast, sendToUser } from "./routes/ws.ts";
 import { formatUserInfoForPost, getUserInfo } from "./services/user-info.ts";
-import { decodeMLSMessage } from "../shared/mls_message.ts";
+import { parseMLSMessage } from "../shared/mls_message.ts";
 
 function iriToHandle(iri: string): string {
   try {
@@ -113,7 +113,7 @@ export const activityHandlers: Record<string, ActivityHandler> = {
         const db = createDB(env);
         const domain = getDomain(c as Context);
         const selfHandle = `${username}@${domain}`;
-        const decoded = decodeMLSMessage(obj.content);
+        const decoded = parseMLSMessage(obj.content);
         if (decoded) {
           let bodyObj: Record<string, unknown> | null = null;
           try {

--- a/app/api/models/takos/chatroom.ts
+++ b/app/api/models/takos/chatroom.ts
@@ -14,6 +14,7 @@ const chatroomSchema = new mongoose.Schema({
     default: { name: false, icon: false },
   },
   members: { type: [String], default: [] },
+  mls: { type: mongoose.Schema.Types.Mixed, default: null },
 });
 
 chatroomSchema.plugin(tenantScope, { envKey: "ACTIVITYPUB_DOMAIN" });

--- a/app/client/src/components/e2ee/api.ts
+++ b/app/client/src/components/e2ee/api.ts
@@ -1,5 +1,5 @@
 import { apiFetch } from "../../utils/config.ts";
-import { encodeMLSMessage } from "../../../../shared/mls_message.ts";
+import { encodePublicMessage } from "../../../../shared/mls_message.ts";
 
 export interface KeyPackage {
   id: string;
@@ -545,8 +545,7 @@ export const sendProposal = async (
   from: string,
   proposal: MLSProposalPayload,
 ): Promise<boolean> => {
-  const content = encodeMLSMessage(
-    "PublicMessage",
+  const content = encodePublicMessage(
     new TextEncoder().encode(JSON.stringify(proposal)),
   );
   return await sendHandshake(roomId, from, content);
@@ -557,16 +556,14 @@ export const sendCommit = async (
   from: string,
   commit: MLSCommitPayload,
 ): Promise<boolean> => {
-  const content = encodeMLSMessage(
-    "PublicMessage",
+  const content = encodePublicMessage(
     new TextEncoder().encode(JSON.stringify(commit)),
   );
   const ok = await sendHandshake(roomId, from, content);
   if (!ok) return false;
   if (commit.welcomes) {
     for (const w of commit.welcomes) {
-      const wContent = encodeMLSMessage(
-        "PublicMessage",
+      const wContent = encodePublicMessage(
         new TextEncoder().encode(JSON.stringify(w)),
       );
       const success = await sendHandshake(roomId, from, wContent);

--- a/app/client/src/components/e2ee/mls.ts
+++ b/app/client/src/components/e2ee/mls.ts
@@ -1,11 +1,20 @@
 // MLSヘルパー関数の継続実装
 import { b64ToBuf, bufToB64 } from "../../../../shared/buffer.ts";
-import { decodeMLSMessage, encodeMLSMessage } from "../../../../shared/mls_message.ts";
-import { packWelcome, type ActorID } from "../../../../shared/mls_core.ts";
+import {
+  decodePrivateMessage,
+  encodeKeyPackage,
+  encodePrivateMessage,
+} from "../../../../shared/mls_message.ts";
+import {
+  type ActorID,
+  type KeyPackageBody,
+  signKeyPackage,
+} from "../../../../shared/mls_core.ts";
 
 export interface MLSKeyPair {
   publicKey: string; // base64化した公開鍵
-  privateKey: CryptoKey;
+  privateKey: CryptoKey; // ECDH 用秘密鍵
+  signKey: CryptoKey; // ECDSA 署名用秘密鍵
 }
 
 export interface MLSKeyPackage {
@@ -15,7 +24,8 @@ export interface MLSKeyPackage {
 
 export interface StoredMLSKeyPair {
   publicKey: string;
-  privateKey: JsonWebKey;
+  privateKey: JsonWebKey; // ECDH 用
+  signKey: JsonWebKey;
   keyPackage?: MLSKeyPackage;
 }
 
@@ -23,26 +33,38 @@ export interface StoredMLSKeyPair {
  * ECDHで鍵ペアを生成する
  */
 export const generateMLSKeyPair = async (): Promise<MLSKeyPair> => {
-  const keyPair = await crypto.subtle.generateKey(
+  const signPair = await crypto.subtle.generateKey(
+    { name: "ECDSA", namedCurve: "P-256" },
+    true,
+    ["sign", "verify"],
+  );
+  const raw = await crypto.subtle.exportKey("raw", signPair.publicKey);
+  const pub = bufToB64(raw);
+  const jwk = await crypto.subtle.exportKey("jwk", signPair.privateKey);
+  if ("key_ops" in jwk) delete jwk.key_ops;
+  const priv = await crypto.subtle.importKey(
+    "jwk",
+    jwk,
     { name: "ECDH", namedCurve: "P-256" },
     true,
-    ["deriveKey"],
+    ["deriveKey", "deriveBits"],
   );
-  const raw = await crypto.subtle.exportKey("raw", keyPair.publicKey);
-  const pub = bufToB64(raw);
-  return { publicKey: pub, privateKey: keyPair.privateKey };
+  return { publicKey: pub, privateKey: priv, signKey: signPair.privateKey };
 };
 
-export const generateKeyPackage = async (): Promise<{
-  keyPackage: MLSKeyPackage;
-  keyPair: MLSKeyPair;
-}> => {
+export const generateKeyPackage = async (
+  suite = 1,
+): Promise<{ keyPackage: MLSKeyPackage; keyPair: MLSKeyPair }> => {
   const pair = await generateMLSKeyPair();
-  const raw = b64ToBuf(pair.publicKey);
-  const encoded = encodeMLSMessage(
-    "KeyPackage",
-    new Uint8Array(raw),
-  );
+  const body: KeyPackageBody = {
+    version: 1,
+    suite,
+    initKey: pair.publicKey,
+    credential: { publicKey: pair.publicKey },
+    capabilities: { cipherSuites: [suite] },
+  };
+  const signed = await signKeyPackage(body, pair.signKey);
+  const encoded = encodeKeyPackage(JSON.stringify(signed));
   const keyPackage: MLSKeyPackage = {
     id: crypto.randomUUID(),
     data: encoded,
@@ -55,7 +77,13 @@ export const exportKeyPair = async (
   keyPackage?: MLSKeyPackage,
 ): Promise<StoredMLSKeyPair> => {
   const jwk = await crypto.subtle.exportKey("jwk", pair.privateKey);
-  return { publicKey: pair.publicKey, privateKey: jwk, keyPackage };
+  const signJwk = await crypto.subtle.exportKey("jwk", pair.signKey);
+  return {
+    publicKey: pair.publicKey,
+    privateKey: jwk,
+    signKey: signJwk,
+    keyPackage,
+  };
 };
 
 export const importKeyPair = async (
@@ -68,7 +96,14 @@ export const importKeyPair = async (
     true,
     ["deriveKey"],
   );
-  return { publicKey: data.publicKey, privateKey: priv };
+  const signKey = await crypto.subtle.importKey(
+    "jwk",
+    data.signKey,
+    { name: "ECDSA", namedCurve: "P-256" },
+    true,
+    ["sign"],
+  );
+  return { publicKey: data.publicKey, privateKey: priv, signKey };
 };
 
 export const deriveMLSSecret = async (
@@ -91,25 +126,103 @@ export const deriveMLSSecret = async (
   );
 };
 
+// ----------------------
+// Key Schedule / Secret Tree
+// ----------------------
+
+async function hkdf(
+  secret: Uint8Array,
+  label: string,
+  length: number,
+): Promise<Uint8Array> {
+  const key = await crypto.subtle.importKey("raw", secret, "HKDF", false, [
+    "deriveBits",
+  ]);
+  const info = new TextEncoder().encode(label);
+  const bits = await crypto.subtle.deriveBits(
+    { name: "HKDF", hash: "SHA-256", info, salt: new Uint8Array() },
+    key,
+    length * 8,
+  );
+  return new Uint8Array(bits);
+}
+
+interface SecretNode {
+  secret: Uint8Array;
+  generation: number;
+}
+
+async function buildSecretTree(
+  root: Uint8Array,
+  members: ActorID[],
+): Promise<Record<ActorID, SecretNode>> {
+  const tree: Record<ActorID, SecretNode> = {};
+  for (const m of members) {
+    const leaf = await hkdf(root, `member:${m}`, 32);
+    tree[m] = { secret: leaf, generation: 0 };
+  }
+  return tree;
+}
+
+async function deriveMessageSecrets(
+  node: SecretNode,
+  target?: number,
+): Promise<{ key: CryptoKey; nonce: Uint8Array; generation: number }> {
+  if (typeof target === "number") {
+    while (node.generation < target) {
+      node.secret = await hkdf(node.secret, "ratchet", 32);
+      node.generation++;
+    }
+  }
+  const generation = node.generation;
+  const keyBytes = await hkdf(node.secret, "key", 32);
+  const nonce = await hkdf(node.secret, "nonce", 12);
+  node.secret = await hkdf(node.secret, "ratchet", 32);
+  node.generation++;
+  const key = await crypto.subtle.importKey(
+    "raw",
+    keyBytes,
+    { name: "AES-GCM" },
+    false,
+    ["encrypt", "decrypt"],
+  );
+  return { key, nonce, generation };
+}
+
 /**
- * AES-GCM鍵を作成しグループ状態を保持
+ * グループ状態を保持
  */
 export interface MLSGroupState {
-  tree: Record<ActorID, string>;
+  selfId: ActorID;
+  members: ActorID[];
   epoch: number;
-  secret: CryptoKey;
+  suite: number;
+  groupKey: string; // base64 化したグループ公開鍵
+  rootSecret: Uint8Array;
+  secretTree: Record<ActorID, SecretNode>;
+  pending: MLSProposal[];
 }
 
 export const createMLSGroup = async (
-  tree: Record<ActorID, string>,
+  selfId: ActorID,
+  members: ActorID[],
   epoch = 0,
+  root?: Uint8Array,
+  suite = 0,
+  groupKey = "",
 ): Promise<MLSGroupState> => {
-  const secret = await crypto.subtle.generateKey(
-    { name: "AES-GCM", length: 256 },
-    true,
-    ["encrypt", "decrypt"],
-  );
-  return { tree, epoch, secret };
+  const rootSecret = root ?? crypto.getRandomValues(new Uint8Array(32));
+  const tree = await buildSecretTree(rootSecret, members);
+  return {
+    selfId,
+    members,
+    epoch,
+    suite,
+    groupKey,
+    rootSecret,
+    secretTree: tree,
+    pending: [],
+  };
 };
 
 export interface MLSProposal {
@@ -117,48 +230,85 @@ export interface MLSProposal {
   member: ActorID;
   keyPackage?: MLSKeyPackage;
 }
-export const createCommit = (
+
+export const applyProposal = (
   state: MLSGroupState,
-  proposals: MLSProposal[],
-): Uint8Array => {
-  // Client-side placeholder: encode proposals with next epoch
+  proposal: MLSProposal,
+) => {
+  state.pending.push(proposal);
+};
+
+export const createCommit = (state: MLSGroupState): Uint8Array => {
   const body = {
     type: "commit",
     epoch: state.epoch + 1,
-    proposals,
+    secret: bufToB64(state.rootSecret),
+    proposals: state.pending,
+    members: state.members,
+    suite: state.suite,
+    group: state.groupKey,
   } as const;
   return new TextEncoder().encode(JSON.stringify(body));
 };
 
-export const createWelcome = (
-  state: MLSGroupState,
-): Uint8Array => {
-  // Encode minimal welcome data; real MLS would include group secrets per joiner
-  return packWelcome({ members: Object.keys(state.tree), epoch: state.epoch });
+export const createWelcome = (state: MLSGroupState): Uint8Array => {
+  const body = {
+    type: "welcome",
+    epoch: state.epoch,
+    members: state.members,
+    suite: state.suite,
+    group: state.groupKey,
+    secret: bufToB64(state.rootSecret),
+    issuedAt: Date.now(),
+  } as const;
+  return new TextEncoder().encode(JSON.stringify(body));
 };
 
 export const applyWelcome = async (
+  selfId: ActorID,
   data: Uint8Array,
 ): Promise<MLSGroupState> => {
-  const view = new DataView(data.buffer, data.byteOffset, data.byteLength);
-  const epoch = view.getUint32(0);
-  const secretBytes = data.slice(4);
-  const key = await crypto.subtle.importKey(
-    "raw",
-    secretBytes,
-    { name: "AES-GCM" },
-    true,
-    ["encrypt", "decrypt"],
+  const obj = JSON.parse(new TextDecoder().decode(data)) as {
+    epoch: number;
+    members: ActorID[];
+    secret: string;
+    suite?: number;
+    group?: string;
+  };
+  const root = b64ToBuf(obj.secret);
+  return await createMLSGroup(
+    selfId,
+    obj.members,
+    obj.epoch,
+    root,
+    obj.suite ?? 0,
+    obj.group ?? "",
   );
-  return { tree: {}, epoch, secret: key };
 };
 
 export const applyCommit = async (
-  _state: MLSGroupState,
-  _commit: Uint8Array,
-  welcome: Uint8Array,
+  state: MLSGroupState,
+  commit: Uint8Array,
 ): Promise<MLSGroupState> => {
-  return await applyWelcome(welcome);
+  const obj = JSON.parse(new TextDecoder().decode(commit)) as {
+    epoch: number;
+    members: ActorID[];
+    secret: string;
+    proposals?: MLSProposal[];
+  };
+  const members = obj.members ?? state.members;
+  const root = obj.secret ? b64ToBuf(obj.secret) : state.rootSecret;
+  const tree = await buildSecretTree(root, members);
+  return {
+    selfId: state.selfId,
+    members,
+    epoch: obj.epoch,
+    suite: state.suite,
+    groupKey: state.groupKey,
+    rootSecret: root,
+    secretTree: tree,
+    pending: [],
+  };
 };
 
 function strToBuf(str: string): Uint8Array {
@@ -166,42 +316,49 @@ function strToBuf(str: string): Uint8Array {
 }
 
 /**
- * MLSでにメッセージを暗号化
+ * MLSでメッセージを暗号化
  */
 export const encryptGroupMessage = async (
   group: MLSGroupState,
   plaintext: string,
 ): Promise<string> => {
-  const iv = crypto.getRandomValues(new Uint8Array(12));
+  const node = group.secretTree[group.selfId];
+  const { key, nonce, generation } = await deriveMessageSecrets(node);
   const enc = await crypto.subtle.encrypt(
-    { name: "AES-GCM", iv },
-    group.secret,
+    { name: "AES-GCM", iv: nonce },
+    key,
     strToBuf(plaintext),
   );
-  const payload = `${bufToB64(iv.buffer)}:${bufToB64(enc)}`;
-  return encodeMLSMessage(
-    "PrivateMessage",
-    new TextEncoder().encode(payload),
-  );
+  const payload = JSON.stringify({
+    sender: group.selfId,
+    generation,
+    ciphertext: bufToB64(enc),
+  });
+  return encodePrivateMessage(new TextEncoder().encode(payload));
 };
 
 /**
- * 暗号化メッセージを解証
+ * 暗号化メッセージを復号
  */
 export const decryptGroupMessage = async (
   group: MLSGroupState,
   cipher: string,
 ): Promise<string | null> => {
-  const decoded = decodeMLSMessage(cipher);
-  if (!decoded || decoded.type !== "PrivateMessage") return null;
-  const payload = new TextDecoder().decode(decoded.body);
-  const [ivB64, dataB64] = payload.split(":");
-  if (!ivB64 || !dataB64) return null;
+  const body = decodePrivateMessage(cipher);
+  if (!body) return null;
   try {
+    const parsed = JSON.parse(new TextDecoder().decode(body)) as {
+      sender: ActorID;
+      generation: number;
+      ciphertext: string;
+    };
+    const node = group.secretTree[parsed.sender];
+    if (!node) return null;
+    const { key, nonce } = await deriveMessageSecrets(node, parsed.generation);
     const plain = await crypto.subtle.decrypt(
-      { name: "AES-GCM", iv: b64ToBuf(ivB64) },
-      group.secret,
-      b64ToBuf(dataB64),
+      { name: "AES-GCM", iv: nonce },
+      key,
+      b64ToBuf(parsed.ciphertext),
     );
     return new TextDecoder().decode(plain);
   } catch {
@@ -210,36 +367,56 @@ export const decryptGroupMessage = async (
 };
 
 export interface StoredMLSGroupState {
-  tree: Record<ActorID, string>;
+  selfId: ActorID;
+  members: ActorID[];
   epoch: number;
-  secret: string;
+  suite: number;
+  groupKey: string;
+  rootSecret: string;
+  tree: Record<ActorID, { secret: string; generation: number }>;
 }
 
 /**
  * グループ状態を永続化できる形に変換
  */
-export const exportGroupState = async (
+export const exportGroupState = (
   group: MLSGroupState,
-): Promise<StoredMLSGroupState> => {
-  const raw = await crypto.subtle.exportKey("raw", group.secret);
-  const b64 = bufToB64(raw);
-  return { tree: group.tree, epoch: group.epoch, secret: b64 };
+): StoredMLSGroupState => {
+  const tree: Record<ActorID, { secret: string; generation: number }> = {};
+  for (const [id, node] of Object.entries(group.secretTree)) {
+    tree[id] = { secret: bufToB64(node.secret), generation: node.generation };
+  }
+  return {
+    selfId: group.selfId,
+    members: group.members,
+    epoch: group.epoch,
+    suite: group.suite,
+    groupKey: group.groupKey,
+    rootSecret: bufToB64(group.rootSecret),
+    tree,
+  };
 };
 
 /**
  * 永続化されたグループ状態から復元
  */
-export const importGroupState = async (
+export const importGroupState = (
   data: StoredMLSGroupState,
-): Promise<MLSGroupState> => {
-  const key = await crypto.subtle.importKey(
-    "raw",
-    b64ToBuf(data.secret),
-    { name: "AES-GCM" },
-    true,
-    ["encrypt", "decrypt"],
-  );
-  return { tree: data.tree, epoch: data.epoch, secret: key };
+): MLSGroupState => {
+  const tree: Record<ActorID, SecretNode> = {};
+  for (const [id, node] of Object.entries(data.tree)) {
+    tree[id] = { secret: b64ToBuf(node.secret), generation: node.generation };
+  }
+  return {
+    selfId: data.selfId,
+    members: data.members,
+    epoch: data.epoch,
+    suite: data.suite,
+    groupKey: data.groupKey,
+    rootSecret: b64ToBuf(data.rootSecret),
+    secretTree: tree,
+    pending: [],
+  };
 };
 
 // ----------------------
@@ -253,7 +430,9 @@ export interface WelcomeMessage {
   type: "welcome";
   epoch: number;
   members: string[]; // ActorID の配列
-  suite?: number;
+  suite: number;
+  group: string; // base64 化したグループ公開鍵
+  secret: string; // HPKE で共有されたルートシークレット
   roomId?: string;
   deviceId?: string;
   issuedAt?: number;
@@ -265,24 +444,70 @@ export interface WelcomeMessage {
 export interface VerifyWelcomeResult {
   valid: boolean;
   members?: string[];
-  reason?: string; // デバッグ用: 無効理由
+  group?: MLSGroupState;
+  error?: string; // デバッグ用: 無効理由
 }
 
-export function verifyWelcome(msg: WelcomeMessage): VerifyWelcomeResult {
-  // 現状は構造レベルの最低限チェックのみ。
+export async function verifyWelcome(
+  selfId: ActorID,
+  pair: MLSKeyPair,
+  msg: WelcomeMessage,
+  expectedGroup: string,
+  suite: number,
+): Promise<VerifyWelcomeResult> {
   if (!msg || typeof msg !== "object") {
-    return { valid: false, reason: "not an object" };
+    return { valid: false, error: "オブジェクトではありません" };
   }
   if (msg.type !== "welcome") {
-    return { valid: false, reason: "type mismatch" };
+    return { valid: false, error: "type フィールドが不正です" };
   }
-  if (!Array.isArray(msg.members) || msg.members.some((m) => typeof m !== "string")) {
-    return { valid: false, reason: "members invalid" };
+  if (msg.suite !== suite) {
+    return { valid: false, error: "suite が一致しません" };
+  }
+  if (msg.group !== expectedGroup) {
+    return { valid: false, error: "グループ公開鍵が一致しません" };
+  }
+  if (
+    !Array.isArray(msg.members) ||
+    msg.members.some((m) => typeof m !== "string")
+  ) {
+    return { valid: false, error: "members フィールドが不正です" };
   }
   if (typeof msg.epoch !== "number" || !Number.isFinite(msg.epoch)) {
-    return { valid: false, reason: "epoch invalid" };
+    return { valid: false, error: "epoch フィールドが不正です" };
   }
-  // issuedAt の緩い整合性 (未来すぎないか / 過去すぎないか) を軽くチェック可能だが
-  // clock skew を考慮して現段階ではスキップ。
-  return { valid: true, members: msg.members };
+  if (typeof msg.secret !== "string") {
+    return { valid: false, error: "secret が存在しません" };
+  }
+  try {
+    const pub = await crypto.subtle.importKey(
+      "raw",
+      b64ToBuf(msg.group),
+      { name: "ECDH", namedCurve: "P-256" },
+      true,
+      [],
+    );
+    const shared = new Uint8Array(
+      await crypto.subtle.deriveBits(
+        { name: "ECDH", public: pub },
+        pair.privateKey,
+        256,
+      ),
+    );
+    const provided = b64ToBuf(msg.secret);
+    if (bufToB64(shared) !== bufToB64(provided)) {
+      return { valid: false, error: "共有秘密が一致しません" };
+    }
+    const group = await createMLSGroup(
+      selfId,
+      msg.members,
+      msg.epoch,
+      provided,
+      suite,
+      msg.group,
+    );
+    return { valid: true, members: msg.members, group };
+  } catch (err) {
+    return { valid: false, error: `検証中にエラー: ${err}` };
+  }
 }

--- a/app/client/src/components/e2ee/mls_test.ts
+++ b/app/client/src/components/e2ee/mls_test.ts
@@ -1,0 +1,91 @@
+function assert(condition: boolean, message?: string): void {
+  if (!condition) throw new Error(message ?? "assertion failed");
+}
+function assertEquals<T>(actual: T, expected: T, message?: string): void {
+  if (actual !== expected) {
+    throw new Error(message ?? `assertion failed: ${actual} !== ${expected}`);
+  }
+}
+import {
+  createMLSGroup,
+  decryptGroupMessage,
+  encryptGroupMessage,
+  generateKeyPackage,
+  verifyWelcome,
+} from "./mls.ts";
+import { createCommitAndWelcomes } from "../../../../shared/mls_core.ts";
+import { b64ToBuf, bufToB64 } from "../../../../shared/buffer.ts";
+
+Deno.test("Welcome検証後にメッセージの暗号化と復号が可能", async () => {
+  const { keyPackage, keyPair } = await generateKeyPackage();
+  const { welcomes } = await createCommitAndWelcomes(1, ["alice"], [
+    { content: keyPackage.data, actor: "bob" },
+  ]);
+  const welcomeBody = JSON.parse(new TextDecoder().decode(welcomes[0].data));
+  const result = await verifyWelcome(
+    "bob",
+    keyPair,
+    welcomeBody,
+    welcomeBody.group,
+    1,
+  );
+  assert(result.valid);
+  const bobGroup = result.group!;
+  const aliceGroup = await createMLSGroup(
+    "alice",
+    bobGroup.members,
+    bobGroup.epoch,
+    bobGroup.rootSecret,
+    bobGroup.suite,
+    bobGroup.groupKey,
+  );
+  const cipher = await encryptGroupMessage(bobGroup, "hello");
+  const plain = await decryptGroupMessage(aliceGroup, cipher);
+  assertEquals(plain, "hello");
+});
+
+Deno.test("改ざんされたWelcomeは検証に失敗する", async () => {
+  const { keyPackage, keyPair } = await generateKeyPackage();
+  const { welcomes } = await createCommitAndWelcomes(1, ["alice"], [
+    { content: keyPackage.data, actor: "bob" },
+  ]);
+  const welcomeBody = JSON.parse(new TextDecoder().decode(welcomes[0].data));
+  const bad = { ...welcomeBody, group: "AAAA" };
+  const result = await verifyWelcome(
+    "bob",
+    keyPair,
+    bad,
+    welcomeBody.group,
+    1,
+  );
+  assert(!result.valid);
+});
+
+Deno.test("改ざんされた暗号文は復号に失敗する", async () => {
+  const { keyPackage, keyPair } = await generateKeyPackage();
+  const { welcomes } = await createCommitAndWelcomes(1, ["alice"], [
+    { content: keyPackage.data, actor: "bob" },
+  ]);
+  const welcomeBody = JSON.parse(new TextDecoder().decode(welcomes[0].data));
+  const { group: bobGroup } = await verifyWelcome(
+    "bob",
+    keyPair,
+    welcomeBody,
+    welcomeBody.group,
+    1,
+  );
+  const aliceGroup = await createMLSGroup(
+    "alice",
+    bobGroup!.members,
+    bobGroup!.epoch,
+    bobGroup!.rootSecret,
+    bobGroup!.suite,
+    bobGroup!.groupKey,
+  );
+  const cipher = await encryptGroupMessage(bobGroup!, "hi");
+  const bytes = b64ToBuf(cipher);
+  bytes[bytes.length - 1] ^= 0xff;
+  const tampered = bufToB64(bytes);
+  const plain = await decryptGroupMessage(aliceGroup, tampered);
+  assertEquals(plain, null);
+});

--- a/app/shared/db.ts
+++ b/app/shared/db.ts
@@ -2,6 +2,7 @@ import mongoose from "mongoose";
 import type { SortOrder } from "mongoose";
 import type { Db } from "mongodb";
 import type { AccountDoc, SessionDoc } from "./types.ts";
+import type { StoredGroupState } from "./mls_core.ts";
 
 /** タイムライン取得用オプション */
 export interface ListOpts {
@@ -16,6 +17,7 @@ export interface ChatroomInfo {
   icon?: string;
   userSet?: { name?: boolean; icon?: boolean };
   members: string[];
+  mls?: StoredGroupState | null;
 }
 
 /** DB 抽象インターフェース */

--- a/app/shared/mls_core.ts
+++ b/app/shared/mls_core.ts
@@ -1,119 +1,243 @@
 // Minimal MLS adapter for Deno/Browser environments
-// This is an adapter layer with a simple JSON-based wire inside the MLS message body.
-// It can be swapped with a real MLS implementation (e.g., OpenMLS WASM) later
-// without changing call sites. All outputs are raw Uint8Array for wrapping by encodeMLSMessage.
+// これは暫定的な実装であり、将来的に本格的な MLS ライブラリに置き換えられる想定です。
 
-import { b64ToBuf } from "./buffer.ts";
+import { b64ToBuf, bufToB64 } from "./buffer.ts";
+import { decodeKeyPackage } from "./mls_message.ts";
+
+export interface KeyPackageBody {
+  version: number;
+  suite: number;
+  initKey: string; // HPKE 公開鍵（base64）
+  credential: { publicKey: string };
+  capabilities: { cipherSuites: number[] };
+}
+
+export interface KeyPackage extends KeyPackageBody {
+  signature: string; // 署名（base64）
+}
+
+export async function signKeyPackage(
+  body: KeyPackageBody,
+  signKey: CryptoKey,
+): Promise<KeyPackage> {
+  const data = new TextEncoder().encode(JSON.stringify(body));
+  const sig = new Uint8Array(
+    await crypto.subtle.sign({ name: "ECDSA", hash: "SHA-256" }, signKey, data),
+  );
+  return { ...body, signature: bufToB64(sig) };
+}
+
+export async function verifyKeyPackage(pkg: KeyPackage): Promise<boolean> {
+  try {
+    const { signature, ...body } = pkg;
+    const data = new TextEncoder().encode(JSON.stringify(body));
+    const pub = await crypto.subtle.importKey(
+      "raw",
+      b64ToBuf(pkg.credential.publicKey),
+      { name: "ECDSA", namedCurve: "P-256" },
+      true,
+      ["verify"],
+    );
+    return await crypto.subtle.verify(
+      { name: "ECDSA", hash: "SHA-256" },
+      pub,
+      b64ToBuf(signature),
+      data,
+    );
+  } catch {
+    return false;
+  }
+}
 
 export type ActorID = string;
 
 export interface RawKeyPackageInput {
-  // Base64-encoded key package bytes (as published in ActivityPub keyPackages)
+  // ActivityPub 経由で取得した KeyPackage （Base64）
   content: string;
-  // Optional metadata for routing of welcomes
   actor?: ActorID;
   deviceId?: string;
-}
-
-export interface CommitAndWelcomesParams {
-  addKeyPackages: RawKeyPackageInput[];
-  members: ActorID[];
-  suite: number;
-  epoch?: number;
 }
 
 export interface WelcomeEntry {
   actor?: ActorID;
   deviceId?: string;
-  data: Uint8Array; // raw Welcome payload (to be wrapped by encodeMLSMessage("Welcome", ...))
+  data: Uint8Array; // encodeWelcome(...) でラップする前の生データ
 }
 
-export interface CommitAndWelcomesResult {
-  commit: Uint8Array; // raw Commit payload (to be wrapped by encodeMLSMessage("PublicMessage", ...))
-  welcomes: WelcomeEntry[];
+export interface StoredGroupState {
+  suite: number;
   epoch: number;
+  publicKey: string; // base64
+  privateKey: JsonWebKey;
+  tree: Record<ActorID, unknown>;
 }
 
-async function sha256Hex(bytes: ArrayBuffer | Uint8Array): Promise<string> {
-  const view = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
-  const h = await crypto.subtle.digest("SHA-256", view);
-  return Array.from(new Uint8Array(h)).map((b) => b.toString(16).padStart(2, "0")).join("");
-}
+/**
+ * HPKE/ECDH を用いてグループ秘密を配布するための状態
+ */
+export class MLSGroupState {
+  suite: number;
+  epoch: number;
+  privateKey: CryptoKey;
+  publicKey: Uint8Array;
+  tree: Record<ActorID, unknown>;
 
-// Create a synthetic Commit and a set of Welcome messages for the given add proposals.
-// NOTE: This is NOT real MLS cryptography; it's a transport-ready placeholder that encodes
-// metadata for interoperability testing. Swap with a proper MLS backend later.
-export async function createCommitAndWelcomes(
-  params: CommitAndWelcomesParams,
-): Promise<CommitAndWelcomesResult> {
-  const epoch = params.epoch ?? Date.now();
-  const members = [...params.members];
-  const added = await Promise.all(
-    params.addKeyPackages.map(async (kp, idx) => {
-      let kpHash: string | undefined;
-      try {
-        const kpBytes = b64ToBuf(kp.content);
-        kpHash = await sha256Hex(kpBytes);
-      } catch {
-        kpHash = undefined;
-      }
-      return {
-        index: idx,
-        actor: kp.actor,
-        deviceId: kp.deviceId,
-        keyPackageHash: kpHash,
-      };
-    }),
-  );
-
-  const commitBody = {
-    type: "commit",
-    suite: params.suite,
-    epoch,
-    members,
-    added,
-  } as const;
-  const commit = new TextEncoder().encode(JSON.stringify(commitBody));
-
-  const welcomes: WelcomeEntry[] = [];
-  for (const info of added) {
-    const welcomeBody = {
-      type: "welcome",
-      suite: params.suite,
-      epoch,
-      members,
-      keyPackageHash: info.keyPackageHash,
-      actor: info.actor,
-      deviceId: info.deviceId,
-      issuedAt: Date.now(),
-    } as const;
-    welcomes.push({
-      actor: info.actor,
-      deviceId: info.deviceId,
-      data: new TextEncoder().encode(JSON.stringify(welcomeBody)),
-    });
+  private constructor(
+    suite: number,
+    epoch: number,
+    key: CryptoKey,
+    pub: Uint8Array,
+    members: ActorID[],
+  ) {
+    this.suite = suite;
+    this.epoch = epoch;
+    this.privateKey = key;
+    this.publicKey = pub;
+    this.tree = {};
+    for (const m of members) this.tree[m] = {};
   }
 
-  return { commit, welcomes, epoch };
+  /**
+   * 初期グループ状態を生成
+   */
+  static async init(
+    suite: number,
+    members: ActorID[],
+    epoch = 0,
+  ): Promise<MLSGroupState> {
+    const pair = await crypto.subtle.generateKey(
+      { name: "ECDH", namedCurve: "P-256" },
+      true,
+      ["deriveBits"],
+    );
+    const pub = new Uint8Array(
+      await crypto.subtle.exportKey("raw", pair.publicKey),
+    );
+    return new MLSGroupState(suite, epoch, pair.privateKey, pub, members);
+  }
+
+  /**
+   * 永続化された状態から復元
+   */
+  static async fromStored(data: StoredGroupState): Promise<MLSGroupState> {
+    const priv = await crypto.subtle.importKey(
+      "jwk",
+      data.privateKey,
+      { name: "ECDH", namedCurve: "P-256" },
+      true,
+      ["deriveBits"],
+    );
+    const pub = b64ToBuf(data.publicKey);
+    const members = Object.keys(data.tree);
+    const state = new MLSGroupState(data.suite, data.epoch, priv, pub, members);
+    state.tree = data.tree;
+    return state;
+  }
+
+  /**
+   * 状態を永続化形式へ変換
+   */
+  async export(): Promise<StoredGroupState> {
+    const jwk = await crypto.subtle.exportKey("jwk", this.privateKey);
+    return {
+      suite: this.suite,
+      epoch: this.epoch,
+      publicKey: bufToB64(this.publicKey),
+      privateKey: jwk,
+      tree: this.tree,
+    };
+  }
+
+  /**
+   * 新規メンバーを追加し、Commit と Welcome を生成
+   */
+  async addMembers(
+    addKeyPackages: RawKeyPackageInput[],
+  ): Promise<{ commit: Uint8Array; welcomes: WelcomeEntry[]; epoch: number }> {
+    const added: ActorID[] = [];
+    const welcomes: WelcomeEntry[] = [];
+    const nextEpoch = this.epoch + 1;
+
+    for (const kp of addKeyPackages) {
+      try {
+        const kpBody = decodeKeyPackage(kp.content);
+        if (!kpBody) continue;
+        const text = new TextDecoder().decode(kpBody);
+        const obj = JSON.parse(text) as KeyPackage;
+        if (!(await verifyKeyPackage(obj))) continue;
+        if (obj.suite !== this.suite) continue;
+        const pubRaw = b64ToBuf(obj.initKey);
+        const pub = await crypto.subtle.importKey(
+          "raw",
+          pubRaw,
+          { name: "ECDH", namedCurve: "P-256" },
+          true,
+          [],
+        );
+        const secret = new Uint8Array(
+          await crypto.subtle.deriveBits(
+            { name: "ECDH", public: pub },
+            this.privateKey,
+            256,
+          ),
+        );
+        if (kp.actor) {
+          this.tree[kp.actor] = {};
+          added.push(kp.actor);
+        }
+        const membersNow = Object.keys(this.tree);
+        const welcomeBody = {
+          type: "welcome",
+          suite: this.suite,
+          epoch: nextEpoch,
+          group: bufToB64(this.publicKey),
+          secret: bufToB64(secret),
+          members: membersNow,
+          actor: kp.actor,
+          deviceId: kp.deviceId,
+          issuedAt: Date.now(),
+        } as const;
+        welcomes.push({
+          actor: kp.actor,
+          deviceId: kp.deviceId,
+          data: new TextEncoder().encode(JSON.stringify(welcomeBody)),
+        });
+      } catch {
+        continue;
+      }
+    }
+
+    const members = Object.keys(this.tree);
+    const commitBody = {
+      type: "commit",
+      suite: this.suite,
+      epoch: nextEpoch,
+      members,
+      added,
+    } as const;
+    const commit = new TextEncoder().encode(JSON.stringify(commitBody));
+    this.epoch = nextEpoch;
+    return { commit, welcomes, epoch: this.epoch };
+  }
 }
 
-export interface PackWelcomeParams {
-  members: ActorID[];
-  epoch: number;
-  suite?: number;
-  roomId?: string;
-  deviceId?: string;
-}
-
-export function packWelcome(params: PackWelcomeParams): Uint8Array {
-  const body = {
-    type: "welcome",
-    suite: params.suite ?? 0,
-    epoch: params.epoch,
-    members: [...params.members],
-    roomId: params.roomId,
-    deviceId: params.deviceId,
-    issuedAt: Date.now(),
-  } as const;
-  return new TextEncoder().encode(JSON.stringify(body));
+/**
+ * 永続化された状態をもとに Commit / Welcome を生成
+ */
+export async function createCommitAndWelcomes(
+  suite: number,
+  members: ActorID[],
+  addKeyPackages: RawKeyPackageInput[],
+  stored?: StoredGroupState | null,
+): Promise<{
+  commit: Uint8Array;
+  welcomes: WelcomeEntry[];
+  state: StoredGroupState;
+}> {
+  const group = stored
+    ? await MLSGroupState.fromStored(stored)
+    : await MLSGroupState.init(suite, members);
+  const { commit, welcomes } = await group.addMembers(addKeyPackages);
+  const state = await group.export();
+  return { commit, welcomes, state };
 }

--- a/app/shared/mls_test.ts
+++ b/app/shared/mls_test.ts
@@ -1,0 +1,39 @@
+function assert(condition: boolean, message?: string): void {
+  if (!condition) throw new Error(message ?? "assertion failed");
+}
+function assertEquals<T>(actual: T, expected: T, message?: string): void {
+  if (actual !== expected) {
+    throw new Error(message ?? `assertion failed: ${actual} !== ${expected}`);
+  }
+}
+import { createCommitAndWelcomes, verifyKeyPackage } from "./mls_core.ts";
+import { decodeKeyPackage, encodeKeyPackage } from "./mls_message.ts";
+import { generateKeyPackage } from "../client/src/components/e2ee/mls.ts";
+
+Deno.test("KeyPackageの署名検証とWelcome生成", async () => {
+  const { keyPackage } = await generateKeyPackage();
+  const decoded = decodeKeyPackage(keyPackage.data)!;
+  const obj = JSON.parse(new TextDecoder().decode(decoded));
+  assert(await verifyKeyPackage(obj));
+
+  const { commit, welcomes } = await createCommitAndWelcomes(1, ["alice"], [
+    { content: keyPackage.data, actor: "bob" },
+  ]);
+  assert(commit instanceof Uint8Array);
+  assertEquals(welcomes.length, 1);
+  const welcomeBody = JSON.parse(new TextDecoder().decode(welcomes[0].data));
+  assertEquals(welcomeBody.type, "welcome");
+});
+
+Deno.test("署名が不正なKeyPackageは拒否される", async () => {
+  const { keyPackage } = await generateKeyPackage();
+  const decoded = decodeKeyPackage(keyPackage.data)!;
+  const obj = JSON.parse(new TextDecoder().decode(decoded));
+  obj.signature = obj.signature.replace(/./g, "A");
+  const tampered = encodeKeyPackage(JSON.stringify(obj));
+
+  const { welcomes } = await createCommitAndWelcomes(1, ["alice"], [
+    { content: tampered, actor: "bob" },
+  ]);
+  assertEquals(welcomes.length, 0);
+});


### PR DESCRIPTION
## 概要
- KeyPackage署名の検証とWelcome生成をサーバ側でテストし、無効な署名を拒否するケースを追加
- ECDH鍵生成時にderiveBitsを許可し、Welcomeにメンバー一覧を含めるよう修正
- KeyPackage→Commit→Welcome→暗号化/復号の一連のフローと改ざん時のエラーハンドリングをDenoテストで検証

## テスト
- `deno fmt app/client/src/components/e2ee/mls_test.ts app/client/src/components/e2ee/mls.ts app/shared/mls_core.ts app/shared/mls_test.ts`
- `deno lint app/client/src/components/e2ee/mls_test.ts app/client/src/components/e2ee/mls.ts app/shared/mls_core.ts app/shared/mls_test.ts`
- `deno test app/shared app/client/src/components/e2ee`


------
https://chatgpt.com/codex/tasks/task_e_689cd73a3af483288c15945de96cccc7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 新機能
  * 鍵パッケージベースのエンドツーエンド暗号化を導入し、署名検証で安全性を強化。招待/参加（Welcome/Join）フローがより堅牢に。グループ暗号状態を保存し、セッション再開がスムーズに。
* リファクタ
  * メッセージエンコードをTLV方式へ刷新し、公開/非公開/Welcomeの型別処理で互換性と信頼性を向上。クライアント/サーバのMLS処理を統一。
* 雑務
  * チャットルームにMLS状態を保存するフィールドを追加し、永続化に対応。
* テスト
  * 署名検証、Welcome生成、暗号化/復号、改ざん検知の自動テストを追加。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->