### PR TITLE
messagesスキーマでnote以外も保存可能に

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,10 +176,13 @@ ActivityPub 形式の一覧が必要な場合は、`/ap/users/:username/follower
 
 - `GET /api/dm?user1=<handle>&user2=<handle>` – 2者間 DM の一覧取得
 - `POST /api/dm` – DM 送信（body:
-  `{ from, to, type, content?, attachments? }`。ActivityPub の object
-  はサーバー側で組み立てられます）
+  `{ from, to, type, content?, url?, mediaType?, key?, iv?, preview?, attachments? }`。ActivityPub
+  の object はサーバー側で組み立てられます。本文がない場合は `url` と
+  `mediaType` を指定して画像などをメインコンテンツとして送信できます）
 - `GET /api/users/:user/keep` – TAKO Keep に保存したメモ一覧を取得（添付対応）
-- `POST /api/users/:user/keep` – TAKO Keep へメモを保存（`{ content?, attachments? }`。`attachments` は `/api/files` で取得した URL と mediaType などを配列で指定）
+- `POST /api/users/:user/keep` – TAKO Keep
+  へメモを保存（`{ content?, attachments? }`。`attachments` は `/api/files`
+  で取得した URL と mediaType などを配列で指定）
 - `GET /api/keeps?handle=<user@domain>` – 上記の簡易エイリアス（認証必須）
 - `POST /api/keeps` – 上記の簡易エイリアス（認証必須）
 - `POST /api/files` – ファイルアップロード（HTTP のみ、要ログイン）

--- a/app/api/models/takos/message.ts
+++ b/app/api/models/takos/message.ts
@@ -5,7 +5,16 @@ const messageSchema = new mongoose.Schema({
   _id: { type: String },
   attributedTo: { type: String, required: true },
   actor_id: { type: String, required: true, index: true },
+  type: {
+    type: String,
+    enum: ["Note", "Image", "Video", "Audio", "Document"],
+    default: "Note",
+    required: true,
+  },
   content: { type: String, default: "" },
+  url: { type: String },
+  mediaType: { type: String },
+  name: { type: String, default: "" },
   extra: { type: mongoose.Schema.Types.Mixed, default: {} },
   published: { type: Date, default: Date.now },
   created_at: { type: Date, default: Date.now },
@@ -15,6 +24,15 @@ const messageSchema = new mongoose.Schema({
     to: { type: [String], default: [] },
     cc: { type: [String], default: [] },
   },
+});
+
+messageSchema.pre("validate", function (next) {
+  if (this.type === "Note") {
+    if (!this.content) this.invalidate("content", "content is required");
+  } else {
+    if (!this.url) this.invalidate("url", "url is required");
+  }
+  next();
 });
 
 messageSchema.plugin(tenantScope, { envKey: "ACTIVITYPUB_DOMAIN" });

--- a/app/api/utils/activitypub.ts
+++ b/app/api/utils/activitypub.ts
@@ -345,7 +345,9 @@ export function parseSignature(
   if (!m) {
     // Signature-Input はあるが形式が不正な場合、Signature ヘッダが cavage 形式で来ている可能性にフォールバック
     const fallback = parseSignatureHeader(sig);
-    if (!fallback.headers || !fallback.signature || !fallback.keyId) return null;
+    if (!fallback.headers || !fallback.signature || !fallback.keyId) {
+      return null;
+    }
     return {
       headers: fallback.headers.split(" "),
       signature: fallback.signature,
@@ -361,7 +363,9 @@ export function parseSignature(
   if (!sigMatch || !keyIdMatch) {
     // Signature-Input があるが Signature が cavage 形式（もしくは label 不一致）の可能性
     const fallback = parseSignatureHeader(sig);
-    if (!fallback.headers || !fallback.signature || !fallback.keyId) return null;
+    if (!fallback.headers || !fallback.signature || !fallback.keyId) {
+      return null;
+    }
     return {
       headers: fallback.headers.split(" "),
       signature: fallback.signature,
@@ -789,12 +793,15 @@ export function buildActivityFromStored(
     content: string;
     published: unknown;
     extra: Record<string, unknown>;
+    url?: string;
+    mediaType?: string;
+    name?: string;
   },
   domain: string,
   username: string,
   withContext = false,
 ) {
-  const base = {
+  const base: Record<string, unknown> = {
     id: `https://${domain}/objects/${obj._id}`,
     type: obj.type,
     attributedTo: `https://${domain}/users/${username}`,
@@ -804,6 +811,9 @@ export function buildActivityFromStored(
       : obj.published,
     ...obj.extra,
   };
+  if (obj.url) base.url = obj.url;
+  if (obj.mediaType) base.mediaType = obj.mediaType;
+  if (obj.name) base.name = obj.name;
   return withContext
     ? { "@context": "https://www.w3.org/ns/activitystreams", ...base }
     : base;

--- a/app/shared/db.ts
+++ b/app/shared/db.ts
@@ -77,6 +77,11 @@ export interface DB {
     type: string,
     content?: string,
     attachments?: Record<string, unknown>[],
+    url?: string,
+    mediaType?: string,
+    key?: string,
+    iv?: string,
+    preview?: Record<string, unknown>,
   ): Promise<unknown>;
   listDMsBetween(user1: string, user2: string): Promise<unknown[]>;
   findObjects(


### PR DESCRIPTION
## Summary
- MessageモデルにActivityStreamsタイプごとの列挙とバリデーションを追加
- saveObjectとDM保存処理を更新し、メディアのURL・媒体タイプをトップレベルで管理
- ActivityPub投稿APIで受理するオブジェクトタイプを制限
- Note投稿ではcontent必須、メディア投稿ではurlとmediaType必須のAPI検証を追加

## Testing
- `deno fmt app/api/routes/dm.ts app/api/routes/activitypub.ts app/api/utils/activitypub.ts`
- `deno lint app/api/routes/dm.ts app/api/routes/activitypub.ts app/api/utils/activitypub.ts`


------
https://chatgpt.com/codex/tasks/task_e_68aa8e3769c88328b91488cd51d91715

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新機能
  - DMでメディア単体の送信に対応（url・mediaType・任意のkey/iv・preview）。本文なしでも送信可能。
  - 受信DMのプレビュー表示と添付の自動補完を強化し、表示の安定性を向上。
  - ActivityPub投稿で画像/動画/音声/ドキュメントに対応し、url・mediaType・nameを含めて配信。
- ドキュメント
  - DM本文フォーマットとメディア送信手順を更新。
  - TAKO Keepのメモ保存の説明を整備し、添付の指定方法を明確化。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->