### PR TITLE
MLS の add_members で複数 Welcome を返すよう変更

### DIFF
--- a/app/client/src/components/e2ee/mls.ts
+++ b/app/client/src/components/e2ee/mls.ts
@@ -24,7 +24,7 @@ interface OpenMlsCreatedGroup {
 
 interface AddMembersResult {
   commit: Uint8Array;
-  welcome: Uint8Array;
+  welcomes: Uint8Array[];
 }
 
 interface JoinWithWelcomeResult {
@@ -512,16 +512,25 @@ export function addMembers(
     const pkgs = addKeyPackages.map((p) => p.content);
     const res = wasm.add_members(state.handle, pkgs);
     const members = await om_getGroupMembers(state.handle);
-    const welcomes = addKeyPackages.map((p) => ({
+    const welcomes = addKeyPackages.map((p, i) => ({
       actor: p.actor,
       deviceId: p.deviceId,
-      data: res.welcome,
+      data: res.welcomes[i],
+    }));
+    const evidences = addKeyPackages.map((p) => ({
+      type: "RosterEvidence" as const,
+      actor: p.actor ?? "",
+      keyPackageUrl: p.url ?? "",
+      keyPackageHash: p.hash ?? "",
+      leafSignatureKeyFpr: p.leafSignatureKeyFpr ?? "",
+      fetchedAt: p.fetchedAt ?? new Date().toISOString(),
+      etag: p.etag,
     }));
     return {
       commit: res.commit,
       welcomes,
       state: { ...state, members },
-      evidences: [],
+      evidences,
     };
   })();
 }

--- a/app/shared/mls-wasm/src/lib.rs
+++ b/app/shared/mls-wasm/src/lib.rs
@@ -245,7 +245,7 @@ pub fn export_group_info(handle: u32) -> Result<String, JsValue> {
 #[wasm_bindgen(getter_with_clone)]
 pub struct AddMembersResult {
     pub commit: Vec<u8>,
-    pub welcome: Vec<u8>,
+    pub welcomes: Vec<Vec<u8>>,
 }
 
 #[wasm_bindgen]
@@ -279,9 +279,11 @@ pub fn add_members(handle: u32, key_packages: Array) -> Result<AddMembersResult,
         .tls_serialize_detached()
         .map_err(|e| JsValue::from_str(&format!("serialize welcome: {:?}", e)))?;
 
+    let welcomes = vec![welcome_bytes.clone(); kps.len()];
+
     Ok(AddMembersResult {
         commit: commit_bytes,
-        welcome: welcome_bytes,
+        welcomes,
     })
 }
 


### PR DESCRIPTION
## 概要
- add_members の戻り値を複数の Welcome に対応
- クライアント側でメンバーごとに Welcome と RosterEvidence を生成

## テスト
- `deno fmt app/client/src/components/e2ee/mls.ts`
- `deno lint app/client/src/components/e2ee/mls.ts`
- `cargo check` (エラー: unresolved import `BasicCredential` など)


------
https://chatgpt.com/codex/tasks/task_e_68a4c8db2f608328b450e11c7fe86bc7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新機能
  - 複数のメンバー／デバイスをまとめて招待する際、各対象ごとに個別の招待データを生成・送信。大量招待時の成功率と初回同期の安定性が向上します。
  - 追加処理で招待に関する証跡を保存（招待元や取得時刻など）。サポート時の検証とトラブルシュートが容易になります。
  - 画面や操作フローの変更はありません。通知やコミット処理の挙動は従来通りです。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->