### PR TITLE
handleHandshake で mediaType と encoding を検証するよう修正

### DIFF
--- a/app/api/routes/e2ee.ts
+++ b/app/api/routes/e2ee.ts
@@ -224,6 +224,12 @@ async function handleHandshake(
   if (!Array.isArray(to) || to.some((v) => typeof v !== "string")) {
     return { ok: false, status: 400, error: "invalid recipients" };
   }
+  if (mediaType !== undefined && mediaType !== "message/mls") {
+    return { ok: false, status: 400, error: "invalid mediaType" };
+  }
+  if (encoding !== undefined && encoding !== "base64") {
+    return { ok: false, status: 400, error: "invalid encoding" };
+  }
   // Public や followers などのコレクション URI を拒否
   const hasCollection = (to as string[]).some((v) => {
     if (v === "https://www.w3.org/ns/activitystreams#Public") return true;
@@ -311,7 +317,8 @@ async function handleHandshake(
   }
   const envelope = decodeMlsEnvelope(content);
   const localTargets = envelope &&
-      (envelope.originalType === "Welcome" || envelope.originalType === "Commit")
+      (envelope.originalType === "Welcome" ||
+        envelope.originalType === "Commit")
     ? recipients.filter((m) => m.endsWith(`@${domain}`) && m !== from)
     : [];
 
@@ -342,8 +349,8 @@ async function handleHandshake(
   const activityObj = buildActivityFromStored(
     {
       ...saved,
-  // 公開用タイプのみ利用（Commit / Proposal は decode 時点で PrivateMessage に正規化済み）
-  type: envelope?.type ?? "PublicMessage",
+      // 公開用タイプのみ利用（Commit / Proposal は decode 時点で PrivateMessage に正規化済み）
+      type: envelope?.type ?? "PublicMessage",
     } as {
       _id: unknown;
       type: string;
@@ -417,7 +424,8 @@ async function handleHandshake(
 
   // Welcome/Commit/Proposal などのハンドシェイクはリモートメンバーへ個別配送
   if (
-    envelope && ["Welcome", "Commit", "Proposal"].includes(envelope.originalType)
+    envelope &&
+    ["Welcome", "Commit", "Proposal"].includes(envelope.originalType)
   ) {
     const remoteMembers = recipients.filter((m) => !m.endsWith(`@${domain}`));
     if (remoteMembers.length > 0) {
@@ -733,7 +741,7 @@ app.post("/users/:user/keyPackages", authRequired, async (c) => {
       "https://purl.archive.org/socialweb/mls",
     ],
     id: `https://${domain}/users/${user}/keyPackages/${pkg._id}`,
-  type: ["Object", "KeyPackage"],
+    type: ["Object", "KeyPackage"],
     attributedTo: actorId,
     to: ["https://www.w3.org/ns/activitystreams#Public"],
     mediaType: pkg.mediaType,


### PR DESCRIPTION
## Summary
- handleHandshake 内で mediaType と encoding を確認し、不正な値なら 400 を返す
- エラーメッセージを追加して原因を明示

## Testing
- `deno fmt app/api/routes/e2ee.ts`
- `deno lint app/api/routes/e2ee.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a367370168832884b84e192917c757

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新機能
  - なし
- バグ修正
  - ハンドシェイク時、無効なmediaTypeまたはencodingが指定された場合に400エラーと明確なエラーメッセージを返すよう改善し、入力検証を強化。
- ドキュメント
  - なし
- リファクタ
  - なし
- スタイル
  - なし
- テスト
  - なし
- 雑務
  - なし
- リバート
  - なし

<!-- end of auto-generated comment: release notes by coderabbit.ai -->