### PR TITLE
グループ一覧取得でメンバーIDをユーザー名に変換

### DIFF
--- a/app/api/routes/groups.ts
+++ b/app/api/routes/groups.ts
@@ -39,9 +39,10 @@ app.use("/api/groups/*", authRequired);
 app.get("/api/groups", async (c) => {
   const member = c.req.query("member");
   if (!member) return c.json({ error: "member is required" }, 400);
+  const username = member.split("@")[0];
   const env = getEnv(c);
   const db = createDB(env);
-  const groups = await db.listGroups(member);
+  const groups = await db.listGroups(username);
   return c.json(groups);
 });
 


### PR DESCRIPTION
## 概要
- `/api/groups` のハンドラで member からユーザー名のみを抽出して `db.listGroups` に渡すように変更

## テスト
- `deno fmt app/api/routes/groups.ts`
- `deno lint app/api/routes/groups.ts`


------
https://chatgpt.com/codex/tasks/task_e_68ad6e90b4f483288492ff1bad9f9ae3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- バグ修正
  - グループ一覧取得で、メンバー識別子の「ユーザー名」のみを用いるよう変更。メール形式などの識別子で所属グループが正しく表示されない／不足する問題を解消。
  - ユーザー名基準の照合により、一貫性と正確性が向上し、グループページ／一覧が期待どおりに表示されます。
  - 一部環境での空表示や誤結果を改善。エンドユーザー側の操作は不要です。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->