### PR TITLE
system アカウントを通常ルートで扱うよう変更

### DIFF
--- a/app/api/server.ts
+++ b/app/api/server.ts
@@ -33,6 +33,8 @@ import { deleteCookie, getCookie } from "hono/cookie";
 import { issueSession } from "./utils/session.ts";
 import { bootstrapDefaultFasp } from "./services/fasp_bootstrap.ts";
 import dms from "./routes/dms.ts";
+import { createDB } from "./DB/mod.ts";
+import { getSystemKey } from "./services/system_actor.ts";
 
 const isDev = Deno.env.get("DEV") === "1";
 
@@ -50,6 +52,8 @@ export async function createTakosApp(env?: Record<string, string>) {
     await rl(c, next);
   });
   await initFileModule(e);
+  const db = createDB(e);
+  await getSystemKey(db, e["ACTIVITYPUB_DOMAIN"] ?? "");
 
   const apiRoutes = [
     wsRouter,

--- a/app/api/services/file.ts
+++ b/app/api/services/file.ts
@@ -27,7 +27,7 @@ export async function saveFile(
   await db.saveObject({
     _id: id,
     type: "Attachment",
-    attributedTo: `https://${domain}/system`,
+    attributedTo: `https://${domain}/users/system`,
     extra: { mediaType, key: options.key, iv: options.iv, storageKey },
   });
   return { id, url: `https://${domain}/api/files/${id}` };

--- a/app/api/services/system_actor.ts
+++ b/app/api/services/system_actor.ts
@@ -8,5 +8,14 @@ export async function getSystemKey(db: DB, domain: string) {
     await db.saveSystemKey(domain, keys.privateKey, keys.publicKey);
     doc = { domain, ...keys };
   }
+  const account = await db.findAccountByUserName("system");
+  if (!account) {
+    await db.createAccount({
+      userName: "system",
+      displayName: "system",
+      privateKey: doc.privateKey,
+      publicKey: doc.publicKey,
+    });
+  }
   return doc;
 }

--- a/app/takos_host/utils/host_context.ts
+++ b/app/takos_host/utils/host_context.ts
@@ -7,6 +7,7 @@ import { createTakosApp } from "../../api/server.ts";
 import { ensureTenant } from "../../api/services/tenant.ts";
 import { createDB } from "../../api/DB/mod.ts";
 import { bootstrapDefaultFasp } from "../../api/services/fasp_bootstrap.ts";
+import { getSystemKey } from "../../api/services/system_actor.ts";
 import { takosEnv } from "../takos_env.ts";
 import { createConsumerApp } from "../consumer.ts";
 import { createAuthApp } from "../auth.ts";
@@ -64,6 +65,10 @@ export async function initHostContext(): Promise<HostContext> {
   const rootDomain =
     (hostEnv["ROOT_DOMAIN"] ?? hostEnv["ACTIVITYPUB_DOMAIN"] ?? "")
       .toLowerCase();
+  if (rootDomain) {
+    const db = createDB(hostEnv);
+    await getSystemKey(db, rootDomain);
+  }
   const rootActivityPubApp = rootDomain
     ? createRootActivityPubApp({ ...takosEnv, ACTIVITYPUB_DOMAIN: rootDomain })
     : null;


### PR DESCRIPTION
## 概要
- `username === "system"` の特別扱いを削除し、通常の `/users/:username` ルートに統一
- `getSystemKey` でシステムアカウントを自動生成し DB に登録
- 起動時にシステムアカウントを初期化する処理を追加

## テスト
- `deno fmt app/api/routes/activitypub.ts app/api/server.ts app/api/services/file.ts app/api/services/system_actor.ts app/takos_host/root_activitypub.ts app/takos_host/utils/host_context.ts`
- `deno lint app/api/routes/activitypub.ts app/api/server.ts app/api/services/file.ts app/api/services/system_actor.ts app/takos_host/root_activitypub.ts app/takos_host/utils/host_context.ts`

------
https://chatgpt.com/codex/tasks/task_e_68ab42de6a60832882a67e9ba8100576

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新機能
  - ActivityPub がユーザー単位に対応。/users/:username と各ユーザーの inbox を提供
  - フォロワー／フォロー中コレクションの取得を改善し、ページングとエラーハンドリングを統一
  - Outbox を保存データから動的生成

- 不具合修正
  - WebFinger の解決精度向上と不正リソース時の 400/404 応答を明確化

- リファクタ
  - “system” 固有の振る舞いを削除し、全フローをユーザー基準に統一
  - 旧 /users/system ルートを /users/:username に置換（互換性に注意）

<!-- end of auto-generated comment: release notes by coderabbit.ai -->