### PR TITLE
feat: DMルーム読み込みの追加

### DIFF
--- a/app/client/src/components/Chat.tsx
+++ b/app/client/src/components/Chat.tsx
@@ -983,6 +983,43 @@ export function Chat() {
       });
     }
 
+    // DMルームをサーバーから取得して追加
+    const dmRooms = await searchRooms(handle, { type: "dm" });
+    for (const item of dmRooms) {
+      const name = item.name ?? "";
+      const icon = item.icon ?? "";
+      // members が不足している場合は pending を参照
+      let members = item.members ?? [] as string[];
+      if (members.length === 0) {
+        try {
+          const pend = await readPending(user.id, item.id, "dm");
+          const others = (pend || []).filter((m: string | undefined) =>
+            !!m && m !== handle
+          ) as string[];
+          if (others.length > 0) members = others;
+        } catch {
+          /* ignore */
+        }
+      }
+      rooms.push({
+        id: item.id,
+        name,
+        userName: user.userName,
+        domain: getDomain(),
+        avatar: icon ||
+          (String(name).length > 0
+            ? String(name).charAt(0).toUpperCase()
+            : "👤"),
+        unreadCount: 0,
+        type: "dm",
+        members,
+        hasName: name !== "",
+        hasIcon: icon !== "",
+        lastMessage: "...",
+        lastMessageTime: undefined,
+      });
+    }
+
     await applyDisplayFallback(rooms);
 
     const unique = rooms.filter(


### PR DESCRIPTION
## Summary
- サーバーからDMルームを取得し、既存ルームと統合
- 取得したDMルームをChatRoomListで表示できるよう整備

## Testing
- `deno fmt app/client/src/components/Chat.tsx`
- `deno lint app/client/src/components/Chat.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68aa5c74db7883288bf0dfc92855fe59

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 新機能
  * DM（ダイレクトメッセージ）ルームをルーム一覧に統合し、グループと併せて表示。
  * 参加者情報が不足するDMでも相手のハンドルを補完して表示。
  * アイコン未設定時は名前の先頭文字や既定アイコンで代替表示。
  * 重複抑制と表示フォールバックを適用し、ルーム一覧の整合性を向上。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->