### PR TITLE
自端末KeyPackageを招待処理に含める

### DIFF
--- a/app/api/DB/mod.ts
+++ b/app/api/DB/mod.ts
@@ -1,7 +1,11 @@
 import type { DB } from "../../shared/db.ts";
-import { MongoDB, startPendingInviteJob } from "./mongo.ts";
+import {
+  MongoDB,
+  startKeyPackageCleanupJob,
+  startPendingInviteJob,
+} from "./mongo.ts";
 
-export { MongoDB, startPendingInviteJob };
+export { MongoDB, startKeyPackageCleanupJob, startPendingInviteJob };
 
 /** MongoDB 実装を生成する */
 export function createDB(env: Record<string, string>): DB {

--- a/app/api/models/takos/encrypted_keypair.ts
+++ b/app/api/models/takos/encrypted_keypair.ts
@@ -3,12 +3,17 @@ import tenantScope from "../plugins/tenant_scope.ts";
 
 const encryptedKeyPairSchema = new mongoose.Schema({
   userName: { type: String, required: true },
+  deviceId: { type: String, required: true },
   content: { type: String, required: true },
   createdAt: { type: Date, default: Date.now },
 });
 
 encryptedKeyPairSchema.plugin(tenantScope, { envKey: "ACTIVITYPUB_DOMAIN" });
-encryptedKeyPairSchema.index({ userName: 1, tenant_id: 1 }, { unique: true });
+encryptedKeyPairSchema.index({
+  userName: 1,
+  deviceId: 1,
+  tenant_id: 1,
+}, { unique: true });
 
 const EncryptedKeyPair = mongoose.models.EncryptedKeyPair ??
   mongoose.model("EncryptedKeyPair", encryptedKeyPairSchema);

--- a/app/api/models/takos/mls_state.ts
+++ b/app/api/models/takos/mls_state.ts
@@ -1,0 +1,24 @@
+import mongoose from "mongoose";
+import tenantScope from "../plugins/tenant_scope.ts";
+
+const mlsStateSchema = new mongoose.Schema({
+  roomId: { type: String, required: true },
+  userName: { type: String, required: true },
+  deviceId: { type: String, required: true },
+  state: { type: String, required: true },
+  updatedAt: { type: Date, default: Date.now },
+});
+
+mlsStateSchema.plugin(tenantScope, { envKey: "ACTIVITYPUB_DOMAIN" });
+mlsStateSchema.index({
+  roomId: 1,
+  userName: 1,
+  deviceId: 1,
+  tenant_id: 1,
+}, { unique: true });
+
+const MLSState = mongoose.models.MLSState ??
+  mongoose.model("MLSState", mlsStateSchema);
+
+export default MLSState;
+export { mlsStateSchema };

--- a/app/api/models/takos_host/mls_state.ts
+++ b/app/api/models/takos_host/mls_state.ts
@@ -1,0 +1,8 @@
+import mongoose from "mongoose";
+import { mlsStateSchema } from "../takos/mls_state.ts";
+
+const HostMLSState = mongoose.models.HostMLSState ??
+  mongoose.model("HostMLSState", mlsStateSchema, "mlsstates");
+
+export default HostMLSState;
+export { mlsStateSchema };

--- a/app/api/server.ts
+++ b/app/api/server.ts
@@ -32,7 +32,7 @@ import { deleteCookie, getCookie } from "hono/cookie";
 import { issueSession } from "./utils/session.ts";
 import { bootstrapDefaultFasp } from "./services/fasp_bootstrap.ts";
 import { migrateFaspCollections } from "./services/fasp_migration.ts";
-import { startPendingInviteJob } from "./DB/mod.ts";
+import { startKeyPackageCleanupJob, startPendingInviteJob } from "./DB/mod.ts";
 
 const isDev = Deno.env.get("DEV") === "1";
 
@@ -205,6 +205,7 @@ if (import.meta.main) {
     // 起動を妨げない
   }
   startPendingInviteJob(env);
+  startKeyPackageCleanupJob(env);
   const app = await createTakosApp(env);
   const hostname = env["SERVER_HOST"];
   const port = Number(env["SERVER_PORT"] ?? "80");

--- a/app/client/src/components/Setting/index.tsx
+++ b/app/client/src/components/Setting/index.tsx
@@ -3,18 +3,26 @@ import {
   languageState,
   microblogPostLimitState,
 } from "../../states/settings.ts";
-import { encryptionKeyState, loginState } from "../../states/session.ts";
+import { loginState } from "../../states/session.ts";
 import { apiFetch } from "../../utils/config.ts";
-import { accounts as accountsAtom } from "../../states/account.ts";
+import {
+  accounts as accountsAtom,
+  activeAccount,
+} from "../../states/account.ts";
 import { deleteMLSDatabase } from "../e2ee/storage.ts";
 import { FaspProviders } from "./FaspProviders.tsx";
+import { useMLS } from "../e2ee/useMLS.ts";
+import { Show } from "solid-js";
 
 export function Setting() {
   const [language, setLanguage] = useAtom(languageState);
   const [postLimit, setPostLimit] = useAtom(microblogPostLimitState);
   const [, setIsLoggedIn] = useAtom(loginState);
-  // 暗号化キー入力は廃止
   const [accs] = useAtom(accountsAtom);
+  const [account] = useAtom(activeAccount);
+  const { generateKeys, status, error } = useMLS(
+    account()?.userName ?? "",
+  );
 
   const handleLogout = async () => {
     try {
@@ -60,6 +68,22 @@ export function Setting() {
       <div>
         <h3 class="font-bold mb-1">FASP 設定</h3>
         <FaspProviders />
+      </div>
+      <div>
+        <h3 class="font-bold mb-1">MLS 鍵管理</h3>
+        <button
+          type="button"
+          class="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700 transition"
+          onClick={generateKeys}
+        >
+          鍵ペア生成
+        </button>
+        <Show when={status()}>
+          <p class="text-green-500 text-sm mt-1">{status()}</p>
+        </Show>
+        <Show when={error()}>
+          <p class="text-red-500 text-sm mt-1">{error()}</p>
+        </Show>
       </div>
       <div class="flex justify-end space-x-2">
         <button

--- a/app/client/src/components/e2ee/mls.ts
+++ b/app/client/src/components/e2ee/mls.ts
@@ -1,0 +1,55 @@
+// 旧実装との互換性を保つためのスタブ
+// ts-mls ベースの新実装では利用しない
+
+export interface MLSKeyPair {
+  dummy: true;
+}
+
+export interface MLSKeyPackage {
+  id: string;
+  data: string;
+}
+
+export interface StoredMLSKeyPair {
+  keyPackage?: MLSKeyPackage;
+}
+
+export type MLSGroupState = Record<string, never>;
+export type StoredMLSGroupState = Record<string, never>;
+
+export const generateMLSKeyPair = (): MLSKeyPair => ({ dummy: true });
+
+export const generateKeyPackage = (
+  _suite = 1,
+): { keyPackage: MLSKeyPackage; keyPair: MLSKeyPair } => ({
+  keyPackage: { id: "", data: "" },
+  keyPair: generateMLSKeyPair(),
+});
+
+export const exportKeyPair = (
+  _pair: MLSKeyPair,
+  keyPackage?: MLSKeyPackage,
+): StoredMLSKeyPair => ({ keyPackage });
+
+export const importKeyPair = (_data: StoredMLSKeyPair): MLSKeyPair => ({
+  dummy: true,
+});
+
+export const deriveMLSSecret = (): Uint8Array => new Uint8Array();
+export const encryptGroupMessage = (
+  _group: MLSGroupState,
+  plaintext: string,
+): string => plaintext;
+export const decryptGroupMessage = (
+  _group: MLSGroupState,
+  cipher: string,
+): string | null => cipher;
+export const exportGroupState = (
+  group: MLSGroupState,
+): StoredMLSGroupState => group;
+export const importGroupState = (
+  data: StoredMLSGroupState,
+): MLSGroupState => data;
+
+export type WelcomeMessage = unknown;
+export const verifyWelcome = (): boolean => true;

--- a/app/client/src/components/e2ee/useMLS.ts
+++ b/app/client/src/components/e2ee/useMLS.ts
@@ -1,0 +1,24 @@
+import { createSignal } from "solid-js";
+import { addKeyPackage } from "./api.ts";
+import { generateKeyPackage } from "./mls_core.ts";
+
+export function useMLS(userName: string) {
+  const [status, setStatus] = createSignal<string | null>(null);
+  const [error, setError] = createSignal<string | null>(null);
+
+  const generateKeys = async () => {
+    try {
+      setStatus("鍵を生成中...");
+      setError(null);
+      const kp = await generateKeyPackage(userName);
+      await addKeyPackage(userName, { content: kp.encoded });
+      setStatus("鍵を生成しました");
+    } catch (err) {
+      console.error("鍵生成に失敗しました", err);
+      setStatus(null);
+      setError("鍵生成に失敗しました");
+    }
+  };
+
+  return { generateKeys, status, error };
+}

--- a/app/shared/db.ts
+++ b/app/shared/db.ts
@@ -148,9 +148,33 @@ export interface DB {
     condition: Record<string, unknown>,
     opts?: { before?: string; after?: string; limit?: number },
   ): Promise<unknown[]>;
-  findEncryptedKeyPair(userName: string): Promise<unknown | null>;
-  upsertEncryptedKeyPair(userName: string, content: string): Promise<void>;
-  deleteEncryptedKeyPair(userName: string): Promise<void>;
+  findEncryptedKeyPair(
+    userName: string,
+    deviceId: string,
+  ): Promise<unknown | null>;
+  upsertEncryptedKeyPair(
+    userName: string,
+    deviceId: string,
+    content: string,
+  ): Promise<void>;
+  deleteEncryptedKeyPair(userName: string, deviceId: string): Promise<void>;
+  deleteEncryptedKeyPairsByUser(userName: string): Promise<void>;
+  findMLSState(
+    roomId: string,
+    userName: string,
+    deviceId: string,
+  ): Promise<string | null>;
+  upsertMLSState(
+    roomId: string,
+    userName: string,
+    deviceId: string,
+    state: string,
+  ): Promise<void>;
+  deleteMLSState(
+    roomId: string,
+    userName: string,
+    deviceId: string,
+  ): Promise<void>;
   listKeyPackages(userName: string): Promise<unknown[]>;
   findKeyPackage(userName: string, id: string): Promise<unknown | null>;
   createKeyPackage(

--- a/app/shared/mls_message.ts
+++ b/app/shared/mls_message.ts
@@ -6,13 +6,19 @@ export type MLSMessageType =
   | "PublicMessage"
   | "PrivateMessage"
   | "Welcome"
-  | "KeyPackage";
+  | "KeyPackage"
+  | "Commit"
+  | "Proposal"
+  | "GroupInfo";
 
 const typeToByte: Record<MLSMessageType, number> = {
   PublicMessage: 1,
   PrivateMessage: 2,
   Welcome: 3,
   KeyPackage: 4,
+  Commit: 5,
+  Proposal: 6,
+  GroupInfo: 7,
 };
 
 const byteToType: Record<number, MLSMessageType> = {
@@ -20,6 +26,9 @@ const byteToType: Record<number, MLSMessageType> = {
   2: "PrivateMessage",
   3: "Welcome",
   4: "KeyPackage",
+  5: "Commit",
+  6: "Proposal",
+  7: "GroupInfo",
 };
 
 function toBytes(body: Uint8Array | string): Uint8Array {
@@ -67,6 +76,18 @@ export function encodeKeyPackage(body: Uint8Array | string): string {
   return bufToB64(serialize("KeyPackage", body));
 }
 
+export function encodeCommit(body: Uint8Array | string): string {
+  return bufToB64(serialize("Commit", body));
+}
+
+export function encodeProposal(body: Uint8Array | string): string {
+  return bufToB64(serialize("Proposal", body));
+}
+
+export function encodeGroupInfo(body: Uint8Array | string): string {
+  return bufToB64(serialize("GroupInfo", body));
+}
+
 export function decodePublicMessage(data: string): Uint8Array | null {
   const decoded = parseMLSMessage(data);
   return decoded && decoded.type === "PublicMessage" ? decoded.body : null;
@@ -85,6 +106,21 @@ export function decodeWelcome(data: string): Uint8Array | null {
 export function decodeKeyPackage(data: string): Uint8Array | null {
   const decoded = parseMLSMessage(data);
   return decoded && decoded.type === "KeyPackage" ? decoded.body : null;
+}
+
+export function decodeCommit(data: string): Uint8Array | null {
+  const decoded = parseMLSMessage(data);
+  return decoded && decoded.type === "Commit" ? decoded.body : null;
+}
+
+export function decodeProposal(data: string): Uint8Array | null {
+  const decoded = parseMLSMessage(data);
+  return decoded && decoded.type === "Proposal" ? decoded.body : null;
+}
+
+export function decodeGroupInfo(data: string): Uint8Array | null {
+  const decoded = parseMLSMessage(data);
+  return decoded && decoded.type === "GroupInfo" ? decoded.body : null;
 }
 
 export function parseMLSMessage(

--- a/app/shared/mls_wrapper.ts
+++ b/app/shared/mls_wrapper.ts
@@ -1,0 +1,388 @@
+// ts-mls のラッパーモジュール
+
+import {
+  acceptAll,
+  bytesToBase64,
+  type CiphersuiteName,
+  type ClientState,
+  createApplicationMessage,
+  createCommit,
+  createGroup,
+  createGroupInfoWithExternalPub,
+  decodeMlsMessage,
+  defaultCapabilities,
+  defaultLifetime,
+  emptyPskIndex,
+  encodeMlsMessage,
+  generateKeyPackage as tsGenerateKeyPackage,
+  getCiphersuiteFromName,
+  getCiphersuiteImpl,
+  joinGroup,
+  type KeyPackage,
+  type PrivateKeyPackage,
+  processPrivateMessage,
+  processPublicMessage,
+  type Proposal,
+  type PublicMessage,
+} from "ts-mls";
+import "@noble/curves/p256";
+
+export type StoredGroupState = ClientState;
+
+export interface GeneratedKeyPair {
+  public: KeyPackage;
+  private: PrivateKeyPackage;
+  encoded: string;
+}
+
+export interface RawKeyPackageInput {
+  content: string;
+  actor?: string;
+  deviceId?: string;
+}
+
+export interface WelcomeEntry {
+  actor?: string;
+  deviceId?: string;
+  data: Uint8Array;
+}
+
+const DEFAULT_SUITE: CiphersuiteName =
+  "MLS_128_DHKEMP256_AES128GCM_SHA256_P256";
+
+async function getSuite(name: CiphersuiteName) {
+  return await getCiphersuiteImpl(getCiphersuiteFromName(name));
+}
+
+function b64ToBytes(b64: string): Uint8Array {
+  const bin = atob(b64);
+  const out = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+  return out;
+}
+
+export async function generateKeyPair(
+  identity: string,
+  suite: CiphersuiteName = DEFAULT_SUITE,
+): Promise<GeneratedKeyPair> {
+  const cs = await getSuite(suite);
+  const credential = {
+    credentialType: "basic",
+    identity: new TextEncoder().encode(identity),
+  };
+  const { publicPackage, privatePackage } = await tsGenerateKeyPackage(
+    credential,
+    defaultCapabilities(),
+    defaultLifetime,
+    [],
+    cs,
+  );
+  const encoded = bytesToBase64(
+    encodeMlsMessage({
+      version: "mls10",
+      wireformat: "mls_key_package",
+      keyPackage: publicPackage,
+    }),
+  );
+  return { public: publicPackage, private: privatePackage, encoded };
+}
+
+export async function verifyKeyPackage(
+  pkg:
+    | string
+    | { credential: { publicKey: string }; signature: string }
+      & Record<string, unknown>,
+): Promise<boolean> {
+  if (typeof pkg === "string") {
+    const decoded = decodeMlsMessage(b64ToBytes(pkg), 0)?.[0];
+    return !!decoded && decoded.wireformat === "mls_key_package";
+  }
+  try {
+    const { signature, ...body } = pkg;
+    const data = new TextEncoder().encode(JSON.stringify(body));
+    const pub = await crypto.subtle.importKey(
+      "raw",
+      b64ToBytes(pkg.credential.publicKey),
+      { name: "ECDSA", namedCurve: "P-256" },
+      true,
+      ["verify"],
+    );
+    return await crypto.subtle.verify(
+      { name: "ECDSA", hash: "SHA-256" },
+      pub,
+      b64ToBytes(signature),
+      data,
+    );
+  } catch {
+    return false;
+  }
+}
+
+export async function verifyCommit(
+  state: StoredGroupState,
+  message: PublicMessage,
+  suite: CiphersuiteName = DEFAULT_SUITE,
+): Promise<boolean> {
+  if (!message.content.commit) return false;
+  try {
+    const cs = await getSuite(suite);
+    await processPublicMessage(state, message, emptyPskIndex, cs, acceptAll);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function verifyWelcome(data: Uint8Array): boolean {
+  try {
+    const decoded = decodeMlsMessage(data, 0)?.[0];
+    return !!decoded && decoded.wireformat === "mls_welcome";
+  } catch {
+    return false;
+  }
+}
+
+export function verifyGroupInfo(data: Uint8Array): boolean {
+  try {
+    const decoded = decodeMlsMessage(data, 0)?.[0];
+    return !!decoded && decoded.wireformat === "mls_group_info" &&
+      decoded.groupInfo.signature?.length > 0;
+  } catch {
+    return false;
+  }
+}
+
+export async function verifyPrivateMessage(
+  state: StoredGroupState,
+  data: Uint8Array,
+  suite: CiphersuiteName = DEFAULT_SUITE,
+): Promise<boolean> {
+  try {
+    const cs = await getSuite(suite);
+    const decoded = decodeMlsMessage(data, 0)?.[0];
+    if (!decoded || decoded.wireformat !== "mls_private_message") {
+      return false;
+    }
+    await processPrivateMessage(
+      state,
+      decoded.privateMessage,
+      emptyPskIndex,
+      cs,
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function createMLSGroup(
+  identity: string,
+  suite: CiphersuiteName = DEFAULT_SUITE,
+): Promise<{
+  state: StoredGroupState;
+  keyPair: GeneratedKeyPair;
+  gid: Uint8Array;
+}> {
+  const keyPair = await generateKeyPair(identity, suite);
+  const gid = new TextEncoder().encode(crypto.randomUUID());
+  const cs = await getSuite(suite);
+  const state = await createGroup(gid, keyPair.public, keyPair.private, [], cs);
+  return { state, keyPair, gid };
+}
+
+export async function addMembers(
+  state: StoredGroupState,
+  addKeyPackages: RawKeyPackageInput[],
+  suite: CiphersuiteName = DEFAULT_SUITE,
+): Promise<{
+  commit: Uint8Array;
+  welcomes: WelcomeEntry[];
+  state: StoredGroupState;
+}> {
+  const cs = await getSuite(suite);
+  const proposals: Proposal[] = [];
+  for (const kp of addKeyPackages) {
+    const decoded = decodeMlsMessage(b64ToBytes(kp.content), 0)?.[0];
+    if (decoded && decoded.wireformat === "mls_key_package") {
+      proposals.push({
+        proposalType: "add",
+        add: { keyPackage: decoded.keyPackage },
+      });
+    }
+  }
+  const result = await createCommit(state, emptyPskIndex, false, proposals, cs);
+  state = result.newState;
+  const commit = encodeMlsMessage(result.commit);
+  const welcomes: WelcomeEntry[] = [];
+  if (result.welcome) {
+    const welcomeBytes = encodeMlsMessage({
+      version: "mls10",
+      wireformat: "mls_welcome",
+      welcome: result.welcome,
+    });
+    for (const kp of addKeyPackages) {
+      welcomes.push({
+        actor: kp.actor,
+        deviceId: kp.deviceId,
+        data: welcomeBytes,
+      });
+    }
+  }
+  return { commit, welcomes, state };
+}
+
+export async function removeMembers(
+  state: StoredGroupState,
+  removeIndices: number[],
+  suite: CiphersuiteName = DEFAULT_SUITE,
+): Promise<{ commit: Uint8Array; state: StoredGroupState }> {
+  const cs = await getSuite(suite);
+  const proposals: Proposal[] = [];
+  for (const index of removeIndices) {
+    proposals.push({
+      proposalType: "remove",
+      remove: { removed: index },
+    });
+  }
+  const result = await createCommit(state, emptyPskIndex, false, proposals, cs);
+  return { commit: encodeMlsMessage(result.commit), state: result.newState };
+}
+
+export async function updateKey(
+  state: StoredGroupState,
+  identity: string,
+  suite: CiphersuiteName = DEFAULT_SUITE,
+): Promise<{
+  commit: Uint8Array;
+  state: StoredGroupState;
+  keyPair: GeneratedKeyPair;
+}> {
+  const cs = await getSuite(suite);
+  const keyPair = await generateKeyPair(identity, suite);
+  const proposals: Proposal[] = [{
+    proposalType: "update",
+    update: { keyPackage: keyPair.public },
+  }];
+  const result = await createCommit(state, emptyPskIndex, false, proposals, cs);
+  return {
+    commit: encodeMlsMessage(result.commit),
+    state: result.newState,
+    keyPair,
+  };
+}
+
+export async function joinWithWelcome(
+  welcome: Uint8Array,
+  keyPair: GeneratedKeyPair,
+  suite: CiphersuiteName = DEFAULT_SUITE,
+): Promise<StoredGroupState> {
+  const cs = await getSuite(suite);
+  const decoded = decodeMlsMessage(welcome, 0)?.[0];
+  if (!decoded || decoded.wireformat !== "mls_welcome") {
+    throw new Error("不正なWelcomeメッセージです");
+  }
+  return await joinGroup(
+    decoded.welcome,
+    keyPair.public,
+    keyPair.private,
+    emptyPskIndex,
+    cs,
+  );
+}
+
+export async function encryptMessage(
+  state: StoredGroupState,
+  plaintext: Uint8Array | string,
+  suite: CiphersuiteName = DEFAULT_SUITE,
+): Promise<{ message: Uint8Array; state: StoredGroupState }> {
+  const cs = await getSuite(suite);
+  const input = typeof plaintext === "string"
+    ? new TextEncoder().encode(plaintext)
+    : plaintext;
+  const { newState, privateMessage } = await createApplicationMessage(
+    state,
+    input,
+    cs,
+  );
+  const message = encodeMlsMessage({
+    version: "mls10",
+    wireformat: "mls_private_message",
+    privateMessage,
+  });
+  return { message, state: newState };
+}
+
+export async function decryptMessage(
+  state: StoredGroupState,
+  data: Uint8Array,
+  suite: CiphersuiteName = DEFAULT_SUITE,
+): Promise<{ plaintext: Uint8Array; state: StoredGroupState } | null> {
+  const cs = await getSuite(suite);
+  const decoded = decodeMlsMessage(data, 0)?.[0];
+  if (!decoded || decoded.wireformat !== "mls_private_message") {
+    return null;
+  }
+  const res = await processPrivateMessage(
+    state,
+    decoded.privateMessage,
+    emptyPskIndex,
+    cs,
+  );
+  if (res.kind !== "applicationMessage") {
+    return { plaintext: new Uint8Array(), state: res.newState };
+  }
+  return { plaintext: res.message, state: res.newState };
+}
+
+export async function exportGroupInfo(
+  state: StoredGroupState,
+  suite: CiphersuiteName = DEFAULT_SUITE,
+): Promise<Uint8Array> {
+  const cs = await getSuite(suite);
+  const info = await createGroupInfoWithExternalPub(state, cs);
+  return encodeMlsMessage({
+    version: "mls10",
+    wireformat: "mls_group_info",
+    groupInfo: info,
+  });
+}
+
+export async function processCommit(
+  state: StoredGroupState,
+  message: PublicMessage,
+  suite: CiphersuiteName = DEFAULT_SUITE,
+): Promise<StoredGroupState> {
+  if (!message.content.commit) {
+    throw new Error("不正なCommitメッセージです");
+  }
+  const cs = await getSuite(suite);
+  const { newState } = await processPublicMessage(
+    state,
+    message,
+    emptyPskIndex,
+    cs,
+    acceptAll,
+  );
+  return newState;
+}
+
+export async function processProposal(
+  state: StoredGroupState,
+  message: PublicMessage,
+  suite: CiphersuiteName = DEFAULT_SUITE,
+): Promise<StoredGroupState> {
+  if (!message.content.proposal) {
+    throw new Error("不正なProposalメッセージです");
+  }
+  const cs = await getSuite(suite);
+  const { newState } = await processPublicMessage(
+    state,
+    message,
+    emptyPskIndex,
+    cs,
+    acceptAll,
+  );
+  return newState;
+}
+
+export { addMembers as createCommitAndWelcomes };


### PR DESCRIPTION
## 概要
- GroupInfoの署名とwireformatを確認する`verifyGroupInfo`を追加
- KeyPackage登録APIとActivityPubハンドラでGroupInfoを検証し、不正な場合は保存を中止
- クライアントのGroupInfo取得処理でも検証を行い、結果を反映

## テスト
- `deno fmt app/shared/mls_wrapper.ts app/api/routes/e2ee.ts app/api/activity_handlers.ts app/client/src/components/e2ee/api.ts`
- `deno lint --config app/api/deno.json app/shared/mls_wrapper.ts app/api/routes/e2ee.ts app/api/activity_handlers.ts app/client/src/components/e2ee/api.ts`


------
https://chatgpt.com/codex/tasks/task_e_689d598342c8832886c0db88937792f4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新機能
  - MLSベースのエンドツーエンド暗号化を導入（ハンドシェイク、メッセージ送受信、検証、提案/コミット処理、Welcome/GroupInfo 検証対応）。
  - 端末単位の鍵管理とMLS状態管理を追加（ユーザー×部屋×端末）。
  - 設定画面に「MLS鍵管理」を追加し、ワンクリックで鍵ペア生成が可能。
  - ルームから特定メンバーを削除するAPIと、ルーム鍵をローテーションする機能を追加。
- 改善
  - 招待フローを強化（自己招待KPの自動取り込み、再招待の安定化）。
  - 既使用のキー・パッケージを再利用しないよう選別。
- 雑務
  - 期限切れキー・パッケージの自動クリーンアップを定期実行。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->