### PR TITLE
MLSメッセージ検証APIにハンドルを導入

### DIFF
--- a/app/client/src/components/Chat.tsx
+++ b/app/client/src/components/Chat.tsx
@@ -733,7 +733,7 @@ export function Chat() {
         const decoded = parseMLSMessage(bufToB64(body));
         if (decoded && group) {
           if (decoded.type === "Commit") {
-            const ok = await verifyCommit(decoded.body);
+            const ok = await verifyCommit(group.handle, decoded.body);
             if (!ok) {
               globalThis.dispatchEvent(
                 new CustomEvent("app:toast", {
@@ -872,6 +872,7 @@ export function Chat() {
     const list = await fetchEncryptedMessages(
       room.id,
       `${user.userName}@${getDomain()}`,
+      group.handle,
       params,
     );
     // 復号は古い順に処理しないとラチェットが進まず失敗するため昇順で処理

--- a/app/client/src/components/chat/ChatSettingsOverlay.tsx
+++ b/app/client/src/components/chat/ChatSettingsOverlay.tsx
@@ -274,10 +274,13 @@ export function ChatSettingsOverlay(props: ChatSettingsOverlayProps) {
 
   const loadMembersFromMessages = async (roomId: string) => {
     const user = accountValue();
-    if (!user) return setMembers([]);
+    const handle = props.groupState?.handle;
+    if (!user || handle === undefined) return setMembers([]);
     try {
       const self = `${user.userName}@${getDomain()}`;
-      const msgs = await fetchEncryptedMessages(roomId, self, { limit: 100 });
+      const msgs = await fetchEncryptedMessages(roomId, self, handle, {
+        limit: 100,
+      });
       const set = new Set<string>();
       for (const m of msgs) {
         if (typeof m.from === "string") {

--- a/app/client/src/components/e2ee/api.ts
+++ b/app/client/src/components/e2ee/api.ts
@@ -435,6 +435,7 @@ export const sendEncryptedMessage = async (
 export const fetchEncryptedMessages = async (
   roomId: string,
   member: string,
+  handle: number,
   params?: { limit?: number; before?: string; after?: string },
 ): Promise<EncryptedMessage[]> => {
   try {
@@ -469,7 +470,7 @@ export const fetchEncryptedMessages = async (
         (msg as { encoding?: unknown }).encoding === "base64"
       ) {
         const raw = b64ToBytes((msg as { content: string }).content);
-        if (!await verifyPrivateMessage(raw)) {
+        if (!await verifyPrivateMessage(handle, raw)) {
           console.warn(
             "[fetchEncryptedMessages] 署名検証に失敗しました",
             msg,

--- a/app/client/src/components/e2ee/mls.ts
+++ b/app/client/src/components/e2ee/mls.ts
@@ -71,8 +71,8 @@ interface WasmModule {
   peek_wire(data: Uint8Array): number;
   free_group(handle: number): void;
   verify_key_package(data: Uint8Array, expected?: string): boolean;
-  verify_commit(data: Uint8Array): boolean;
-  verify_private_message(data: Uint8Array): boolean;
+  verify_commit(handle: number, data: Uint8Array): boolean;
+  verify_private_message(handle: number, data: Uint8Array): boolean;
   verify_group_info(data: Uint8Array): boolean;
   verify_welcome(data: Uint8Array): boolean;
 }
@@ -426,10 +426,13 @@ export async function verifyKeyPackage(
   }
 }
 
-export async function verifyCommit(data: Uint8Array): Promise<boolean> {
+export async function verifyCommit(
+  handle: number,
+  data: Uint8Array,
+): Promise<boolean> {
   try {
     const wasm = await loadWasm();
-    return wasm.verify_commit(data);
+    return wasm.verify_commit(handle, data);
   } catch (err) {
     console.warn("verifyCommit failed", err);
     return false;
@@ -437,11 +440,12 @@ export async function verifyCommit(data: Uint8Array): Promise<boolean> {
 }
 
 export async function verifyPrivateMessage(
+  handle: number,
   data: Uint8Array,
 ): Promise<boolean> {
   try {
     const wasm = await loadWasm();
-    return wasm.verify_private_message(data);
+    return wasm.verify_private_message(handle, data);
   } catch (err) {
     console.warn("verifyPrivateMessage failed", err);
     return false;
@@ -662,7 +666,7 @@ export async function decryptMessage(
   data: Uint8Array,
 ): Promise<{ plaintext: Uint8Array; state: StoredGroupState } | null> {
   const wasm = await loadWasm();
-  if (!wasm.verify_private_message(data)) {
+  if (!wasm.verify_private_message(state.handle, data)) {
     console.warn("verifyPrivateMessage failed");
     return null;
   }

--- a/app/shared/mls-wasm/pkg/mls_wasm.d.ts
+++ b/app/shared/mls-wasm/pkg/mls_wasm.d.ts
@@ -1,0 +1,64 @@
+export interface KeyPackageResult {
+  key_package: string;
+}
+
+export interface CreateGroupResult {
+  handle: number;
+  group_info: string;
+}
+
+export interface EncryptResult {
+  message: string;
+}
+
+export interface DecryptResult {
+  plaintext: Uint8Array;
+}
+
+export function generate_key_package(identity: string): KeyPackageResult;
+export function create_group(identity: string): CreateGroupResult;
+export function encrypt(handle: number, plaintext: Uint8Array): EncryptResult;
+export function decrypt(handle: number, messageB64: string): DecryptResult;
+export function export_group_info(handle: number): string;
+export function get_group_members(handle: number): { members: string[] };
+export function add_members(
+  handle: number,
+  keyPackages: string[],
+): { commit: Uint8Array; welcome: Uint8Array };
+export function join_with_welcome(
+  identity: string,
+  welcome: Uint8Array,
+): { handle: number; group_info: string };
+export function remove_members(
+  handle: number,
+  indices: number[],
+): { commit: Uint8Array };
+export function update_key(
+  handle: number,
+): { commit: Uint8Array; key_package: string };
+export function join_with_group_info(
+  identity: string,
+  groupInfo: Uint8Array,
+): { handle: number; commit: Uint8Array; group_info: string };
+export function process_commit(
+  handle: number,
+  commit: Uint8Array,
+): { members: string[] };
+export function process_proposal(
+  handle: number,
+  proposal: Uint8Array,
+): { members: string[] };
+export function decode_key_package(data: Uint8Array): Uint8Array;
+export function peek_wire(data: Uint8Array): number;
+export function free_group(handle: number): void;
+export function verify_key_package(
+  data: Uint8Array,
+  expected?: string,
+): boolean;
+export function verify_commit(handle: number, data: Uint8Array): boolean;
+export function verify_private_message(
+  handle: number,
+  data: Uint8Array,
+): boolean;
+export function verify_group_info(data: Uint8Array): boolean;
+export function verify_welcome(data: Uint8Array): boolean;

--- a/app/shared/mls-wasm/src/lib.rs
+++ b/app/shared/mls-wasm/src/lib.rs
@@ -586,29 +586,50 @@ pub fn verify_key_package(data: &[u8], expected_identity: Option<String>) -> boo
 }
 
 #[wasm_bindgen]
-pub fn verify_commit(data: &[u8]) -> bool {
+pub fn verify_commit(handle: u32, data: &[u8]) -> bool {
     let provider = &OpenMlsRustCrypto::default();
+    let mut guard = GROUPS.lock().unwrap();
+    let h = match guard.get_mut(&handle) {
+        Some(h) => h,
+        None => return false,
+    };
+
     let mut buf = data.to_vec();
     let msg = match MlsMessageIn::tls_deserialize(&mut buf.as_slice()) {
         Ok(m) => m,
         Err(_) => return false,
     };
-    match msg {
-        MlsMessageIn::Plaintext(pt) => pt.verify(provider).is_ok(),
-        _ => false,
+
+    let processed = match h.group.process_message(provider, msg) {
+        Ok(p) => p,
+        Err(_) => return false,
+    };
+
+    if matches!(processed, ProcessedMessage::CommitMessage(_)) {
+        let _ = h.group.clear_pending_commit(provider.storage());
+        true
+    } else {
+        false
     }
 }
 
 #[wasm_bindgen]
-pub fn verify_private_message(data: &[u8]) -> bool {
+pub fn verify_private_message(handle: u32, data: &[u8]) -> bool {
     let provider = &OpenMlsRustCrypto::default();
+    let mut guard = GROUPS.lock().unwrap();
+    let h = match guard.get_mut(&handle) {
+        Some(h) => h,
+        None => return false,
+    };
+
     let mut buf = data.to_vec();
     let msg = match MlsMessageIn::tls_deserialize(&mut buf.as_slice()) {
         Ok(m) => m,
         Err(_) => return false,
     };
-    match msg {
-        MlsMessageIn::Ciphertext(ct) => ct.decrypt(provider).is_ok(),
+
+    match h.group.process_message(provider, msg) {
+        Ok(ProcessedMessage::ApplicationMessage(_)) => true,
         _ => false,
     }
 }


### PR DESCRIPTION
## 概要
- verify_commit / verify_private_message をグループハンドル必須に変更
- WASM バインディングと TypeScript ラッパーを更新
- Chat 周りでハンドルを渡して検証し、失敗時に警告を表示

## テスト
- `deno fmt app/client/src/components/Chat.tsx app/client/src/components/chat/ChatSettingsOverlay.tsx app/client/src/components/e2ee/api.ts app/client/src/components/e2ee/mls.ts app/shared/mls-wasm/src/lib.rs app/shared/mls-wasm/pkg/mls_wasm.d.ts`
- `deno lint app/client/src/components/e2ee/mls.ts app/client/src/components/e2ee/api.ts app/client/src/components/Chat.tsx app/client/src/components/chat/ChatSettingsOverlay.tsx app/shared/mls-wasm/pkg/mls_wasm.d.ts`
- `cargo check` *(エラーあり)*

------
https://chatgpt.com/codex/tasks/task_e_68a4c8dca3588328acdebf1b6ecf6479

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- バグ修正
  - グループ単位でメッセージ検証・取得を厳密化し、誤った文脈での検証失敗や取得ミスを防止。未知のグループ時は安全に失敗。コミット/プライベートメッセージ処理の信頼性を向上（UI変更なし）。

- リファクタ
  - 内部APIにグループ識別子を追加し、処理の一貫性と拡張性を改善。

- 雑務
  - MLS WASM の型定義を追加し、開発時の型安全性と補完精度を向上。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->