### PR TITLE
FASPプロバイダ操作のリポジトリ化

### DIFF
--- a/app/core/db/types.ts
+++ b/app/core/db/types.ts
@@ -175,6 +175,28 @@ export interface FcmRepo {
   list(): Promise<{ token: string }[]>;
 }
 
+export interface FaspProvidersRepo {
+  getSettings(): Promise<
+    | {
+      shareEnabled?: boolean;
+      shareServerIds?: string[];
+      searchServerId?: string | null;
+    }
+    | null
+  >;
+  list(filter: Record<string, unknown>): Promise<unknown[]>;
+  findOne(filter: Record<string, unknown>): Promise<unknown | null>;
+  upsertByBaseUrl(
+    baseUrl: string,
+    set: Record<string, unknown>,
+    setOnInsert?: Record<string, unknown>,
+  ): Promise<void>;
+  updateByBaseUrl(
+    baseUrl: string,
+    update: Record<string, unknown>,
+  ): Promise<unknown | null>;
+}
+
 export interface DataStore {
   accounts: AccountsRepo;
   posts: PostsRepo;
@@ -184,6 +206,7 @@ export interface DataStore {
   system: SystemRepo;
   sessions: SessionsRepo;
   fcm: FcmRepo;
+  faspProviders: FaspProvidersRepo;
   /** 実装依存の生コネクション（必要時のみ使用） */
   raw?(): Promise<unknown>;
 }

--- a/app/takos_host/db/mongo_store.ts
+++ b/app/takos_host/db/mongo_store.ts
@@ -124,6 +124,50 @@ export function createMongoDataStore(
       unregister: (t) => impl.unregisterFcmToken(t),
       list: () => impl.listFcmTokens(),
     },
+    faspProviders: {
+      getSettings: async () => {
+        const mongo = await impl.getDatabase();
+        const doc = await mongo.collection("fasp_client_settings").findOne({
+          _id: "default",
+        }).catch(() => null);
+        return doc as
+          | {
+            shareEnabled?: boolean;
+            shareServerIds?: string[];
+            searchServerId?: string | null;
+          }
+          | null;
+      },
+      list: async (filter) => {
+        const mongo = await impl.getDatabase();
+        return await mongo.collection("fasp_client_providers").find(filter)
+          .toArray();
+      },
+      findOne: async (filter) => {
+        const mongo = await impl.getDatabase();
+        return await mongo.collection("fasp_client_providers").findOne(filter);
+      },
+      upsertByBaseUrl: async (baseUrl, set, setOnInsert) => {
+        const mongo = await impl.getDatabase();
+        const update: Record<string, unknown> = { $set: set };
+        if (setOnInsert) update.$setOnInsert = setOnInsert;
+        await mongo.collection("fasp_client_providers").updateOne(
+          { baseUrl },
+          update,
+          { upsert: true },
+        );
+      },
+      updateByBaseUrl: async (baseUrl, update) => {
+        const mongo = await impl.getDatabase();
+        const res = await mongo.collection("fasp_client_providers")
+          .findOneAndUpdate(
+            { baseUrl },
+            { $set: update },
+            { returnDocument: "after" },
+          );
+        return res.value as unknown | null;
+      },
+    },
     tenant: {
       ensure: async (id, domain) => {
         const exists = await Tenant.findOne({ _id: id }).lean();


### PR DESCRIPTION
## 概要
- FaspProvidersRepoを追加し、DataStoreへ統合
- Mongo実装にFaspProvidersRepoを実装
- fasp関連サービスをリポジトリ経由のデータ取得・更新に変更

## テスト
- `deno fmt app/core/db/types.ts app/takos/db/mongo_store.ts app/takos_host/db/mongo_store.ts app/core/services/fasp.ts app/core/services/fasp_bootstrap.ts`
- `deno lint -c app/takos/deno.json app/takos/db/mongo_store.ts`
- `deno lint -c app/takos_host/deno.json app/takos_host/db/mongo_store.ts`
- `deno lint -c app/core/deno.json app/core/db/types.ts app/core/services/fasp.ts app/core/services/fasp_bootstrap.ts` *(import解決エラーにより失敗)*

------
https://chatgpt.com/codex/tasks/task_e_68afe746641883289c5615ebd33c4f74

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- リファクタリング
  - FASPプロバイダー関連のデータアクセスを一元化し、設定取得・検索・通知送信の安定性と一貫性を向上。
  - 検索サーバーの選択ロジックを整理し、承認済みかつ有効なプロバイダーを優先利用。
  - 共有設定が無効な場合の通知送信を適切に抑止。

- 雑務
  - データストアにプロバイダー管理の共通APIを追加。外部インターフェースの互換性は維持され、既存機能への影響はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->