### PR TITLE
feat: グループ一覧取得APIの追加

### DIFF
--- a/app/client/src/components/Chat.tsx
+++ b/app/client/src/components/Chat.tsx
@@ -2106,14 +2106,28 @@ async function searchRooms(
         `/api/groups?owner=${encodeURIComponent(_handle)}`,
       );
       if (!gres.ok) return [];
-      return await gres.json();
+      const j = await gres.json();
+      if (!Array.isArray(j)) return [];
+      return j.map((r) => ({
+        id: String(r.id ?? ""),
+        name: String(r.name ?? ""),
+        icon: typeof r.icon === "string" ? r.icon : undefined,
+        members: Array.isArray(r.members) ? r.members.map(String) : [],
+      }));
     }
     if (roomType === "dm" || roomType === undefined) {
       const dres = await apiFetch(
         `/api/dms?owner=${encodeURIComponent(_handle)}`,
       );
       if (!dres.ok) return [];
-      return await dres.json();
+      const j = await dres.json();
+      if (!Array.isArray(j)) return [];
+      return j.map((r) => ({
+        id: String(r.id ?? ""),
+        name: String(r.name ?? ""),
+        icon: typeof r.icon === "string" ? r.icon : undefined,
+        members: Array.isArray(r.members) ? r.members.map(String) : [],
+      }));
     }
     return [];
   } catch {

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -658,6 +658,34 @@ paths:
         "200":
           description: 送信結果
   /api/groups:
+    get:
+      summary: グループ一覧取得
+      parameters:
+        - name: owner
+          in: query
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: 所属グループの配列
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: string
+                    name:
+                      type: string
+                    icon:
+                      type: string
+                    members:
+                      type: array
+                      items:
+                        type: string
     post:
       summary: グループ作成
       requestBody:


### PR DESCRIPTION
## 概要
- 所属グループを取得する GET `/api/groups` を追加
- フロントエンドのルーム検索処理を調整
- OpenAPI ドキュメントを更新

## テスト
- `deno fmt app/api/routes/groups.ts app/client/src/components/Chat.tsx docs/openapi.yaml`
- `deno lint app/api/routes/groups.ts app/client/src/components/Chat.tsx docs/openapi.yaml`


------
https://chatgpt.com/codex/tasks/task_e_68aa5c7e00e8832894fb602c2eb89e50

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新機能
  - GET /api/groups エンドポイントを追加。owner クエリで所属グループ一覧を取得し、id・name・icon・members を返却
- リファクタ
  - ルーム検索結果（グループ/DM）のメタデータを統一フォーマットに正規化し、欠損や型ゆれに強い挙動に改善
- ドキュメント
  - OpenAPI に GET /api/groups を追記（owner パラメータ、200 応答スキーマを定義）

<!-- end of auto-generated comment: release notes by coderabbit.ai -->