### PR TITLE
FASP ルートで DataStore を使用するよう修正

### DIFF
--- a/app/core/db/types.ts
+++ b/app/core/db/types.ts
@@ -217,7 +217,21 @@ export interface FaspProvidersRepo {
     baseUrl: string,
     update: Record<string, unknown>,
   ): Promise<unknown | null>;
-  deleteOne(filter: Record<string, unknown>): Promise<{ deletedCount?: number }>;
+  deleteOne(
+    filter: Record<string, unknown>,
+  ): Promise<{ deletedCount?: number }>;
+  registrationUpsert(data: {
+    name: string;
+    baseUrl: string;
+    serverId: string;
+    publicKey: string;
+    faspId: string;
+  }): Promise<void>;
+  listProviders(): Promise<unknown[]>;
+  insertEventSubscription(id: string, payload: unknown): Promise<void>;
+  deleteEventSubscription(id: string): Promise<void>;
+  createBackfill(id: string, payload: unknown): Promise<void>;
+  continueBackfill(id: string): Promise<void>;
 }
 
 export interface DataStore {


### PR DESCRIPTION
## 概要
- FASP ルートが直接の fasp_client 呼び出しではなく DataStore を利用するよう変更
- FaspProvidersRepo に登録・サブスクリプション・バックフィル関連メソッドを追加
- MongoDB 実装に対応メソッドを実装

## テスト
- `deno fmt app/core/routes/fasp.ts app/core/db/types.ts app/takos/db/mongo_store.ts app/takos_host/db/mongo_store.ts`
- `deno lint app/core/routes/fasp.ts app/core/db/types.ts app/takos/db/mongo_store.ts app/takos_host/db/mongo_store.ts` *(JSR パッケージの取得に失敗)*

------
https://chatgpt.com/codex/tasks/task_e_68b1572c4cb08328afa0e5d40e6ef4d8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新機能
  - プロバイダー登録のアップサートに対応し、管理画面で一覧表示が可能に
  - イベント購読の追加・削除、バックフィルの作成・再開をサポート
  - テナント単位でのプロバイダー／購読／バックフィル管理に対応
- 改善
  - バックフィル要求の入力バリデーションを強化し、不正入力時は 422 を返却
  - データ永続化経路を統一し、登録・能力設定・通知処理の信頼性を向上

<!-- end of auto-generated comment: release notes by coderabbit.ai -->