### PR TITLE
クライアントのMLS関連処理を削除

### DIFF
--- a/app/client/src/components/Setting/index.tsx
+++ b/app/client/src/components/Setting/index.tsx
@@ -5,21 +5,12 @@ import {
 } from "../../states/settings.ts";
 import { loginState } from "../../states/session.ts";
 import { apiFetch } from "../../utils/config.ts";
-import {
-  accounts as accountsAtom,
-  activeAccount,
-} from "../../states/account.ts";
 import { FaspProviders } from "./FaspProviders.tsx";
-import { Show } from "solid-js";
-
-/* E2EE および MLS 機能は廃止されました */
 
 export function Setting() {
   const [language, setLanguage] = useAtom(languageState);
   const [postLimit, setPostLimit] = useAtom(microblogPostLimitState);
   const [, setIsLoggedIn] = useAtom(loginState);
-  const [accs] = useAtom(accountsAtom);
-  const [account] = useAtom(activeAccount);
 
   const handleLogout = async () => {
     try {
@@ -28,7 +19,6 @@ export function Setting() {
       console.error("logout failed", err);
     } finally {
       setIsLoggedIn(false);
-      localStorage.removeItem("encryptionKey");
     }
   };
 
@@ -62,10 +52,6 @@ export function Setting() {
       <div>
         <h3 class="font-bold mb-1">FASP 設定</h3>
         <FaspProviders />
-      </div>
-      <div>
-        <h3 class="font-bold mb-1">MLS 鍵管理</h3>
-        <p class="text-sm text-gray-400">MLS 鍵生成機能は廃止されました。</p>
       </div>
       <div class="flex justify-end space-x-2">
         <button

--- a/app/client/src/states/session.ts
+++ b/app/client/src/states/session.ts
@@ -1,4 +1,3 @@
 import { atom } from "solid-jotai";
 
 export const loginState = atom<boolean | null>(null);
-export const encryptionKeyState = atom<string | null>(null);

--- a/app/client/src/utils/config.ts
+++ b/app/client/src/utils/config.ts
@@ -79,8 +79,6 @@ export function getDomain(): string {
   return domain;
 }
 
-// MLS KeyPackage pool 設定は廃止（互換のためキーは残さない）
-
 // --- 複数サーバー管理 ---
 
 const SERVERS_KEY = "takos-servers";

--- a/app/takos_host/client/src/pages/WelcomePage.tsx
+++ b/app/takos_host/client/src/pages/WelcomePage.tsx
@@ -128,23 +128,6 @@ const Globe = () => (
   </svg>
 );
 
-const Lock = () => (
-  <svg
-    class="w-8 h-8 text-indigo-400 mb-4"
-    fill="none"
-    stroke="currentColor"
-    stroke-width="2"
-    viewBox="0 0 24 24"
-    stroke-linecap="round"
-    stroke-linejoin="round"
-    aria-hidden="true"
-  >
-    <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
-    <circle cx="12" cy="16" r="1" />
-    <path d="M7 11V7a5 5 0 0110 0v4" />
-  </svg>
-);
-
 const Smartphone = () => (
   <svg
     class="w-8 h-8 text-indigo-400 mb-4"
@@ -194,13 +177,6 @@ const FEATURES = [
     highlight: "自由度",
   },
   {
-    icon: Lock,
-    title: "ac",
-    desc:
-      "activitypub-e2eeを利用したエンドツーエンド暗号化。プライバシーを最優先に考えた設計。",
-    highlight: "セキュア",
-  },
-  {
     icon: Smartphone,
     title: "マルチプラットフォーム",
     desc:
@@ -227,16 +203,6 @@ const COMPARISON = [
     others: {
       Mastodon: "○",
       Misskey: "○",
-      Twitter: "×",
-      Facebook: "×",
-    },
-  },
-  {
-    label: "E2EE (エンドツーエンド暗号化)",
-    takos: "○",
-    others: {
-      Mastodon: "×",
-      Misskey: "×",
       Twitter: "×",
       Facebook: "×",
     },

--- a/app/takos_host/deno.lock
+++ b/app/takos_host/deno.lock
@@ -20,7 +20,6 @@
     "npm:mongoose@^8.16.4": "8.17.1",
     "npm:nodemailer@^6.9.11": "6.10.1",
     "npm:solid-app-router@~0.4.2": "0.4.2_solid-js@1.9.7__seroval@1.3.2",
-    "npm:ts-mls@1.0.4": "1.0.4",
     "npm:zod@^3.25.56": "3.25.76"
   },
   "jsr": {
@@ -282,12 +281,6 @@
         "punycode"
       ]
     },
-    "ts-mls@1.0.4": {
-      "integrity": "sha512-JYwcIrCv399G0LmXl+hhcegAH3HjWv/V68/ueGQBC3VslbuqL5H0hN+/cIqQeWhD0ttqJ4xGzhjwAmQ12iipsQ==",
-      "dependencies": [
-        "@hpke/core"
-      ]
-    },
     "tslib@2.8.1": {
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
@@ -317,11 +310,7 @@
     "https://esm.sh/@noble/curves@^1.9.2/ed25519?target=denonext": "https://esm.sh/@noble/curves@1.9.7/ed25519?target=denonext",
     "https://esm.sh/@noble/curves@^1.9.2/ed448?target=denonext": "https://esm.sh/@noble/curves@1.9.7/ed448?target=denonext",
     "https://esm.sh/@noble/curves@^1.9.2/nist?target=denonext": "https://esm.sh/@noble/curves@1.9.7/nist?target=denonext",
-    "https://esm.sh/mlkem@^2.5.0?target=denonext": "https://esm.sh/mlkem@2.5.0?target=denonext",
-    "https://esm.sh/ts-mls": "https://esm.sh/ts-mls@1.1.0",
-    "https://esm.sh/ts-mls@": "https://esm.sh/ts-mls@1.1.0",
-    "https://esm.sh/ts-mls@1": "https://esm.sh/ts-mls@1.1.0",
-    "https://esm.sh/ts-mls@1.1": "https://esm.sh/ts-mls@1.1.0"
+    "https://esm.sh/mlkem@^2.5.0?target=denonext": "https://esm.sh/mlkem@2.5.0?target=denonext"
   },
   "remote": {
     "https://deno.land/x/bcrypt@v0.4.1/mod.ts": "ff09bdae282583cf5f7d87efe37ddcecef7f14f6d12e8b8066a3058db8c6c2f7",
@@ -395,9 +384,7 @@
     "https://esm.sh/@noble/post-quantum@0.4.1/denonext/ml-dsa.mjs": "8941f2818e975eb150f6ab1684f0a9fdf91016bd9dcc46afaca368dab9193dc2",
     "https://esm.sh/@noble/post-quantum@0.4.1/denonext/utils.mjs": "ae9816210bbddc80575107fb49f95cb8ef967c5f8e2c065e8775b97d6c204e25",
     "https://esm.sh/mlkem@2.5.0/denonext/mlkem.mjs": "eb11ce36395384fe01c17c290b2f52e1b9dd2c4fdd63400f85b4cfb9862125e5",
-    "https://esm.sh/mlkem@2.5.0?target=denonext": "80fb7be6c3e9e45d755ca12efb3003834ab56685ccdc9cac2c04f5e9d8c29f75",
-    "https://esm.sh/ts-mls@1.1.0": "736040719faff07256db94f912330abecfcd46df1364970b0bb3d1e5e7724b8a",
-    "https://esm.sh/ts-mls@1.1.0/denonext/ts-mls.mjs": "80d785347d53f5181a57b0b90f8ca18b40ce9068293cf4067756feb35169fe14"
+    "https://esm.sh/mlkem@2.5.0?target=denonext": "80fb7be6c3e9e45d755ca12efb3003834ab56685ccdc9cac2c04f5e9d8c29f75"
   },
   "workspace": {
     "dependencies": [


### PR DESCRIPTION
## 概要
- クライアント設定やチャット、設定画面などからMLS/E2EE関連コードを削除
- Welcomeページと依存関係からMLSやE2EEの記述を除去

## テスト
- `deno fmt app/client/src/utils/config.ts app/client/src/states/session.ts app/client/src/components/Setting/index.tsx app/client/src/components/Chat.tsx app/takos_host/client/src/pages/WelcomePage.tsx`
- `deno lint app/client/src/utils/config.ts app/client/src/states/session.ts app/client/src/components/Setting/index.tsx app/client/src/components/Chat.tsx app/takos_host/client/src/pages/WelcomePage.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68a9c11712608328b3c67d366b212bc9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新機能
  - DM送受信の信頼性を向上。選択中ルームは増分更新、未選択は軽量取得で表示を高速化。
- リファクタ
  - チャットをサーバー主導のDMモデルへ移行し、メンバー・招待の取得をサーバー基準に統一。
  - ルーム別の復号メッセージキャッシュを導入し、再表示を高速化。
  - 送信時の相手解決と楽観反映を安定化。
- 雑務
  - 設定・ウェルカム画面からE2EE関連の表示を削除し、不要な鍵管理やログアウト時の処理を整理。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->