### PR TITLE
HTTP署名をRFC9421形式に統一

### DIFF
--- a/app/api/utils/activitypub_test.ts
+++ b/app/api/utils/activitypub_test.ts
@@ -1,41 +1,12 @@
 import { assert } from "https://deno.land/std@0.208.0/assert/assert.ts";
 import { verifyHttpSignature } from "./activitypub.ts";
-import {
-  bufferToPem,
-  generateKeyPair,
-  pemToArrayBuffer,
-} from "../../shared/crypto.ts";
+import { generateKeyPair, pemToArrayBuffer } from "../../shared/crypto.ts";
 import { bufToB64 } from "../../shared/buffer.ts";
-
-async function computeLegacyDigest(body: string): Promise<string> {
-  const buf = new TextEncoder().encode(body);
-  const hash = await crypto.subtle.digest("SHA-256", buf);
-  return `SHA-256=${bufToB64(hash)}`;
-}
 
 async function computeContentDigest(body: string): Promise<string> {
   const buf = new TextEncoder().encode(body);
   const hash = await crypto.subtle.digest("SHA-256", buf);
   return `sha-256=:${bufToB64(hash)}:`;
-}
-
-async function generateRsaKeyPair() {
-  const pair = await crypto.subtle.generateKey(
-    {
-      name: "RSASSA-PKCS1-v1_5",
-      modulusLength: 2048,
-      publicExponent: new Uint8Array([1, 0, 1]),
-      hash: "SHA-256",
-    },
-    true,
-    ["sign", "verify"],
-  );
-  const priv = await crypto.subtle.exportKey("pkcs8", pair.privateKey);
-  const pub = await crypto.subtle.exportKey("spki", pair.publicKey);
-  return {
-    privateKey: bufferToPem(priv, "PRIVATE KEY"),
-    publicKey: bufferToPem(pub, "PUBLIC KEY"),
-  };
 }
 
 async function withStubbedKey(
@@ -61,92 +32,6 @@ async function withStubbedKey(
     globalThis.fetch = orig;
   }
 }
-
-Deno.test("cavage署名を検証できる", async () => {
-  const { privateKey, publicKey } = await generateKeyPair();
-  const keyId = "https://example.com/actor#main-key";
-  const body = JSON.stringify({ hello: "world" });
-  const url = "https://example.com/inbox";
-  const method = "POST";
-  const headers = new Headers();
-  headers.set("Host", "example.com");
-  const date = new Date().toUTCString();
-  headers.set("Date", date);
-  const digest = await computeLegacyDigest(body);
-  headers.set("Digest", digest);
-  const signingString = [
-    `(request-target): ${method.toLowerCase()} /inbox`,
-    "host: example.com",
-    `date: ${date}`,
-    `digest: ${digest}`,
-  ].join("\n");
-  const keyData = pemToArrayBuffer(privateKey);
-  const cryptoKey = await crypto.subtle.importKey(
-    "pkcs8",
-    keyData,
-    { name: "Ed25519" },
-    false,
-    ["sign"],
-  );
-  const signature = await crypto.subtle.sign(
-    "Ed25519",
-    cryptoKey,
-    new TextEncoder().encode(signingString),
-  );
-  const sigB64 = bufToB64(signature);
-  headers.set(
-    "Signature",
-    `keyId="${keyId}",algorithm="ed25519",headers="(request-target) host date digest",signature="${sigB64}"`,
-  );
-  const req = new Request(url, { method, headers });
-  await withStubbedKey(keyId, publicKey, async () => {
-    const ok = await verifyHttpSignature(req, body);
-    assert(ok);
-  });
-});
-
-Deno.test("RSA鍵のcavage署名を検証できる", async () => {
-  const { privateKey, publicKey } = await generateRsaKeyPair();
-  const keyId = "https://example.com/actor#rsa-key";
-  const body = JSON.stringify({ hello: "rsa" });
-  const url = "https://example.com/inbox";
-  const method = "POST";
-  const headers = new Headers();
-  headers.set("Host", "example.com");
-  const date = new Date().toUTCString();
-  headers.set("Date", date);
-  const digest = await computeLegacyDigest(body);
-  headers.set("Digest", digest);
-  const signingString = [
-    `(request-target): ${method.toLowerCase()} /inbox`,
-    "host: example.com",
-    `date: ${date}`,
-    `digest: ${digest}`,
-  ].join("\n");
-  const keyData = pemToArrayBuffer(privateKey);
-  const cryptoKey = await crypto.subtle.importKey(
-    "pkcs8",
-    keyData,
-    { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256" },
-    false,
-    ["sign"],
-  );
-  const signature = await crypto.subtle.sign(
-    "RSASSA-PKCS1-v1_5",
-    cryptoKey,
-    new TextEncoder().encode(signingString),
-  );
-  const sigB64 = bufToB64(signature);
-  headers.set(
-    "Signature",
-    `keyId="${keyId}",algorithm="rsa-sha256",headers="(request-target) host date digest",signature="${sigB64}"`,
-  );
-  const req = new Request(url, { method, headers });
-  await withStubbedKey(keyId, publicKey, async () => {
-    const ok = await verifyHttpSignature(req, body);
-    assert(ok);
-  });
-});
 
 Deno.test("RFC9421リクエスト署名を検証できる", async () => {
   const { privateKey, publicKey } = await generateKeyPair();


### PR DESCRIPTION
## 概要
- Cavage 互換処理を廃止し RFC9421 の Signature-Input/Signature のみに対応
- Digest 検証を Content-Digest のみ扱うよう変更
- 呼び出し側を RFC9421 形式に合わせて整理

## テスト
- `deno fmt app/api/utils/activitypub.ts app/api/utils/activitypub_test.ts`
- `deno lint app/api/utils/activitypub.ts app/api/utils/activitypub_test.ts`
- `deno test app/api/utils/activitypub_test.ts` *(証明書エラーのため失敗)*

------
https://chatgpt.com/codex/tasks/task_e_68ab31b976c883288b29558d9f84e10f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新機能
  - リクエスト/レスポンス署名で Content-Digest を使用可能にし、content-length も署名対象に追加。
- リファクタリング
  - 署名フローを統一し、Signature-Input/Signature を一貫した形式に整理。
  - 互換性のない変更: 旧来の Digest ヘッダーと cavage 形式の署名サポートを削除。
- バグ修正
  - 署名対象の組み立てを見直し、送信/取得時の不整合を解消。
- テスト
  - レガシー方式のテストを削除し、RFC9421 ベースのテストに集約。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->