### PR TITLE
FASPプロバイダ操作リポジトリの追加

### DIFF
--- a/app/takos_host/db/mod.ts
+++ b/app/takos_host/db/mod.ts
@@ -3,6 +3,7 @@ export { createMongoDataStore } from "./mongo_store.ts";
 export { createDB, setStoreFactory } from "../../core/db/mod.ts";
 export type {
   DomainsRepo,
+  FaspProvidersRepo,
   HostDataStore,
   HostRepo,
   OAuthRepo,

--- a/app/takos_host/db/mongo_store.ts
+++ b/app/takos_host/db/mongo_store.ts
@@ -5,6 +5,7 @@ import Instance from "../models/instance.ts";
 import OAuthClient from "../models/oauth_client.ts";
 import HostDomain from "../models/domain.ts";
 import type mongoose from "mongoose";
+import type { Db } from "mongodb";
 
 /**
  * 既存の MongoDB 実装をホスト用 DataStore に束ねる実装。
@@ -239,6 +240,40 @@ export function createMongoDataStore(
       },
       verify: (id) =>
         HostDomain.updateOne({ _id: id }, { $set: { verified: true } }),
+    },
+    faspProviders: {
+      findByBaseUrl: async (baseUrl) => {
+        const db = await impl.getDatabase() as Db;
+        const col = db.collection("fasp_client_providers");
+        const doc = await col.findOne<{ secret?: string }>({
+          tenant_id: tenantId,
+          baseUrl,
+        });
+        return doc ? { secret: doc.secret } : null;
+      },
+      createDefault: async (data) => {
+        const db = await impl.getDatabase() as Db;
+        const col = db.collection("fasp_client_providers");
+        await col.insertOne({
+          name: data.name,
+          baseUrl: data.baseUrl,
+          serverId: data.serverId,
+          status: "approved",
+          capabilities: {},
+          secret: data.secret,
+          tenant_id: tenantId,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        });
+      },
+      updateSecret: async (baseUrl, secret) => {
+        const db = await impl.getDatabase() as Db;
+        const col = db.collection("fasp_client_providers");
+        await col.updateOne(
+          { tenant_id: tenantId, baseUrl },
+          { $set: { secret, updatedAt: new Date() } },
+        );
+      },
     },
     raw: () => impl.getDatabase(),
     // 互換用: 旧 API で使用していた getDatabase を残す

--- a/app/takos_host/db/types.ts
+++ b/app/takos_host/db/types.ts
@@ -44,6 +44,20 @@ export interface DomainsRepo {
   verify(id: string): Promise<void>;
 }
 
+// FASP プロバイダ操作用リポジトリ
+export interface FaspProvidersRepo {
+  findByBaseUrl(
+    baseUrl: string,
+  ): Promise<{ secret?: string } | null>;
+  createDefault(data: {
+    name: string;
+    baseUrl: string;
+    serverId: string;
+    secret: string;
+  }): Promise<void>;
+  updateSecret(baseUrl: string, secret: string): Promise<void>;
+}
+
 export interface HostDataStore extends DataStore {
   tenantId: string;
   multiTenant: boolean;
@@ -51,4 +65,5 @@ export interface HostDataStore extends DataStore {
   host: HostRepo;
   oauth: OAuthRepo;
   domains: DomainsRepo;
+  faspProviders: FaspProvidersRepo;
 }


### PR DESCRIPTION
## 概要
- FASPプロバイダ操作用リポジトリを追加
- Mongo実装にFASPプロバイダ操作メソッドを実装
- `seedDefaultFasp` を新リポジトリAPIで実装し Mongo 固有コードを排除

## テスト
- `deno fmt app/takos_host/db/types.ts app/takos_host/db/mod.ts app/takos_host/db/mongo_store.ts app/takos_host/utils/host_context.ts`
- `deno lint app/takos_host/db/types.ts app/takos_host/db/mod.ts app/takos_host/db/mongo_store.ts app/takos_host/utils/host_context.ts`


------
https://chatgpt.com/codex/tasks/task_e_68afe75625e48328a1d309235bf76e25

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新機能
  - マルチテナント環境でのFASPプロバイダ管理を追加。既定プロバイダの自動プロビジョニング、シークレットの生成・更新、ベースURLによる検索をサポート。
  - 初期ブートストラップでデフォルト設定を自動適用し、セットアップを簡素化。

- リファクタ
  - テナントDBアクセスを統一ストア経由に切替え、プロビジョニング処理を簡素化・堅牢化。
  - 型整合性の改善により拡張性と保守性を向上。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->