### PR TITLE
KeyPackage の summary をドキュメントと同じ文章に修正

### DIFF
--- a/app/api/routes/e2ee.ts
+++ b/app/api/routes/e2ee.ts
@@ -486,7 +486,7 @@ async function handleHandshake(
           mediaType: "message/mls",
           encoding: "base64",
           summary:
-            "This is an encrypted private message. See https://swicg.github.io/activitypub-e2ee/ …",
+            "This is an encrypted private message. See https://swicg.github.io/activitypub-e2ee/ for information about how to read messages like these.",
         };
 
         if (hsObj.mediaType !== "message/mls" || hsObj.encoding !== "base64") {
@@ -639,7 +639,7 @@ app.get(
         mediaType: doc.mediaType,
         encoding: doc.encoding,
         summary:
-          "This is binary-encoded cryptographic key package. See https://swicg.github.io/activitypub-e2ee/ …",
+          "This is binary-encoded cryptographic key package. See https://swicg.github.io/activitypub-e2ee/ for information about how to read messages like these.",
         groupInfo: doc.groupInfo,
         expiresAt: doc.expiresAt,
         version: doc.version,
@@ -691,7 +691,7 @@ app.get(
         }
         if (typeof out.summary !== "string") {
           out.summary =
-            "This is binary-encoded cryptographic key package. See https://swicg.github.io/activitypub-e2ee/ …";
+            "This is binary-encoded cryptographic key package. See https://swicg.github.io/activitypub-e2ee/ for information about how to read messages like these.";
         }
         return out;
       });
@@ -724,7 +724,7 @@ app.get("/users/:user/keyPackages/:keyId", async (c) => {
     mediaType: doc.mediaType,
     encoding: doc.encoding,
     summary:
-      "This is binary-encoded cryptographic key package. See https://swicg.github.io/activitypub-e2ee/ …",
+      "This is binary-encoded cryptographic key package. See https://swicg.github.io/activitypub-e2ee/ for information about how to read messages like these.",
     content: doc.content,
     groupInfo: doc.groupInfo,
     expiresAt: doc.expiresAt,
@@ -823,7 +823,7 @@ app.post("/users/:user/keyPackages", authRequired, async (c) => {
     mediaType: pkg.mediaType,
     encoding: pkg.encoding,
     summary:
-      "This is binary-encoded cryptographic key package. See https://swicg.github.io/activitypub-e2ee/ …",
+      "This is binary-encoded cryptographic key package. See https://swicg.github.io/activitypub-e2ee/ for information about how to read messages like these.",
     content: pkg.content,
     groupInfo: pkg.groupInfo,
     expiresAt: pkg.expiresAt,


### PR DESCRIPTION
## 概要
- ActivityPub E2EE の KeyPackage summary をドキュメントの文章に合わせて修正
- PrivateMessage の summary も同様に修正

## テスト
- `deno fmt app/api/routes/e2ee.ts`
- `deno lint app/api/routes/e2ee.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a42787ca088328aa1b9c284be6b54e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- スタイル
  - ActivityPub関連オブジェクトの公開サマリー文言を明確化。リンク先に「この種のメッセージの読み方に関する情報」への案内を追加。ハンドシェイク（ウェルカム／コミット／プロポーザル）やキー・パッケージの一覧・詳細・作成で表示される説明に反映。
  - 挙動や機能の変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->