### PR TITLE
グループAPIのownerを廃止しメンバー判定に変更

### DIFF
--- a/app/api/DB/mongo.ts
+++ b/app/api/DB/mongo.ts
@@ -678,8 +678,8 @@ export class MongoDB implements DB {
     return res != null;
   }
 
-  async listGroups(owner: string) {
-    const query = this.withTenant(Group.find({ followers: owner }));
+  async listGroups(member: string) {
+    const query = this.withTenant(Group.find({ followers: member }));
     return await query.lean<GroupDoc[]>();
   }
 

--- a/app/client/src/components/Chat.tsx
+++ b/app/client/src/components/Chat.tsx
@@ -1949,14 +1949,14 @@ export function Chat() {
         onCreate={async (name: string, membersStr: string) => {
           const user = account();
           if (!user) return;
-          const owner = `${user.userName}@${getDomain()}`;
+          const handle = `${user.userName}@${getDomain()}`;
           const id = crypto.randomUUID();
           // membersStr is comma-separated list
           const members = membersStr.split(",").map((s) => s.trim()).filter(
             Boolean,
           );
           try {
-            await _addRoom(owner, { id, name, members, type: "group" });
+            await _addRoom(handle, { id, name, members, type: "group" });
             selectRoom(id);
           } catch {
             /* ignore */
@@ -2053,7 +2053,7 @@ async function searchRooms(
     const roomType = _opts?.type;
     if (roomType === "group") {
       const gres = await apiFetch(
-        `/api/groups?owner=${encodeURIComponent(_handle)}`,
+        `/api/groups?member=${encodeURIComponent(_handle)}`,
       );
       if (!gres.ok) return [];
       const j = await gres.json();
@@ -2157,6 +2157,7 @@ async function _addRoom(
         body: JSON.stringify({
           groupName: _room.name,
           displayName: _room.name,
+          member: _handle,
         }),
       });
     }

--- a/app/client/src/components/Setting/GroupSettingsForm.tsx
+++ b/app/client/src/components/Setting/GroupSettingsForm.tsx
@@ -1,5 +1,7 @@
 import { createSignal, For, onMount } from "solid-js";
-import { apiFetch } from "../../utils/config.ts";
+import { apiFetch, getDomain } from "../../utils/config.ts";
+import { useAtom } from "solid-jotai";
+import { activeAccount } from "../../states/account.ts";
 
 interface GroupOptions {
   membershipPolicies: string[];
@@ -7,6 +9,7 @@ interface GroupOptions {
 }
 
 export function GroupSettingsForm() {
+  const [account] = useAtom(activeAccount);
   const [options, setOptions] = createSignal<GroupOptions>({
     membershipPolicies: [],
     visibilities: [],
@@ -34,6 +37,7 @@ export function GroupSettingsForm() {
   const createGroup = async () => {
     setMessage("");
     try {
+      const handle = account() ? `${account()!.userName}@${getDomain()}` : "";
       const res = await apiFetch("/api/groups", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -44,6 +48,7 @@ export function GroupSettingsForm() {
           membershipPolicy: membershipPolicy() || undefined,
           visibility: visibility() || undefined,
           allowInvites: allowInvites(),
+          member: handle,
         }),
       });
       setMessage(res.ok ? "作成しました" : "作成に失敗しました");

--- a/app/shared/db.ts
+++ b/app/shared/db.ts
@@ -113,7 +113,7 @@ export interface DB {
     update: Record<string, unknown>,
   ): Promise<DirectMessageDoc | null>;
   deleteDirectMessage(owner: string, id: string): Promise<boolean>;
-  listGroups(owner: string): Promise<GroupDoc[]>;
+  listGroups(member: string): Promise<GroupDoc[]>;
   findGroupByName(name: string): Promise<GroupDoc | null>;
   createGroup(data: Record<string, unknown>): Promise<GroupDoc>;
   updateGroupByName(


### PR DESCRIPTION
## Summary
- グループ取得・作成APIでownerを廃止しmemberで参加者を判定
- グループの最後のローカルメンバーは退出できないよう制限
- フロントエンドのグループ処理を新仕様に対応

## Testing
- `deno fmt app/api/DB/mongo.ts app/api/routes/groups.ts app/client/src/components/Chat.tsx app/client/src/components/Setting/GroupSettingsForm.tsx app/shared/db.ts`
- `deno lint app/api/DB/mongo.ts app/api/routes/groups.ts app/client/src/components/Chat.tsx app/client/src/components/Setting/GroupSettingsForm.tsx app/shared/db.ts`


------
https://chatgpt.com/codex/tasks/task_e_68aafcd6c4648328a736929fd68d9235

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新機能
  - グループ作成時に作成者が自動的にメンバーとして登録されます。
  - グループ一覧は「所有グループ」ではなく「参加中のグループ」を表示するようになりました。
  - 検索・作成フローがメンバー情報を基準に統一されました。
- バグ修正
  - ローカルグループで最後のローカルメンバーが退出できないよう保護し、適切なエラーを返すようにしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->