### PR TITLE
グループ参加者リストに自分を含めるよう修正

### DIFF
--- a/app/client/src/components/chat/ChatRoomList.tsx
+++ b/app/client/src/components/chat/ChatRoomList.tsx
@@ -122,8 +122,10 @@ export function ChatRoomList(props: ChatRoomListProps) {
     const me = account();
     if (!me) return room.name;
     if (room.type === "memo") return room.name;
-    if (room.members.length === 0) return "メンバー同期中";
     const self = selfHandle();
+    if (room.members.filter((m) => m !== self).length === 0) {
+      return "メンバー同期中";
+    }
     // グループ（1:1以外）はそのまま（後段の補完で名前が入る想定）
     if (!isFriendRoom(room, self)) return room.name;
     const rawOther = room.members.find((m) => m !== self) ??
@@ -392,7 +394,8 @@ export function ChatRoomList(props: ChatRoomListProps) {
                       </span>
                       <span class="text-[12px] text-[#aaaaaa] font-normal flex justify-between items-center">
                         <p class="truncate">
-                          {room.members.length === 0
+                          {room.members.filter((m) => m !== selfHandle())
+                              .length === 0
                             ? "メンバー同期中"
                             : room.status === "invited"
                             ? "招待中"
@@ -509,7 +512,8 @@ export function ChatRoomList(props: ChatRoomListProps) {
                       </span>
                       <span class="text-[12px] text-[#aaaaaa] font-normal flex justify-between items-center">
                         <p class="truncate">
-                          {room.members.length === 0
+                          {room.members.filter((m) => m !== selfHandle())
+                              .length === 0
                             ? "メンバー同期中"
                             : room.status === "invited"
                             ? "招待中"

--- a/app/client/src/components/chat/ChatTitleBar.tsx
+++ b/app/client/src/components/chat/ChatTitleBar.tsx
@@ -44,7 +44,9 @@ export function ChatTitleBar(props: ChatTitleBarProps) {
       return room.displayName;
     }
     const selfHandle = `${me.userName}@${getDomain()}`;
-    if (room.members.length === 0) return "メンバー同期中";
+    if (room.members.filter((m) => m !== selfHandle).length === 0) {
+      return "メンバー同期中";
+    }
     if (isFriendRoom(room, selfHandle)) {
       const other = room.members.find((m) => m !== selfHandle) ??
         room.members[0];

--- a/app/client/src/components/chat/FriendRoomList.tsx
+++ b/app/client/src/components/chat/FriendRoomList.tsx
@@ -25,7 +25,7 @@ export function FriendRoomList(props: FriendRoomListProps) {
     });
   });
   const loadingMembers = createMemo(() =>
-    props.rooms.some((r) => r.members.length === 0)
+    props.rooms.some((r) => r.members.length <= 1)
   );
 
   function normalizeHandle(id?: string): string | undefined {


### PR DESCRIPTION
## 概要
- loadRooms で自分のハンドルを除外しないよう変更
- 1対1判定やメンバー表示ロジックを自己ハンドル対応に調整

## 動作確認
- `deno fmt app/client/src/components/Chat.tsx app/client/src/components/chat/ChatRoomList.tsx app/client/src/components/chat/FriendRoomList.tsx app/client/src/components/chat/ChatTitleBar.tsx`
- `deno lint app/client/src/components/Chat.tsx app/client/src/components/chat/ChatRoomList.tsx app/client/src/components/chat/FriendRoomList.tsx app/client/src/components/chat/ChatTitleBar.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68a5b9f8d65c8328a9d4a57eb201a1c0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新機能
  - デバイスごとのハンドシェイクに対応し、参加時の信頼性を向上。
- 改善
  - 1対1のDMを「2人DM」として一貫して扱い、自分を除外した相手情報の表示名・アバターを適切に表示。
  - ルーム一覧・タイトルバーで「メンバー同期中」の表示条件を、自分以外のメンバー数に基づく判定へ調整。
  - フレンド一覧で、メンバーが1人以下の場合にも「メンバー情報を読み込み中…」を表示。
- バグ修正
  - 自分が相手として扱われる誤表示を解消し、DM相手の判定と表示を安定化。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->