### PR TITLE
MLS メッセージデコード機能の拡張

### DIFF
--- a/app/client/src/components/e2ee/api.ts
+++ b/app/client/src/components/e2ee/api.ts
@@ -192,8 +192,8 @@ export const fetchKeyPackage = async (
       return null;
     }
     const bytes = b64ToBytes(data.content);
-    const decoded = await decodeMlsMessage(bytes, 0);
-    const key = (decoded?.[0] as unknown as {
+    const decoded = await decodeMlsMessage(bytes, 1);
+    const key = (decoded as unknown as {
       keyPackage?: { leafNode?: { signaturePublicKey?: Uint8Array } };
     })?.keyPackage?.leafNode?.signaturePublicKey;
     if (key) {
@@ -277,8 +277,8 @@ export const fetchVerifiedKeyPackage = async (
       // KT 検証に失敗しても致命的ではない
     }
     let fpr: string | undefined = undefined;
-    const decoded = await decodeMlsMessage(bytes, 0);
-    const key = (decoded?.[0] as unknown as {
+    const decoded = await decodeMlsMessage(bytes, 1);
+    const key = (decoded as unknown as {
       keyPackage?: { leafNode?: { signaturePublicKey?: Uint8Array } };
     })?.keyPackage?.leafNode?.signaturePublicKey;
     if (key) fpr = `ed25519:${toHex(key)}`;
@@ -356,8 +356,8 @@ export const importRosterEvidence = async (
     const hashBuffer = await crypto.subtle.digest("SHA-256", bytes);
     const hashHex = toHex(new Uint8Array(hashBuffer));
     if (`sha256:${hashHex}` !== evidence.keyPackageHash) return false;
-    const decoded = await decodeMlsMessage(bytes, 0);
-    const key = (decoded?.[0] as unknown as {
+    const decoded = await decodeMlsMessage(bytes, 1);
+    const key = (decoded as unknown as {
       keyPackage?: { leafNode?: { signaturePublicKey?: Uint8Array } };
     })?.keyPackage?.leafNode?.signaturePublicKey;
     if (!key || `ed25519:${toHex(key)}` !== evidence.leafSignatureKeyFpr) {


### PR DESCRIPTION
## 概要
- WireFormat に応じた MLS メッセージのデコードに対応
- WASM 側へ Welcome / GroupInfo / Public / PrivateMessage 用のデコード関数を追加
- KeyPackage 取得処理などを新しい戻り値構造に合わせて更新

## テスト
- `deno fmt app/client/src/components/e2ee/mls.ts app/client/src/components/e2ee/api.ts`
- `deno lint app/client/src/components/e2ee/mls.ts app/client/src/components/e2ee/api.ts`
- `cargo fmt` (app/shared/mls-wasm)
- `cargo check` (app/shared/mls-wasm) :x:

------
https://chatgpt.com/codex/tasks/task_e_68a4c8daf50883289abcb05c17f1dd17

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 新機能
  * MLSメッセージのデコード対象を拡充（Welcome／GroupInfo／Public／Private／KeyPackage）。結果を単一オブジェクトで返却し、取り扱いを簡素化。
* 不具合修正
  * キーパッケージのデコード位置の誤りを修正し、正しい公開鍵の抽出と検証の安定性を向上。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->