### PR TITLE
MLSハンドシェイク配送の拡張

### DIFF
--- a/docs/e2ee.md
+++ b/docs/e2ee.md
@@ -59,7 +59,8 @@
 
 - 自分自身のActor向けも、**コミットを実行した端末を除く他のアクティブ端末**に対してWelcomeを作成する（コミット端末は既にメンバーでWelcome不要）。
 
-5. **配送**：各Welcomeを `Create` で**対象Actorの `inbox`
+5. **配送**：各Welcomeに加え、`Commit` や `Proposal` などのハンドシェイクも
+   `Create` で**対象Actorの `inbox`
    へ明示宛先**で投函（`mediaType: "message/mls"`,
    `encoding: "base64"`）。([SWICG][1])
 


### PR DESCRIPTION
## 概要
- MLSハンドシェイクの種類を解析し、ActivityPubオブジェクトのtypeに反映
- Welcome以外のハンドシェイク(Commit/Proposal)をリモートメンバーへ個別配送
- ドキュメントにCommit/Proposal配送を追記

## テスト
- `deno fmt app/api/routes/e2ee.ts docs/e2ee.md`
- `deno lint app/api/routes/e2ee.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a35735dca08328b95bdbe7cfac317e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新機能
  - リモート配信の対象をWelcomeに加えCommit/Proposalのハンドシェイクにも拡大。
  - アクティビティ/オブジェクトの型を動的に判定し、受信者を明示指定して確実に配信。
  - リモートメンバーへの配信経路を統一し、信頼性を向上。
- ドキュメント
  - 配信手順を更新し、WelcomeだけでなくCommit/Proposalも対象であること、明示的な受信者指定と既存のメディア形式が維持されることを反映。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->