### PR TITLE
resolveActor を廃止し acct 形式に統一

### DIFF
--- a/app/api/services/user-info.ts
+++ b/app/api/services/user-info.ts
@@ -1,6 +1,6 @@
 import { createDB } from "../DB/mod.ts";
 import type { DB } from "../../shared/db.ts";
-import { resolveActor } from "../utils/activitypub.ts";
+import { resolveActorFromAcct } from "../utils/activitypub.ts";
 import { isUrl } from "../../shared/url.ts";
 
 export interface UserInfo {
@@ -108,7 +108,7 @@ export async function getUserInfo(
     const [name, host] = identifier.split("@");
     userName = name;
     userDomain = host;
-    const actor = await resolveActor(name, host);
+    const actor = await resolveActorFromAcct(`${name}@${host}`);
     if (actor) {
       displayName = actor.name ?? actor.preferredUsername ?? userName;
       const icon = actor.icon;

--- a/app/api/utils/activitypub.ts
+++ b/app/api/utils/activitypub.ts
@@ -600,16 +600,6 @@ export async function resolveActorFromAcct(
   return await actorRes.json();
 }
 
-/**
- * 旧API: username, domain指定のまま残すが内部でacct形式に変換して新APIを利用
- */
-export function resolveActor(
-  username: string,
-  domain: string,
-): Promise<ActivityPubActor | null> {
-  return resolveActorFromAcct(`${username}@${domain}`);
-}
-
 export function getDomain(c: Context): string {
   const env = getEnv(c);
   return env["ACTIVITYPUB_DOMAIN"];

--- a/docs/chat.md
+++ b/docs/chat.md
@@ -175,10 +175,10 @@ Group）\*\*を用いて複数人で会話する最低相互運用仕様を定�
   としてGroupにも知らせてよい（Group側でのUX補助）。
 - 乱用対策として、Groupは**招待の存在を加入要件にしない**（招待が無くてもJoin/Followを受け付ける）。
 
-Takos では管理エンドポイント `/api/groups/:name/invite` に招待したい Actor の ID
-を指定して POST することで、グループから招待を送信できま す。受け手が `Join`
-または `Follow` を返送するとサーバーは自動で `Accept`
-を返し、メンバーに追加されます。
+Takos では管理エンドポイント `/api/groups/:name/invite` に招待したいアカウントの
+acct（`username@domain`）を指定して POST
+することで、グループから招待を送信できま す。受け手が `Join` または `Follow`
+を返送するとサーバーは自動で `Accept` を返し、メンバーに追加されます。
 
 #### 例: 非保有ActorからのInvite
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -390,15 +390,13 @@ paths:
           required: true
           schema:
             type: string
+          description: |
+            検索クエリ。ユーザー検索では `username@domain` 形式の acct を指定してください。
         - name: type
           in: query
           schema:
             type: string
             enum: [all, users, posts]
-        - name: server
-          in: query
-          schema:
-            type: string
       responses:
         "200":
           description: 検索結果の配列
@@ -796,11 +794,11 @@ paths:
             schema:
               type: object
               properties:
-                actor:
+                acct:
                   type: string
-                  description: 招待先Actor ID
+                  description: 招待先の acct (`username@domain`)
               required:
-                - actor
+                - acct
       responses:
         "200":
           description: 送信結果


### PR DESCRIPTION
## 概要
- ActivityPub ユーティリティから `resolveActor` を削除し `resolveActorFromAcct` のみを公開
- 各種サービス・API で `username@domain` 形式の `acct` を受け取り `resolveActorFromAcct` を利用するよう修正
- API ドキュメントを `acct` 形式に合わせて更新

## 動作確認
- `deno fmt app/api/utils/activitypub.ts app/api/services/user-info.ts app/api/routes/groups.ts app/api/routes/search.ts app/api/routes/rooms.ts docs/openapi.yaml docs/chat.md`
- `deno lint app/api/utils/activitypub.ts app/api/services/user-info.ts app/api/routes/groups.ts app/api/routes/search.ts app/api/routes/rooms.ts docs/openapi.yaml docs/chat.md`


------
https://chatgpt.com/codex/tasks/task_e_68ab37d1fb5c83289af7c56d8b48c00b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - 俳優解決をacct（username@domain）ベースに統一。POST /api/groups/:name/invite と POST /rooms/:id/invite の入力を{ acct }に変更（従来のactor URLは非対応）。/api/searchはserverクエリを削除し、acct形式やqのusername@domainを解釈。無効なacctは400を返却。
- Documentation
  - 招待フローとOpenAPIを更新。Invite/Joinの例とセキュリティ注記を追加。新しいacct指定方法を明記。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->