### PR TITLE
fetchJson ユーティリティの廃止と fetch への置換

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ MongoDB にはセッション自動削除用の TTL インデックスが必要�
 特に `ACTIVITYPUB_DOMAIN` は Mastodon など外部からアクセスされる公開ドメインを
 設定してください。未設定の場合はリクエストされたホスト名が利用されます。 以前の
 `TENANT_ID` 変数は廃止され、ドメイン名そのものがテナント ID として扱われます。
-`getEnv(c)` で取得した環境変数を `fetchJson` や `deliverActivityPubObject`
-へ渡すことで マルチテナント環境でも正しいドメインが利用されます。
+`getEnv(c)` で取得した環境変数を `deliverActivityPubObject` へ渡すことで
+マルチテナント環境でも正しいドメインが利用されます。
 
 ### 初期設定
 


### PR DESCRIPTION
## 概要
- ActivityPub ユーティリティから fetchJson を削除
- fetchActorInbox と resolveRemoteActor を素の fetch 利用に変更
- ドキュメントから fetchJson の記述を削除

## テスト
- `deno fmt app/api/utils/activitypub.ts README.md`
- `deno lint app/api/utils/activitypub.ts README.md`


------
https://chatgpt.com/codex/tasks/task_e_68ab42d778988328a2d68b0bc426d92e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* ドキュメント
  * マルチテナント環境でのドメイン解決手順を簡素化し、環境変数の受け渡し先を明確化。
* リファクタリング
  * ActivityPub の外部リソース取得処理をシンプル化し、標準ヘッダーでの直接取得に統一。
  * 必須メタデータ（inbox・公開鍵ID）欠落時のエラーメッセージを明確化し、問題判別性を向上。
  * 例外・エラーハンドリングを整理し、挙動の一貫性を改善。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->