### PR TITLE
ACTIVITYPUB_DOMAIN に統一し Vite 環境変数を削除

### DIFF
--- a/app/client/src/utils/config.ts
+++ b/app/client/src/utils/config.ts
@@ -1,8 +1,6 @@
 import { fetch as tauriFetch } from "@tauri-apps/plugin-http";
 
-let apiBase = import.meta.env.VITE_API_BASE ||
-  localStorage.getItem("takos-api-base") ||
-  "";
+let apiBase = localStorage.getItem("takos-api-base") || "";
 
 export function setApiBase(url: string) {
   apiBase = url;
@@ -71,8 +69,7 @@ export function getOrigin(): string {
 }
 
 if (!domain) {
-  domain = import.meta.env.VITE_ACTIVITYPUB_DOMAIN ||
-    new URL(getOrigin()).hostname;
+  domain = new URL(getOrigin()).hostname;
 }
 
 export function getDomain(): string {

--- a/app/client/vite.config.mts
+++ b/app/client/vite.config.mts
@@ -16,15 +16,12 @@ export default defineConfig({
     host: "0.0.0.0",
     port: 1420,
     strictPort: true,
-  // HMR: when developing with a custom hostname (eg. tako.host1.local) you
-  // may need to tune hmr.host/protocol/clientPort so the browser can reach
-  // the Vite websocket server. Leave unset here to avoid hardcoding; see
-  // vite docs if you need a custom value.
-  // hmr: { protocol: 'wss', host: 'tako.host1.local', clientPort: 1420 },
+    // HMR: when developing with a custom hostname (eg. tako.host1.local) you
+    // may need to tune hmr.host/protocol/clientPort so the browser can reach
+    // the Vite websocket server. Leave unset here to avoid hardcoding; see
+    // vite docs if you need a custom value.
+    // hmr: { protocol: 'wss', host: 'tako.host1.local', clientPort: 1420 },
   },
-
-  envPrefix: ["VITE_", "TAURI_"],
-
   build: {
     target: process.env.TAURI_PLATFORM ? "es2021" : "esnext",
     minify: !process.env.TAURI_DEBUG ? "esbuild" : false,

--- a/app/takos/.env.example
+++ b/app/takos/.env.example
@@ -60,5 +60,3 @@ ADSENSE_CLIENT=
 ADSENSE_SLOT=
 ADSENSE_ACCOUNT=
 
-# takos host用のtakos host本体のドメイン
-ROOT_DOMAIN=takos.jp

--- a/app/takos_host/.env.example
+++ b/app/takos_host/.env.example
@@ -20,7 +20,7 @@ SERVER_CERT=
 SERVER_KEY=
 
 # マルチテナント用のデフォルトルートドメイン
-ROOT_DOMAIN=takos.jp
+ACTIVITYPUB_DOMAIN=takos.jp
 
 # フリープランで作成できるインスタンス数
 FREE_PLAN_LIMIT=1


### PR DESCRIPTION
## 概要
- ドメイン指定の環境変数を `ACTIVITYPUB_DOMAIN` に統一
- Vite の環境変数を廃止し `import.meta.env` 参照を削除
- `.env.example` の `ROOT_DOMAIN` を削除・置換
- Service Worker 登録時の `import.meta.env.DEV` 判定を廃止し、ホスト名でローカル判定
- Vite 設定から `envPrefix` を削除し環境変数を露出しないように

## テスト
- `deno fmt app/client/src/utils/firebase.ts app/client/vite.config.mts`
- `deno lint app/client/src/utils/firebase.ts app/client/vite.config.mts`


------
https://chatgpt.com/codex/tasks/task_e_68af95ad22fc8328a7d73e2a62031e06

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新機能
  - なし
- 改良（Refactor）
  - APIベースURLの決定をlocalStorageのみで行うよう変更
  - ドメイン推定を常に実行時のオリジンから導出
  - localhost判定に基づき、開発環境ではサービスワーカー登録をスキップ
  - 実行環境判定のデバッグログを追加
- ドキュメント
  - 環境変数サンプルの説明を更新
- 雑務（Chores）
  - Vite設定からenvPrefixを削除
  - takos_hostの環境変数名をROOT_DOMAINからACTIVITYPUB_DOMAINへ変更
  - takosの.env.exampleから不要な行を削除

<!-- end of auto-generated comment: release notes by coderabbit.ai -->