### PR TITLE
chatrooms の所有者を userName に変更し招待状態を判定

### DIFF
--- a/app/api/models/takos/chatroom.ts
+++ b/app/api/models/takos/chatroom.ts
@@ -4,16 +4,16 @@ import tenantScope from "../plugins/tenant_scope.ts";
 // MLS の暗号状態はクライアントで管理し、サーバーでは保持しない
 // このコレクションはメタデータの補完用であり、存在しなくても
 // 暗号化メッセージから参加メンバーを推測してトークを表示できる
-// サーバーでは chatroom の永続化は owner と id のみ。
+// サーバーでは chatroom の永続化は userName と id のみ。
 // name / icon / members などのメタ情報や参加者は保持しない。
 // （参加者は暗号化メッセージ履歴から推測 / クライアント側管理）
 const chatroomSchema = new mongoose.Schema({
-  owner: { type: String, required: true },
+  userName: { type: String, required: true },
   id: { type: String, required: true },
 });
 
 chatroomSchema.plugin(tenantScope, { envKey: "ACTIVITYPUB_DOMAIN" });
-chatroomSchema.index({ owner: 1, id: 1, tenant_id: 1 }, { unique: true });
+chatroomSchema.index({ userName: 1, id: 1, tenant_id: 1 }, { unique: true });
 
 const Chatroom = mongoose.models.Chatroom ??
   mongoose.model("Chatroom", chatroomSchema);

--- a/app/client/src/components/Chat.tsx
+++ b/app/client/src/components/Chat.tsx
@@ -1285,7 +1285,9 @@ export function Chat() {
     ];
     const handle = `${user.userName}@${getDomain()}` as ActorID;
     // 暗黙のルーム（メッセージ由来）は除外して、明示的に作成されたもののみ取得
-    const serverRooms = await searchRooms(user.id, { implicit: "include" });
+    const serverRooms = await searchRooms(user.userName, {
+      implicit: "include",
+    });
     for (const item of serverRooms) {
       const state = groups()[item.id];
       const meta = state
@@ -1354,6 +1356,7 @@ export function Chat() {
         unreadCount: 0,
         type: "group",
         members,
+        status: item.status,
         hasName: name.trim() !== "",
         hasIcon: icon.trim() !== "",
         lastMessage: "...",
@@ -1561,7 +1564,7 @@ export function Chat() {
     await initGroupState(room.id);
     try {
       await addRoom(
-        user.id,
+        user.userName,
         { id: room.id, name: room.name, members },
       );
     } catch (e) {
@@ -2149,6 +2152,7 @@ export function Chat() {
             unreadCount: 0,
             type: "group",
             members: others,
+            status: "invited",
             lastMessage: "...",
             lastMessageTime: undefined,
           };
@@ -2349,6 +2353,7 @@ export function Chat() {
           unreadCount: 0,
           type: "group",
           members: [],
+          status: "invited",
           lastMessage: "...",
           lastMessageTime: undefined,
         };
@@ -2375,8 +2380,10 @@ export function Chat() {
           if (joined) {
             // 参加成功: 自分の chatrooms に登録
             try {
-              await addRoom(user.id, { id: room.id });
+              await addRoom(user.userName, { id: room.id });
             } catch { /* ignore */ }
+            room.status = "joined";
+            upsertRoom(room);
             setGroups({ ...groups(), [room.id]: joined });
             await saveGroupStates();
             setPendingWelcomes((prev) => {
@@ -2990,7 +2997,7 @@ export function Chat() {
                             }
                             if (joined) {
                               try {
-                                await addRoom(user.id, { id });
+                                await addRoom(user.userName, { id });
                               } catch { /* ignore */ }
                               setGroups({ ...groups(), [id]: joined });
                               await saveGroupStates();

--- a/app/client/src/components/Profile.tsx
+++ b/app/client/src/components/Profile.tsx
@@ -247,7 +247,7 @@ export default function Profile() {
     const handle = normalizeActor(name);
     const me = `${user.userName}@${getDomain()}`;
     await addRoom(
-      user.id,
+      user.userName,
       { id: handle, name: handle, members: [handle, me] },
       { from: me, content: "hi", to: [handle, me] },
     );

--- a/app/client/src/components/chat/ChatRoomList.tsx
+++ b/app/client/src/components/chat/ChatRoomList.tsx
@@ -119,7 +119,6 @@ export function ChatRoomList(props: ChatRoomListProps) {
     if (!me) return room.name;
     if (room.type === "memo") return room.name;
     const selfHandle = `${me.userName}@${getDomain()}`;
-    const members = room.members ?? [];
     // グループ（1:1以外）はそのまま（後段の補完で名前が入る想定）
     if (!isFriendRoom(room)) return room.name;
     if (isFriendRoom(room)) {
@@ -400,7 +399,11 @@ export function ChatRoomList(props: ChatRoomListProps) {
                         </span>
                       </span>
                       <span class="text-[12px] text-[#aaaaaa] font-normal flex justify-between items-center">
-                        <p class="truncate">{room.lastMessage}</p>
+                        <p class="truncate">
+                          {room.status === "invited"
+                            ? "招待中"
+                            : room.lastMessage}
+                        </p>
                       </span>
                     </span>
                   </div>
@@ -511,7 +514,11 @@ export function ChatRoomList(props: ChatRoomListProps) {
                         </span>
                       </span>
                       <span class="text-[12px] text-[#aaaaaa] font-normal flex justify-between items-center">
-                        <p class="truncate">{room.lastMessage}</p>
+                        <p class="truncate">
+                          {room.status === "invited"
+                            ? "招待中"
+                            : room.lastMessage}
+                        </p>
                       </span>
                     </span>
                   </div>

--- a/app/client/src/components/chat/types.ts
+++ b/app/client/src/components/chat/types.ts
@@ -34,6 +34,7 @@ export interface Room {
   members: ActorID[];
   // サーバー未同期時などに使用される招待者リスト（存在しない場合がある）
   pendingInvites?: ActorID[];
+  status?: "joined" | "invited";
   hasName?: boolean;
   hasIcon?: boolean;
 }

--- a/app/client/src/components/home/NotificationsContent.tsx
+++ b/app/client/src/components/home/NotificationsContent.tsx
@@ -251,7 +251,7 @@ const NotificationsContent: Component = () => {
                             {invite
                               ? `${
                                 invite.sender ?? "不明"
-                              } からの会話招待です。参加しますか？`
+                              } からの会話招待です。チャットに追加しますか？`
                               : n.message}
                           </p>
                         </div>
@@ -282,7 +282,7 @@ const NotificationsContent: Component = () => {
                               await deleteNotification(n.id);
                             }}
                           >
-                            参加する
+                            チャットに追加
                           </Button>
                           <Button
                             variant="ghost"

--- a/app/shared/db.ts
+++ b/app/shared/db.ts
@@ -12,6 +12,7 @@ export interface ListOpts {
 /** チャットルーム情報（MLS 状態は含まない） */
 export interface ChatroomInfo {
   id: string;
+  status: "joined" | "invited";
   // name, icon, members はサーバーでは保持しない
 }
 
@@ -36,29 +37,29 @@ export interface DB {
   addFollowing(id: string, target: string): Promise<string[]>;
   removeFollowing(id: string, target: string): Promise<string[]>;
   listChatrooms(
-    id: string,
+    userName: string,
   ): Promise<ChatroomInfo[]>;
   listChatroomsByMember(
     member: string,
   ): Promise<ChatroomInfo[]>;
   addChatroom(
-    id: string,
+    userName: string,
     room: ChatroomInfo,
   ): Promise<ChatroomInfo[]>;
   removeChatroom(
-    id: string,
+    userName: string,
     roomId: string,
   ): Promise<ChatroomInfo[]>;
   findChatroom(
     roomId: string,
   ): Promise<
     {
-      owner: string;
+      userName: string;
       room: ChatroomInfo;
     } | null
   >;
   updateChatroom(
-    owner: string,
+    userName: string,
     room: ChatroomInfo,
   ): Promise<void>;
   updateSessionActivity(


### PR DESCRIPTION
## Summary
- chatrooms の owner フィールドを userName に変更
- ルーム一覧 API とクライアントを userName 対応に更新し参加/招待ステータスを返す
- 招待中ルームを一覧に表示し「招待中」と明示
- 通知からチャットに追加するボタンの文言を調整

## Testing
- `deno fmt app/client/src/components/Chat.tsx app/client/src/components/chat/ChatRoomList.tsx app/client/src/components/chat/types.ts app/client/src/components/home/NotificationsContent.tsx`
- `deno lint app/client/src/components/Chat.tsx app/client/src/components/chat/ChatRoomList.tsx app/client/src/components/chat/types.ts app/client/src/components/home/NotificationsContent.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68a42ea37b7083288b10b2cbc7b22bd6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 新機能
  * ルームの参加状態（「参加済み」「招待中」）を表示。検索結果・一覧・クライアント状態に反映し、招待受諾後は自動で「参加済み」に更新。
* リファクタ
  * ルーム管理をユーザー名ベースに統一し、関連APIのパラメータと入出力形式を更新。
* スタイル
  * 招待通知の文言とボタンを分かりやすく変更（例：「チャットに追加」）。
  * ルーム一覧で招待中のスレッドに「招待中」と表示。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->