### PR TITLE
E2EE ハンドシェイクと配送先の検証を追加

### DIFF
--- a/app/api/routes/e2ee.ts
+++ b/app/api/routes/e2ee.ts
@@ -180,6 +180,22 @@ async function handleHandshake(
   if (!Array.isArray(to) || to.some((v) => typeof v !== "string")) {
     return { ok: false, status: 400, error: "invalid recipients" };
   }
+  // Public や followers などのコレクション URI を拒否
+  const hasCollection = (to as string[]).some((v) => {
+    if (v === "https://www.w3.org/ns/activitystreams#Public") return true;
+    if (v.includes("/followers") || v.includes("/following")) {
+      try {
+        const path = v.startsWith("http") ? new URL(v).pathname : v;
+        return path.endsWith("/followers") || path.endsWith("/following");
+      } catch {
+        return true;
+      }
+    }
+    return false;
+  });
+  if (hasCollection) {
+    return { ok: false, status: 400, error: "invalid recipients" };
+  }
   const [sender] = from.split("@");
   if (!sender) {
     return { ok: false, status: 400, error: "invalid user format" };


### PR DESCRIPTION
## 概要
- Handshake の `to` に Public や followers などのコレクション URI が含まれている場合はエラーを返すように修正
- ActivityPub 配送時に各ターゲットがアクター IRI であることを確認し、コレクション URI には配送しない

## テスト
- `deno fmt app/api/routes/e2ee.ts app/api/utils/activitypub.ts`
- `deno lint app/api/routes/e2ee.ts app/api/utils/activitypub.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a3572bf3348328b74a44835ee3192c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- バグ修正
  - E2EEハンドシェイクで、受信者にコレクションURI（Public や /followers, /following 等）が含まれる場合は無効として拒否し、400を返すように改善。
  - ActivityPub配信で、コレクション/非アクターURI（/outbox, /collections, /liked, /likes 等）への配信をスキップし、エラーを記録。
  - 送信先のインボックスが特定できない場合は配信を中止し、エラーを記録。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->