### PR TITLE
サービス層へのDB操作移譲

### DIFF
--- a/app/core/routes/dms.ts
+++ b/app/core/routes/dms.ts
@@ -1,14 +1,14 @@
-import { Hono } from "hono";
+import { type Context, Hono } from "hono";
 import { z } from "zod";
 import { zValidator } from "@hono/zod-validator";
 import authRequired from "../utils/auth.ts";
 import { getDB } from "../db/mod.ts";
-import { getEnv } from "@takos/config";
-import { saveFile } from "../services/file.ts";
 import type { DirectMessageDoc } from "@takos/types";
 
 const app = new Hono();
-app.use("/dms/*", authRequired);
+const auth = (c: Context, next: () => Promise<void>) =>
+  authRequired(getDB(c))(c, next);
+app.use("/dms/*", auth);
 
 app.get("/dms", async (c) => {
   const owner = c.req.query("owner");
@@ -31,10 +31,10 @@ app.post(
 );
 
 // DM は保持情報が最小のため、更新エンドポイントは未対応
-app.patch("/dms/:id", async (c) => c.json({ error: "not supported" }, 400));
+app.patch("/dms/:id", (c) => c.json({ error: "not supported" }, 400));
 
 // DM はアイコンを保存しない
-app.post("/dms/:id/icon", async (c) => c.json({ error: "not supported" }, 400));
+app.post("/dms/:id/icon", (c) => c.json({ error: "not supported" }, 400));
 
 app.delete("/dms/:id", async (c) => {
   const owner = c.req.query("owner");

--- a/app/core/routes/follow.ts
+++ b/app/core/routes/follow.ts
@@ -4,16 +4,8 @@ import { zValidator } from "@hono/zod-validator";
 import authRequired from "../utils/auth.ts";
 import { getDB } from "../db/mod.ts";
 import { getEnv } from "@takos/config";
-import {
-  createAcceptActivity,
-  createFollowActivity,
-  createUndoFollowActivity,
-  deliverActivityPubObject,
-  getDomain,
-  jsonResponse,
-} from "../utils/activitypub.ts";
-import { addNotification } from "../services/notification.ts";
-import type { AccountDoc } from "@takos/types";
+import { getDomain, jsonResponse } from "../utils/activitypub.ts";
+import { processFollow } from "../services/follow.ts";
 
 const urlValidator = (field: string) =>
   z.string()
@@ -28,114 +20,62 @@ const followSchema = z.object({
 });
 
 const app = new Hono();
-app.use("/follow", authRequired);
-
-async function processFollow(c: Context, remove: boolean) {
-  const body = await c.req.json();
-  const validated = followSchema.parse(body);
-  const { follower: followerUrl, target: targetUrl } = validated;
-  const domain = getDomain(c);
-  const env = getEnv(c);
-  const db = getDB(c);
-
-  // 自分自身をフォローすることは許可しない
-  if (followerUrl === targetUrl) {
-    return jsonResponse(
-      c,
-      { error: "自分自身をフォローすることはできません" },
-      400,
-    );
-  }
-
-  const followerInfo = new URL(followerUrl);
-  const isLocalFollower = followerInfo.hostname === domain;
-  let account: AccountDoc | null = null;
-  if (isLocalFollower) {
-    const followerName = followerInfo.pathname.split("/")[2];
-    account = await db.accounts.findByUserName(followerName);
-    if (!account) {
-      return jsonResponse(c, { error: "Follower not found" }, 404);
-    }
-  }
-
-  const following = account
-    ? (remove
-      ? await db.accounts.removeFollowing(String(account._id), targetUrl)
-      : await db.accounts.addFollowing(String(account._id), targetUrl))
-    : [];
-
-  try {
-    const actorId = account
-      ? `https://${domain}/users/${account.userName}`
-      : followerUrl;
-    const url = new URL(targetUrl);
-    if (url.hostname === domain && url.pathname.startsWith("/users/")) {
-      const name = url.pathname.split("/")[2];
-      if (remove) {
-        await db.accounts.removeFollowerByName(name, actorId);
-      } else {
-        await db.accounts.addFollowerByName(name, actorId);
-      }
-      if (account) {
-        if (!remove) {
-          await addNotification(
-            name,
-            "新しいフォロー",
-            `${account.userName}さんが${name}さんをフォローしました`,
-            "info",
-            env,
-          );
-        }
-      } else if (!remove) {
-        const accept = createAcceptActivity(
-          domain,
-          `https://${domain}/users/${name}`,
-          createFollowActivity(domain, actorId, targetUrl),
-        );
-        deliverActivityPubObject(
-          [followerUrl],
-          accept,
-          name,
-          domain,
-          env,
-        ).catch((err) => console.error("Delivery failed:", err));
-      }
-    } else if (account) {
-      const activity = remove
-        ? createUndoFollowActivity(domain, actorId, targetUrl)
-        : createFollowActivity(domain, actorId, targetUrl);
-      deliverActivityPubObject(
-        [targetUrl],
-        activity,
-        account.userName,
-        domain,
-        env,
-      ).catch((err) => console.error("Delivery failed:", err));
-      if (remove) {
-        if (db.posts.unfollow) await db.posts.unfollow(account.userName, targetUrl);
-      } else {
-        await db.posts.follow(account.userName, targetUrl);
-      }
-    } else {
-      return jsonResponse(c, { error: "unsupported" }, 400);
-    }
-  } catch (err) {
-    console.error("Follow operation failed:", err);
-  }
-
-  return jsonResponse(c, { following });
-}
+const auth = (c: Context, next: () => Promise<void>) =>
+  authRequired(getDB(c))(c, next);
+app.use("/follow", auth);
 
 app.post(
   "/follow",
   zValidator("json", followSchema),
-  (c) => processFollow(c, false),
+  async (c) => {
+    const { follower: followerUrl, target: targetUrl } = c.req.valid("json");
+    const domain = getDomain(c);
+    const env = getEnv(c);
+    const db = getDB(c);
+    if (followerUrl === targetUrl) {
+      return jsonResponse(
+        c,
+        { error: "自分自身をフォローすることはできません" },
+        400,
+      );
+    }
+    const following = await processFollow(
+      db,
+      env,
+      domain,
+      followerUrl,
+      targetUrl,
+      false,
+    );
+    return jsonResponse(c, { following });
+  },
 );
 
 app.delete(
   "/follow",
   zValidator("json", followSchema),
-  (c) => processFollow(c, true),
+  async (c) => {
+    const { follower: followerUrl, target: targetUrl } = c.req.valid("json");
+    const domain = getDomain(c);
+    const env = getEnv(c);
+    const db = getDB(c);
+    if (followerUrl === targetUrl) {
+      return jsonResponse(
+        c,
+        { error: "自分自身をフォローすることはできません" },
+        400,
+      );
+    }
+    const following = await processFollow(
+      db,
+      env,
+      domain,
+      followerUrl,
+      targetUrl,
+      true,
+    );
+    return jsonResponse(c, { following });
+  },
 );
 
 export default app;

--- a/app/core/routes/login.ts
+++ b/app/core/routes/login.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import { zValidator } from "@hono/zod-validator";
 import { getEnv } from "@takos/config";
 import { issueSession } from "../utils/session.ts";
+import { getDB } from "../db/mod.ts";
 import { setCookie } from "hono/cookie";
 
 const app = new Hono();
@@ -96,7 +97,7 @@ app.post(
         const user = data.user;
         if (!user || !user.id) return c.json({ error: "Invalid user" }, 401);
 
-        await issueSession(c);
+        await issueSession(c, getDB(c));
         return c.json({ success: true, message: "Login successful" });
       } finally {
         clearTimeout(timeout);
@@ -114,7 +115,7 @@ app.post(
         return c.json({ error: "Invalid password" }, 401);
       }
 
-      await issueSession(c);
+      await issueSession(c, getDB(c));
 
       return c.json({ success: true, message: "Login successful" });
     } catch (error) {

--- a/app/core/routes/logout.ts
+++ b/app/core/routes/logout.ts
@@ -1,10 +1,12 @@
-import { Hono } from "hono";
+import { type Context, Hono } from "hono";
 import { deleteCookie, getCookie } from "hono/cookie";
 import { getDB } from "../db/mod.ts";
 import authRequired from "../utils/auth.ts";
 
 const app = new Hono();
-app.use("/logout", authRequired);
+const auth = (c: Context, next: () => Promise<void>) =>
+  authRequired(getDB(c))(c, next);
+app.use("/logout", auth);
 
 app.post("/logout", async (c) => {
   const sessionId = getCookie(c, "sessionId");

--- a/app/core/routes/notifications.ts
+++ b/app/core/routes/notifications.ts
@@ -1,4 +1,4 @@
-import { Hono } from "hono";
+import { type Context, Hono } from "hono";
 import { z } from "zod";
 import { zValidator } from "@hono/zod-validator";
 import { getDB } from "../db/mod.ts";
@@ -17,7 +17,9 @@ interface NotificationDoc {
 }
 
 const app = new Hono();
-app.use("/notifications/*", authRequired);
+const auth = (c: Context, next: () => Promise<void>) =>
+  authRequired(getDB(c))(c, next);
+app.use("/notifications/*", auth);
 
 app.get("/notifications", async (c) => {
   const db = getDB(c);

--- a/app/core/routes/onboarding.ts
+++ b/app/core/routes/onboarding.ts
@@ -1,9 +1,11 @@
-import { Hono } from "hono";
+import { type Context, Hono } from "hono";
 import { getDB } from "../db/mod.ts";
 import { generateKeyPair } from "@takos/crypto";
 import authRequired from "../utils/auth.ts";
 
 const app = new Hono();
+const auth = (c: Context, next: () => Promise<void>) =>
+  authRequired(getDB(c))(c, next);
 
 // 初回オンボーディングの表示可否は「アカウントが存在するか」で判定する
 app.get("/onboarding/status", async (c) => {
@@ -18,46 +20,46 @@ app.get("/onboarding/status", async (c) => {
 // /api/setup POSTエンドポイント
 // オンボーディングは「初回のアカウント作成と初期フォロー設定」を担う用途。
 // すでにログイン済みであることを前提とし、env の生成/更新は行わない。
-app.post("/onboarding", authRequired, async (c) => {
+app.post("/onboarding", auth, async (c) => {
   const db = getDB(c);
   const { username, displayName, follow } = await c.req.json();
 
-    if (!username || typeof username !== "string") {
-      return c.json({ error: "invalid_parameters" }, 400);
-    }
-    const name = String(username).trim();
-    if (!/^[-_a-zA-Z0-9]{3,32}$/.test(name) || name === "system") {
-      return c.json({ error: "invalid_username" }, 400);
-    }
+  if (!username || typeof username !== "string") {
+    return c.json({ error: "invalid_parameters" }, 400);
+  }
+  const name = String(username).trim();
+  if (!/^[-_a-zA-Z0-9]{3,32}$/.test(name) || name === "system") {
+    return c.json({ error: "invalid_username" }, 400);
+  }
 
   // 既存ユーザー名チェック（重複防止）
   const exists = await db.accounts.findByUserName(name);
-    if (exists) {
-      return c.json({ error: "username_exists" }, 409);
-    }
+  if (exists) {
+    return c.json({ error: "username_exists" }, 409);
+  }
 
-    const keys = await generateKeyPair();
-    const account = await db.accounts.create({
-      userName: name,
-      displayName: (displayName && String(displayName).trim()) || name,
-      avatarInitial: name.charAt(0).toUpperCase().substring(0, 2),
-      privateKey: keys.privateKey,
-      publicKey: keys.publicKey,
-      followers: [],
-      following: [],
-    });
+  const keys = await generateKeyPair();
+  const account = await db.accounts.create({
+    userName: name,
+    displayName: (displayName && String(displayName).trim()) || name,
+    avatarInitial: name.charAt(0).toUpperCase().substring(0, 2),
+    privateKey: keys.privateKey,
+    publicKey: keys.publicKey,
+    followers: [],
+    following: [],
+  });
 
-    // 初期フォロー（URL/Acct/ローカル名を許容）
-    // ここでは DB 上の following のみ更新（AP配達は行わない）
-    if (Array.isArray(follow)) {
-      for (const target of follow) {
-        try {
-          await db.accounts.addFollowing(String(account._id), String(target));
-        } catch (_e) {
-          // 個別のフォロー失敗は握りつぶす（セットアップ全体は継続）
-        }
+  // 初期フォロー（URL/Acct/ローカル名を許容）
+  // ここでは DB 上の following のみ更新（AP配達は行わない）
+  if (Array.isArray(follow)) {
+    for (const target of follow) {
+      try {
+        await db.accounts.addFollowing(String(account._id), String(target));
+      } catch (_e) {
+        // 個別のフォロー失敗は握りつぶす（セットアップ全体は継続）
       }
     }
+  }
 
   return c.json({ success: true });
 });

--- a/app/core/services/accounts.ts
+++ b/app/core/services/accounts.ts
@@ -1,0 +1,49 @@
+import type { DataStore } from "../db/types.ts";
+import type { AccountDoc } from "@takos/types";
+
+/** アカウント一覧を取得し、system アカウントを除外します */
+export async function listAccounts(db: DataStore): Promise<AccountDoc[]> {
+  const list = await db.accounts.list();
+  return list.filter((doc) => doc.userName !== "system");
+}
+
+/** ユーザー名でアカウントを検索します */
+export function findAccountByUserName(
+  db: DataStore,
+  userName: string,
+): Promise<AccountDoc | null> {
+  return db.accounts.findByUserName(userName);
+}
+
+/** アカウントを作成します */
+export function createAccount(
+  db: DataStore,
+  data: Record<string, unknown>,
+): Promise<AccountDoc> {
+  return db.accounts.create(data);
+}
+
+/** ID でアカウントを取得します */
+export function findAccountById(
+  db: DataStore,
+  id: string,
+): Promise<AccountDoc | null> {
+  return db.accounts.findById(id);
+}
+
+/** ID でアカウントを更新します */
+export function updateAccountById(
+  db: DataStore,
+  id: string,
+  update: Record<string, unknown>,
+): Promise<AccountDoc | null> {
+  return db.accounts.updateById(id, update);
+}
+
+/** ID でアカウントを削除します */
+export function deleteAccountById(
+  db: DataStore,
+  id: string,
+): Promise<boolean> {
+  return db.accounts.deleteById(id);
+}

--- a/app/core/services/fcm.ts
+++ b/app/core/services/fcm.ts
@@ -1,4 +1,3 @@
-import { createDB } from "../db/mod.ts";
 import type { DataStore } from "../db/types.ts";
 import { pemToArrayBuffer } from "@takos/crypto";
 import { bufToB64 } from "@takos/buffer";
@@ -80,33 +79,28 @@ async function getAccessToken(
 }
 
 export async function registerToken(
+  db: DataStore,
   token: string,
   userName: string,
-  env: Record<string, string>,
-  dbInst?: DataStore,
-) {
-  const db = dbInst ?? createDB(env);
+): Promise<void> {
   await db.fcm.register(token, userName);
 }
 
 export async function unregisterToken(
+  db: DataStore,
   token: string,
-  env: Record<string, string>,
-  dbInst?: DataStore,
-) {
-  const db = dbInst ?? createDB(env);
+): Promise<void> {
   await db.fcm.unregister(token);
 }
 
 export async function sendNotification(
+  db: DataStore,
   title: string,
   body: string,
   env: Record<string, string>,
-  dbInst?: DataStore,
-) {
+): Promise<void> {
   const accessToken = await getAccessToken(env);
   if (!accessToken) return;
-  const db = dbInst ?? createDB(env);
   const list = await db.fcm.list();
   const projectId = env["FIREBASE_PROJECT_ID"];
   const url =

--- a/app/core/services/follow-info.ts
+++ b/app/core/services/follow-info.ts
@@ -1,4 +1,3 @@
-import { createDB } from "../db/mod.ts";
 import type { DataStore } from "../db/types.ts";
 
 /**
@@ -15,12 +14,10 @@ export class UserNotFoundError extends Error {
  * 指定したユーザーのフォロー/フォロワー一覧を取得
  */
 export async function getFollowList(
+  db: DataStore,
   username: string,
   type: "followers" | "following",
-  env: Record<string, string>,
-  dbInst?: DataStore,
 ): Promise<string[]> {
-  const db = dbInst ?? createDB(env);
   const account = await db.accounts.findByUserName(username);
   if (!account) {
     throw new UserNotFoundError();
@@ -39,12 +36,10 @@ export interface FollowInfo {
  * URL のリストをローカル向けオブジェクト配列へ変換
  */
 export async function formatFollowList(
+  db: DataStore,
   list: string[],
   domain: string,
-  env: Record<string, string>,
-  dbInst?: DataStore,
 ): Promise<FollowInfo[]> {
-  const db = dbInst ?? createDB(env);
   const result: FollowInfo[] = [];
   for (const url of list) {
     try {
@@ -80,28 +75,26 @@ export async function formatFollowList(
  * API 用フォロー情報取得
  */
 export async function getFormattedFollowInfo(
+  db: DataStore,
   username: string,
   type: "followers" | "following",
   domain: string,
-  env: Record<string, string>,
-  dbInst?: DataStore,
 ): Promise<FollowInfo[]> {
-  const list = await getFollowList(username, type, env, dbInst);
-  return await formatFollowList(list, domain, env, dbInst);
+  const list = await getFollowList(db, username, type);
+  return await formatFollowList(db, list, domain);
 }
 
 /**
  * ActivityPub 用フォロー情報生成
  */
 export async function buildActivityPubFollowCollection(
+  db: DataStore,
   username: string,
   type: "followers" | "following",
   page: string | undefined,
   domain: string,
-  env: Record<string, string>,
-  dbInst?: DataStore,
 ): Promise<Record<string, unknown>> {
-  const list = await getFollowList(username, type, env, dbInst);
+  const list = await getFollowList(db, username, type);
   const baseId = `https://${domain}/ap/users/${username}/${type}`;
   if (page) {
     return {

--- a/app/core/services/follow.ts
+++ b/app/core/services/follow.ts
@@ -1,0 +1,96 @@
+import {
+  createAcceptActivity,
+  createFollowActivity,
+  createUndoFollowActivity,
+  deliverActivityPubObject,
+} from "../utils/activitypub.ts";
+import { addNotification } from "./notification.ts";
+import type { DataStore } from "../db/types.ts";
+import type { AccountDoc } from "@takos/types";
+
+/** フォロー/フォロー解除処理を行います */
+export async function processFollow(
+  db: DataStore,
+  env: Record<string, string>,
+  domain: string,
+  followerUrl: string,
+  targetUrl: string,
+  remove: boolean,
+): Promise<string[]> {
+  const followerInfo = new URL(followerUrl);
+  const isLocalFollower = followerInfo.hostname === domain;
+  let account: AccountDoc | null = null;
+  if (isLocalFollower) {
+    const followerName = followerInfo.pathname.split("/")[2];
+    account = await db.accounts.findByUserName(followerName);
+    if (!account) return [];
+  }
+
+  const following = account
+    ? (remove
+      ? await db.accounts.removeFollowing(String(account._id), targetUrl)
+      : await db.accounts.addFollowing(String(account._id), targetUrl))
+    : [];
+
+  try {
+    const actorId = account
+      ? `https://${domain}/users/${account.userName}`
+      : followerUrl;
+    const url = new URL(targetUrl);
+    if (url.hostname === domain && url.pathname.startsWith("/users/")) {
+      const name = url.pathname.split("/")[2];
+      if (remove) {
+        await db.accounts.removeFollowerByName(name, actorId);
+      } else {
+        await db.accounts.addFollowerByName(name, actorId);
+      }
+      if (account) {
+        if (!remove) {
+          await addNotification(
+            db,
+            name,
+            "新しいフォロー",
+            `${account.userName}さんが${name}さんをフォローしました`,
+            "info",
+            env,
+          );
+        }
+      } else if (!remove) {
+        const accept = createAcceptActivity(
+          domain,
+          `https://${domain}/users/${name}`,
+          createFollowActivity(domain, actorId, targetUrl),
+        );
+        deliverActivityPubObject(
+          [followerUrl],
+          accept,
+          name,
+          domain,
+          db,
+        ).catch((err) => console.error("Delivery failed:", err));
+      }
+    } else if (account) {
+      const activity = remove
+        ? createUndoFollowActivity(domain, actorId, targetUrl)
+        : createFollowActivity(domain, actorId, targetUrl);
+      deliverActivityPubObject(
+        [targetUrl],
+        activity,
+        account.userName,
+        domain,
+        db,
+      ).catch((err) => console.error("Delivery failed:", err));
+      if (remove) {
+        if (db.posts.unfollow) {
+          await db.posts.unfollow(account.userName, targetUrl);
+        }
+      } else {
+        await db.posts.follow(account.userName, targetUrl);
+      }
+    }
+  } catch (err) {
+    console.error("Follow operation failed:", err);
+  }
+
+  return following;
+}

--- a/app/core/services/groups.ts
+++ b/app/core/services/groups.ts
@@ -1,0 +1,89 @@
+import type { DataStore } from "../db/types.ts";
+import type { ListedGroup } from "@takos/types";
+
+/** 指定ユーザーが所属するグループ一覧を取得します */
+export function listGroups(
+  db: DataStore,
+  member: string,
+): Promise<ListedGroup[]> {
+  return db.groups.list(member);
+}
+
+interface MessageOpts {
+  limit?: number;
+  before?: Date;
+  after?: Date;
+}
+
+/** グループのメッセージ一覧を取得します */
+export async function listGroupMessages(
+  db: DataStore,
+  groupId: string,
+  opts: MessageOpts,
+): Promise<Record<string, unknown>[]> {
+  let msgs = await db.posts.findMessages({ "aud.to": groupId }) as {
+    _id?: string;
+    actor_id?: string;
+    attributedTo?: string;
+    content?: string;
+    extra?: Record<string, unknown>;
+    url?: string;
+    mediaType?: string;
+    published?: Date;
+  }[];
+  if (opts.before) {
+    const b = opts.before;
+    msgs = msgs.filter((m) =>
+      new Date(String(m.published)).getTime() < b.getTime()
+    );
+  }
+  if (opts.after) {
+    const a = opts.after;
+    msgs = msgs.filter((m) =>
+      new Date(String(m.published)).getTime() > a.getTime()
+    );
+  }
+  msgs.sort((a, b) =>
+    new Date(String(a.published)).getTime() -
+    new Date(String(b.published)).getTime()
+  );
+  if (opts.limit && msgs.length > opts.limit) {
+    msgs = msgs.slice(msgs.length - opts.limit);
+  }
+  return msgs.map((m) => ({
+    id: m._id ?? "",
+    from: m.actor_id ?? m.attributedTo ?? "",
+    to: groupId,
+    type: typeof m.extra?.type === "string" ? m.extra.type as string : "note",
+    content: typeof m.content === "string" ? m.content : "",
+    attachments: Array.isArray(m.extra?.attachments)
+      ? m.extra.attachments as Record<string, unknown>[]
+      : undefined,
+    url: typeof m.url === "string" ? m.url : undefined,
+    mediaType: typeof m.mediaType === "string" ? m.mediaType : undefined,
+    key: typeof m.extra?.key === "string" ? m.extra.key as string : undefined,
+    iv: typeof m.extra?.iv === "string" ? m.extra.iv as string : undefined,
+    preview: (m.extra?.preview && typeof m.extra.preview === "object")
+      ? m.extra.preview as Record<string, unknown>
+      : undefined,
+    createdAt: m.published ?? new Date(),
+  }));
+}
+
+/** グループ宛メッセージを保存します */
+export function saveGroupMessage(
+  db: DataStore,
+  domain: string,
+  fromUser: string,
+  content: string,
+  extra: Record<string, unknown>,
+  groupId: string,
+): Promise<{ _id?: string; published?: Date }> {
+  return db.posts.saveMessage(
+    domain,
+    `https://${domain}/users/${fromUser}`,
+    content,
+    extra,
+    { to: [groupId], cc: [] },
+  ) as Promise<{ _id?: string; published?: Date }>;
+}

--- a/app/core/services/notification.ts
+++ b/app/core/services/notification.ts
@@ -1,4 +1,3 @@
-import { createDB } from "../db/mod.ts";
 import type { DataStore } from "../db/types.ts";
 import { sendNotification as sendFcm } from "./fcm.ts";
 
@@ -6,15 +5,14 @@ import { sendNotification as sendFcm } from "./fcm.ts";
  * 通知を追加するユーティリティ関数
  */
 export async function addNotification(
+  db: DataStore,
   owner: string,
   title: string,
   message: string,
   type: string = "info",
   env: Record<string, string>,
-  dbInst?: DataStore,
-) {
-  const db = dbInst ?? createDB(env);
+): Promise<boolean> {
   await db.notifications.create(owner, title, message, type);
-  await sendFcm(title, message, env, db);
+  await sendFcm(db, title, message, env);
   return true;
 }

--- a/app/core/services/posts.ts
+++ b/app/core/services/posts.ts
@@ -82,7 +82,7 @@ export async function notifyFollowers(
   parentId?: string,
   objectId?: string,
 ): Promise<void> {
-  deliverToFollowers(env, author, createActivity, domain);
+  deliverToFollowers(db, author, createActivity, domain);
   if (parentId) {
     const parent = await findPost(db, parentId);
     if (
@@ -95,7 +95,7 @@ export async function notifyFollowers(
         createActivity,
         author,
         domain,
-        env,
+        db,
       );
     } else if (
       parent &&
@@ -108,6 +108,7 @@ export async function notifyFollowers(
           localName && localName !== author && isLocalActor(url.href, domain)
         ) {
           await addNotification(
+            db,
             localName,
             "新しい返信",
             `${author}さんが${localName}さんの投稿に返信しました`,
@@ -158,7 +159,7 @@ export async function announceToFasp(
 ): Promise<void> {
   if (objectId && faspShare !== false) {
     const objectUrl = `https://${domain}/objects/${objectId}`;
-    await announceIfPublicAndDiscoverable(env, domain, {
+    await announceIfPublicAndDiscoverable(db, env, domain, {
       category: "content",
       eventType: "new",
       objectUris: [objectUrl],

--- a/app/core/services/user-info.ts
+++ b/app/core/services/user-info.ts
@@ -1,4 +1,4 @@
-import { createDB } from "../db/mod.ts";
+import type { DataStore } from "../db/types.ts";
 import { resolveActorFromAcct } from "../utils/activitypub.ts";
 
 export interface UserInfo {
@@ -17,16 +17,14 @@ export interface UserInfoCache {
  * 単一のユーザー情報を取得する
  */
 export async function getUserInfo(
+  db: DataStore,
   acct: string,
   domain: string,
-  env: Record<string, string>,
   cache?: UserInfoCache,
 ): Promise<UserInfo> {
   if (cache && cache[acct]) {
     return cache[acct];
   }
-
-  const db = createDB(env);
   const [userName, userDomain] = acct.split("@");
   let displayName = userName;
   let authorAvatar = "";
@@ -79,13 +77,12 @@ export async function getUserInfo(
  * 複数のユーザー情報をバッチで取得する
  */
 export async function getUserInfoBatch(
+  db: DataStore,
   accts: string[],
   domain: string,
-  env: Record<string, string>,
 ): Promise<UserInfo[]> {
   const cache: UserInfoCache = {};
   const results: UserInfo[] = [];
-  const db = createDB(env);
 
   const uniqueAccts = [...new Set(accts)];
   const localNames = uniqueAccts
@@ -108,7 +105,7 @@ export async function getUserInfoBatch(
 
   for (const acct of uniqueAccts) {
     if (!cache[acct]) {
-      const info = await getUserInfo(acct, domain, env, cache);
+      const info = await getUserInfo(db, acct, domain, cache);
       cache[acct] = info;
     }
   }

--- a/app/core/utils/auth.ts
+++ b/app/core/utils/auth.ts
@@ -1,27 +1,20 @@
 import type { MiddlewareHandler } from "hono";
-import { createDB } from "../db/mod.ts";
-import { getEnv } from "@takos/config";
 import { createAuthMiddleware } from "@takos/auth";
 import type { SessionDoc } from "@takos/types";
+import type { DataStore } from "../db/types.ts";
 
-const authRequired: MiddlewareHandler = createAuthMiddleware<SessionDoc>({
-  cookieName: "sessionId",
-  errorMessage: "認証が必要です",
-  findSession: async (sid, c) => {
-    const env = getEnv(c);
-    const db = createDB(env);
-    return await db.sessions.findById(sid);
-  },
-  deleteSession: async (sid, c) => {
-    const env = getEnv(c);
-    const db = createDB(env);
-    await db.sessions.deleteById(sid);
-  },
-  updateSession: async (session, expires, c) => {
-    const env = getEnv(c);
-    const db = createDB(env);
-    await db.sessions.updateExpires(session.sessionId, expires);
-  },
-});
-
-export default authRequired;
+export default function authRequired(db: DataStore): MiddlewareHandler {
+  return createAuthMiddleware<SessionDoc>({
+    cookieName: "sessionId",
+    errorMessage: "認証が必要です",
+    findSession: async (sid) => {
+      return await db.sessions.findById(sid);
+    },
+    deleteSession: async (sid) => {
+      await db.sessions.deleteById(sid);
+    },
+    updateSession: async (session, expires) => {
+      await db.sessions.updateExpires(session.sessionId, expires);
+    },
+  });
+}

--- a/app/core/utils/deliver.ts
+++ b/app/core/utils/deliver.ts
@@ -1,13 +1,12 @@
-import { createDB } from "../db/mod.ts";
 import { deliverActivityPubObject } from "./activitypub.ts";
+import type { DataStore } from "../db/types.ts";
 
 export async function deliverToFollowers(
-  env: Record<string, string>,
+  db: DataStore,
   user: string,
   activity: unknown,
   domain: string,
 ): Promise<void> {
-  const db = createDB(env);
   const account = await db.accounts.findByUserName(user);
   if (!account || !account.followers) return;
 
@@ -21,7 +20,7 @@ export async function deliverToFollowers(
   });
 
   if (targets.length > 0) {
-    deliverActivityPubObject(targets, activity, user, domain, env).catch(
+    deliverActivityPubObject(targets, activity, user, domain, db).catch(
       (err) => {
         console.error("Delivery failed:", err);
       },

--- a/app/core/utils/oauth_callback.ts
+++ b/app/core/utils/oauth_callback.ts
@@ -1,6 +1,7 @@
 import type { Context, MiddlewareHandler } from "hono";
 import { deleteCookie, getCookie } from "hono/cookie";
 import { issueSession } from "./session.ts";
+import { getDB } from "../db/mod.ts";
 
 export interface OAuthCallbackDeps {
   getCookie: typeof getCookie;
@@ -65,7 +66,7 @@ export function createHandleOAuthCallback(
       if (!verifyRes.ok) return await next();
       const v = await verifyRes.json();
       if (!v.active) return await next();
-      await deps.issueSession(c);
+      await deps.issueSession(c, getDB(c));
       return c.redirect("/");
     } catch (_e) {
       await next();

--- a/app/core/utils/session.ts
+++ b/app/core/utils/session.ts
@@ -1,13 +1,13 @@
 import { setCookie } from "hono/cookie";
 import type { Context } from "hono";
-import { createDB } from "../db/mod.ts";
-import { getEnv } from "@takos/config";
+import type { DataStore } from "../db/types.ts";
 
-export async function issueSession(c: Context): Promise<void> {
-  const env = getEnv(c);
+export async function issueSession(
+  c: Context,
+  db: DataStore,
+): Promise<void> {
   const sessionId = crypto.randomUUID();
   const expiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
-  const db = createDB(env);
   const deviceId = crypto.randomUUID();
   await db.sessions.create(sessionId, expiresAt, deviceId);
   setCookie(c, "sessionId", sessionId, {

--- a/app/takos/db/mongo.ts
+++ b/app/takos/db/mongo.ts
@@ -2,7 +2,10 @@ import Note from "../models/takos/note.ts";
 import Message from "../models/takos/message.ts";
 import Attachment from "../models/takos/attachment.ts";
 import FollowEdge from "../models/takos/follow_edge.ts";
-import { createObjectId, resolveRemoteActor } from "../../core/utils/activitypub.ts";
+import {
+  createObjectId,
+  resolveRemoteActor,
+} from "../../core/utils/activitypub.ts";
 import Account from "../models/takos/account.ts";
 import Notification from "../models/takos/notification.ts";
 import SystemKey from "../models/takos/system_key.ts";
@@ -140,12 +143,14 @@ export class MongoDB {
   /** Attachment を作成します。 */
   private async createAttachment(obj: Record<string, unknown>) {
     const data = this.normalizeObject(obj);
-    const doc = this.attachEnv(new Attachment({
-      _id: data._id,
-      attributedTo: String(data.attributedTo),
-      actor_id: String(data.actor_id),
-      extra: data.extra ?? {},
-    }));
+    const doc = this.attachEnv(
+      new Attachment({
+        _id: data._id,
+        attributedTo: String(data.attributedTo),
+        actor_id: String(data.actor_id),
+        extra: data.extra ?? {},
+      }),
+    );
     await doc.save();
     return doc.toObject();
   }
@@ -153,15 +158,17 @@ export class MongoDB {
   /** Note を作成します。 */
   private async createNote(obj: Record<string, unknown>) {
     const data = this.normalizeObject(obj);
-    const doc = this.attachEnv(new Note({
-      _id: data._id,
-      attributedTo: String(data.attributedTo),
-      actor_id: String(data.actor_id),
-      content: String(data.content ?? ""),
-      extra: data.extra ?? {},
-      published: data.published ?? new Date(),
-      aud: data.aud ?? { to: [], cc: [] },
-    }));
+    const doc = this.attachEnv(
+      new Note({
+        _id: data._id,
+        attributedTo: String(data.attributedTo),
+        actor_id: String(data.actor_id),
+        content: String(data.content ?? ""),
+        extra: data.extra ?? {},
+        published: data.published ?? new Date(),
+        aud: data.aud ?? { to: [], cc: [] },
+      }),
+    );
     await doc.save();
     return doc.toObject();
   }
@@ -175,21 +182,23 @@ export class MongoDB {
       throw new Error(`unsupported object type: ${objectType}`);
     }
     const url = typeof data.url === "string" ? data.url : "";
-    const doc = this.attachEnv(new Message({
-      _id: data._id,
-      type: objectType,
-      attributedTo: String(data.attributedTo),
-      actor_id: String(data.actor_id),
-      content: String(data.content ?? ""),
-      url,
-      mediaType: typeof data.mediaType === "string"
-        ? data.mediaType
-        : undefined,
-      name: typeof data.name === "string" ? data.name : undefined,
-      extra: data.extra ?? {},
-      published: data.published ?? new Date(),
-      aud: data.aud ?? { to: [], cc: [] },
-    }));
+    const doc = this.attachEnv(
+      new Message({
+        _id: data._id,
+        type: objectType,
+        attributedTo: String(data.attributedTo),
+        actor_id: String(data.actor_id),
+        content: String(data.content ?? ""),
+        url,
+        mediaType: typeof data.mediaType === "string"
+          ? data.mediaType
+          : undefined,
+        name: typeof data.name === "string" ? data.name : undefined,
+        extra: data.extra ?? {},
+        published: data.published ?? new Date(),
+        aud: data.aud ?? { to: [], cc: [] },
+      }),
+    );
     await doc.save();
     return doc.toObject();
   }
@@ -248,9 +257,11 @@ export class MongoDB {
   }
 
   async createAccount(data: Record<string, unknown>): Promise<AccountDoc> {
-    const doc = this.attachEnv(new Account({
-      ...data,
-    }));
+    const doc = this.attachEnv(
+      new Account({
+        ...data,
+      }),
+    );
     await doc.save();
     return doc.toObject() as AccountDoc;
   }
@@ -270,7 +281,9 @@ export class MongoDB {
     id: string,
     update: Record<string, unknown>,
   ): Promise<AccountDoc | null> {
-    return await this.withEnv(Account.findOneAndUpdate({ _id: id }, update, { new: true }))
+    return await this.withEnv(
+      Account.findOneAndUpdate({ _id: id }, update, { new: true }),
+    )
       .lean<AccountDoc | null>();
   }
 
@@ -324,18 +337,20 @@ export class MongoDB {
   ) {
     const id = createObjectId(domain);
     const actor = normalizeActorUrl(author, domain);
-    const doc = this.attachEnv(new Note({
-      _id: id,
-      attributedTo: actor,
-      actor_id: actor,
-      content,
-      extra,
-      published: new Date(),
-      aud: aud ?? {
-        to: ["https://www.w3.org/ns/activitystreams#Public"],
-        cc: [],
-      },
-    }));
+    const doc = this.attachEnv(
+      new Note({
+        _id: id,
+        attributedTo: actor,
+        actor_id: actor,
+        content,
+        extra,
+        published: new Date(),
+        aud: aud ?? {
+          to: ["https://www.w3.org/ns/activitystreams#Public"],
+          cc: [],
+        },
+      }),
+    );
     await doc.save();
     return doc.toObject();
   }
@@ -508,10 +523,14 @@ export class MongoDB {
   }
 
   async updateObject(id: string, update: Record<string, unknown>) {
-    let doc = await this.withEnv(Note.findOneAndUpdate({ _id: id }, update, { new: true }))
+    let doc = await this.withEnv(
+      Note.findOneAndUpdate({ _id: id }, update, { new: true }),
+    )
       .lean();
     if (doc) return doc;
-    doc = await this.withEnv(Message.findOneAndUpdate({ _id: id }, update, { new: true }))
+    doc = await this.withEnv(
+      Message.findOneAndUpdate({ _id: id }, update, { new: true }),
+    )
       .lean();
     if (doc) return doc;
     return null;
@@ -612,14 +631,24 @@ export class MongoDB {
   }
 
   async deleteDirectMessage(owner: string, id: string) {
-    const res = await this.withEnv(DirectMessage.findOneAndDelete({ owner, id }))
+    const res = await this.withEnv(
+      DirectMessage.findOneAndDelete({ owner, id }),
+    )
       .lean<DirectMessageDoc | null>();
     return res != null;
   }
 
   async listGroups(member: string): Promise<ListedGroup[]> {
     const acc = await Account.findOne({ userName: member })
-      .lean<{ groups?: string[]; groupOverrides?: Record<string, { displayName?: string; icon?: unknown }> } | null>();
+      .lean<
+        {
+          groups?: string[];
+          groupOverrides?: Record<
+            string,
+            { displayName?: string; icon?: unknown }
+          >;
+        } | null
+      >();
     if (!acc) return [];
     const groups = acc.groups ?? [];
     const domain = this.env["ACTIVITYPUB_DOMAIN"];
@@ -649,7 +678,7 @@ export class MongoDB {
       // Resolve remote actors and upsert them
       for (const id of remoteIds) {
         try {
-          const remoteActor = await resolveRemoteActor(id, this.env);
+          const remoteActor = await resolveRemoteActor(id);
           await this.upsertRemoteActor({
             actorUrl: remoteActor.id,
             name: remoteActor.name || "",
@@ -678,7 +707,11 @@ export class MongoDB {
           const followersUrl = typeof actor.followers === "string"
             ? actor.followers
             : (() => {
-              try { return new URL("followers", actorUrl).href; } catch { return ""; }
+              try {
+                return new URL("followers", actorUrl).href;
+              } catch {
+                return "";
+              }
             })();
           if (!followersUrl) return [];
           const fRes = await fetch(followersUrl, {
@@ -689,24 +722,47 @@ export class MongoDB {
           });
           if (!fRes.ok) return [];
           const col = await fRes.json() as
-            | { orderedItems?: unknown[]; items?: unknown[]; first?: string | { orderedItems?: unknown[]; items?: unknown[] } }
+            | {
+              orderedItems?: unknown[];
+              items?: unknown[];
+              first?: string | { orderedItems?: unknown[]; items?: unknown[] };
+            }
             | undefined;
-          const toStrs = (arr?: unknown[]) => (Array.isArray(arr) ? arr : [])
-            .map((v) => (typeof v === "string" ? v : (v && typeof v === "object" && typeof (v as { id?: unknown }).id === "string") ? (v as { id: string }).id : ""))
-            .filter((s): s is string => !!s);
+          const toStrs = (arr?: unknown[]) =>
+            (Array.isArray(arr) ? arr : [])
+              .map((
+                v,
+              ) => (typeof v === "string" ? v : (v && typeof v === "object" &&
+                  typeof (v as { id?: unknown }).id === "string")
+                ? (v as { id: string }).id
+                : "")
+              )
+              .filter((s): s is string => !!s);
           let items: string[] = [];
           if (col) {
             items = toStrs(col.orderedItems ?? col.items);
             if (items.length === 0 && col.first) {
               try {
-                const firstUrl = typeof col.first === "string" ? col.first : undefined;
-                const firstObj = typeof col.first === "object" ? col.first as { orderedItems?: unknown[]; items?: unknown[] } : undefined;
+                const firstUrl = typeof col.first === "string"
+                  ? col.first
+                  : undefined;
+                const firstObj = typeof col.first === "object"
+                  ? col.first as { orderedItems?: unknown[]; items?: unknown[] }
+                  : undefined;
                 if (firstObj) {
                   items = toStrs(firstObj.orderedItems ?? firstObj.items);
                 } else if (firstUrl) {
-                  const pRes = await fetch(firstUrl, { headers: { Accept: 'application/activity+json, application/ld+json; profile="https://www.w3.org/ns/activitystreams"' } });
+                  const pRes = await fetch(firstUrl, {
+                    headers: {
+                      Accept:
+                        'application/activity+json, application/ld+json; profile="https://www.w3.org/ns/activitystreams"',
+                    },
+                  });
                   if (pRes.ok) {
-                    const page = await pRes.json() as { orderedItems?: unknown[]; items?: unknown[] };
+                    const page = await pRes.json() as {
+                      orderedItems?: unknown[];
+                      items?: unknown[];
+                    };
                     items = toStrs(page.orderedItems ?? page.items);
                   }
                 }
@@ -743,7 +799,8 @@ export class MongoDB {
         const ov = acc?.groupOverrides?.[id];
         res.push({
           id,
-          name: (ov?.displayName && String(ov.displayName)) || r.preferredUsername || r.name || r.actorUrl,
+          name: (ov?.displayName && String(ov.displayName)) ||
+            r.preferredUsername || r.name || r.actorUrl,
           icon: typeof ov?.icon === "string" ? ov.icon : icon,
           members: followersMap.get(r.actorUrl) ?? [],
         });
@@ -752,7 +809,12 @@ export class MongoDB {
         if (!found.has(id)) {
           // followers は未取得
           const ov = acc?.groupOverrides?.[id];
-          res.push({ id, name: (ov?.displayName && String(ov.displayName)) || id, icon: typeof ov?.icon === "string" ? ov.icon : undefined, members: [] });
+          res.push({
+            id,
+            name: (ov?.displayName && String(ov.displayName)) || id,
+            icon: typeof ov?.icon === "string" ? ov.icon : undefined,
+            members: [],
+          });
         }
       }
     }
@@ -779,9 +841,11 @@ export class MongoDB {
   }
 
   async updateGroupByName(name: string, update: Record<string, unknown>) {
-    return await this.withEnv(Group.findOneAndUpdate({ groupName: name }, update, {
-      new: true,
-    }))
+    return await this.withEnv(
+      Group.findOneAndUpdate({ groupName: name }, update, {
+        new: true,
+      }),
+    )
       .lean<GroupDoc | null>();
   }
 
@@ -841,7 +905,9 @@ export class MongoDB {
     message: string,
     type: string,
   ) {
-    const doc = this.attachEnv(new Notification({ owner, title, message, type }));
+    const doc = this.attachEnv(
+      new Notification({ owner, title, message, type }),
+    );
     await doc.save();
     return doc.toObject();
   }
@@ -917,14 +983,18 @@ export class MongoDB {
     privateKey: string,
     publicKey: string,
   ) {
-    const doc = this.attachEnv(new SystemKey({ domain, privateKey, publicKey }));
+    const doc = this.attachEnv(
+      new SystemKey({ domain, privateKey, publicKey }),
+    );
     await doc.save();
   }
 
   async registerFcmToken(token: string, userName: string) {
-    await this.withEnv(FcmToken.updateOne({ token }, { $set: { token, userName } }, {
-      upsert: true,
-    }));
+    await this.withEnv(
+      FcmToken.updateOne({ token }, { $set: { token, userName } }, {
+        upsert: true,
+      }),
+    );
   }
 
   async unregisterFcmToken(token: string) {
@@ -946,12 +1016,14 @@ export class MongoDB {
     expiresAt: Date,
     deviceId: string,
   ): Promise<SessionDoc> {
-    const doc = this.attachEnv(new Session({
-      sessionId,
-      deviceId,
-      expiresAt,
-      lastDecryptAt: new Date(),
-    }));
+    const doc = this.attachEnv(
+      new Session({
+        sessionId,
+        deviceId,
+        expiresAt,
+        lastDecryptAt: new Date(),
+      }),
+    );
     await doc.save();
     return doc.toObject() as SessionDoc;
   }
@@ -965,7 +1037,9 @@ export class MongoDB {
   }
 
   async updateSessionExpires(sessionId: string, expires: Date) {
-    await this.withEnv(Session.updateOne({ sessionId }, { expiresAt: expires }));
+    await this.withEnv(
+      Session.updateOne({ sessionId }, { expiresAt: expires }),
+    );
   }
 
   async updateSessionActivity(sessionId: string, date = new Date()) {

--- a/app/takos_host/root_activitypub.ts
+++ b/app/takos_host/root_activitypub.ts
@@ -36,7 +36,7 @@ export function createRootActivityPubApp(env: Record<string, string>) {
       return jsonResponse(c, { error: "Not found" }, 404);
     }
     const db = createDB(env);
-  const account = await db.accounts.findByUserName(username);
+    const account = await db.accounts.findByUserName(username);
     if (!account) {
       return jsonResponse(c, { error: "Not found" }, 404);
     }
@@ -56,7 +56,7 @@ export function createRootActivityPubApp(env: Record<string, string>) {
   app.get("/users/:username", async (c) => {
     const username = c.req.param("username");
     const db = createDB(env);
-  const account = await db.accounts.findByUserName(username);
+    const account = await db.accounts.findByUserName(username);
     if (!account) return jsonResponse(c, { error: "Not found" }, 404);
     const domain = getDomain(c);
     const actor = createActor(domain, {
@@ -70,19 +70,19 @@ export function createRootActivityPubApp(env: Record<string, string>) {
   async function handleInbox(c: Context) {
     const username = c.req.param("username");
     const db = createDB(env);
-  const account = await db.accounts.findByUserName(username);
+    const account = await db.accounts.findByUserName(username);
     if (!account) {
       return jsonResponse(c, { error: "Not found" }, 404);
     }
     const result = await parseActivityRequest(c);
     if (!result) return jsonResponse(c, { error: "Invalid signature" }, 401);
     const { activity } = result;
-    const storedInfo = await storeCreateActivity(activity, env);
+    const storedInfo = await storeCreateActivity(activity, db);
     if (storedInfo) {
       const { stored, actorId } = storedInfo;
       const domain = getDomain(c);
       const handle = iriToHandle(actorId);
-      const userInfo = await getUserInfo(handle, domain, env);
+      const userInfo = await getUserInfo(db, handle, domain);
       const formatted = formatUserInfoForPost(
         userInfo,
         stored,

--- a/app/takos_host/utils/host_context.ts
+++ b/app/takos_host/utils/host_context.ts
@@ -201,10 +201,14 @@ async function seedDefaultFasp(
     await FaspClient.updateOne({ tenant: host }, {
       $set: { tenant: host, secret },
     }, { upsert: true }).catch(() => {});
-    await bootstrapDefaultFasp({
-      ...appEnv,
-      FASP_DEFAULT_BASE_URL: defaultFaspBaseUrl,
-    }, host).catch(() => {});
+    await bootstrapDefaultFasp(
+      {
+        ...appEnv,
+        FASP_DEFAULT_BASE_URL: defaultFaspBaseUrl,
+      },
+      host,
+      tenantDb,
+    ).catch(() => {});
   } catch { /* ignore */ }
 }
 


### PR DESCRIPTION
## 概要
- accounts/follow/groups のサービス層を追加しルートからDB操作を分離
- 各ルートは getDB(c) で取得した DataStore をサービスに渡す構成へ

## テスト
- `deno fmt app/core/services/accounts.ts app/core/services/follow.ts app/core/services/groups.ts app/core/routes/accounts.ts app/core/routes/follow.ts app/core/routes/groups.ts`
- `DENO_TLS_CA_STORE=system deno lint app/core/services/accounts.ts app/core/services/follow.ts app/core/services/groups.ts app/core/routes/accounts.ts app/core/routes/follow.ts app/core/routes/groups.ts` *(npm:mongoose の解決エラー)*

------
https://chatgpt.com/codex/tasks/task_e_68b146ab97908328a62db8387824f144

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新機能
  - DMの新APIを追加: DMルーム一覧取得（GET /dms）と作成（POST /dms）。
- 改善
  - グループ機能を強化：添付ファイルの取り扱い向上、署名検証の強化、フォロワー配信と通知の信頼性アップ。
  - 検索・トレンド・投稿・ユーザー周りの処理を最適化し、応答性と安定性を改善。
  - アカウント管理の一貫性を向上（一覧・作成・更新・削除の動作を整理）。
  - 連合（ActivityPub）配信の安定性・成功率を向上。
  - 認証基盤を刷新し、各APIでの認証の堅牢性を強化。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->