### PR TITLE
feat: ブラウザで MLS グループ状態を IndexedDB に保存

### DIFF
--- a/app/client/src/components/e2ee/storage.ts
+++ b/app/client/src/components/e2ee/storage.ts
@@ -108,7 +108,17 @@ export const saveMLSGroupStates = async (
     await store.save();
     return;
   }
-  return;
+  const db = await openDB(accountId);
+  const tx = db.transaction(STORE_NAME, "readwrite");
+  const store = tx.objectStore(STORE_NAME);
+  store.clear();
+  for (const [id, state] of Object.entries(states)) {
+    store.put(state, id);
+  }
+  await new Promise((resolve, reject) => {
+    tx.oncomplete = () => resolve(undefined);
+    tx.onerror = () => reject(tx.error);
+  });
 };
 
 export const loadMLSKeyPair = async (


### PR DESCRIPTION
## 概要
- Tauri 以外の環境で MLS グループ状態を IndexedDB に保存
- `openDB` を利用して `STORE_NAME` へ書き込み

## テスト
- `deno fmt app/client/src/components/e2ee/storage.ts`
- `deno lint app/client/src/components/e2ee/storage.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a5b9feac5c8328b4451b55e156f533

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Web版でE2EEグループ状態が永続化されない不具合を修正。
  * ブラウザの再読み込み・再起動後もグループ鍵と状態が保持されるよう改善。
  * デスクトップ版と同等の保存動作となり、信頼性とデータ整合性が向上。
  * 一部ユーザーで発生していた再参加や復元の失敗を軽減。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->