### PR TITLE
Export managed runtime storage adapters

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -26,7 +26,7 @@
     },
     "packages/api": {
       "name": "@takosjp/yurucommu-api",
-      "version": "3.4.0",
+      "version": "3.4.2",
       "devDependencies": {
         "typescript": "^5.7.0",
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@takosjp/yurucommu-core",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "license": "AGPL-3.0-only",
   "type": "module",
   "workspaces": [

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@takosjp/yurucommu-api",
-  "version": "3.4.0",
+  "version": "3.4.2",
   "description": "Typed client SDK and public API contract for yurucommu-server clients.",
   "license": "AGPL-3.0-only",
   "type": "module",

--- a/scripts/check-packed-consumer.mjs
+++ b/scripts/check-packed-consumer.mjs
@@ -71,6 +71,10 @@ import {
   getBrowserNotificationPushState,
   refreshBrowserNotificationPush,
 } from "@takosjp/yurucommu-api";
+import {
+  createManagedRuntimeKeyValueStore,
+  createManagedRuntimeObjectStorage,
+} from "@takosjp/yurucommu-core/server";
 import { applyMigrations } from "@takosjp/yurucommu-core/migrations";
 
 const coreEntry = Bun.resolveSync("@takosjp/yurucommu-core", import.meta.dir);
@@ -81,6 +85,8 @@ if (!existsSync(join(coreRoot, "migrations/0019_notification_push_delivery.sql")
 for (const [name, value] of Object.entries({
   applyMigrations,
   clearBrowserNotificationPush,
+  createManagedRuntimeKeyValueStore,
+  createManagedRuntimeObjectStorage,
   disableBrowserNotificationPush,
   enableBrowserNotificationPush,
   fetchNotificationPusherPublicConfig,

--- a/src/backend/__tests__/public-managed-runtime-exports.test.ts
+++ b/src/backend/__tests__/public-managed-runtime-exports.test.ts
@@ -1,0 +1,25 @@
+import { expect, test } from "bun:test";
+
+import {
+  createManagedRuntimeKeyValueStore,
+  createManagedRuntimeObjectStorage,
+  type IKeyValueStore,
+  type IObjectStorage,
+  type ManagedRuntimeDataAdapterOptions,
+} from "../public.ts";
+import {
+  createManagedRuntimeKeyValueStore as createManagedRuntimeKeyValueStoreDirect,
+  createManagedRuntimeObjectStorage as createManagedRuntimeObjectStorageDirect,
+} from "../runtime/managed-runtime.ts";
+
+test("server public surface exports the managed data adapters and their contracts", () => {
+  const keyValueFactory: (
+    options: ManagedRuntimeDataAdapterOptions,
+  ) => IKeyValueStore = createManagedRuntimeKeyValueStore;
+  const objectStorageFactory: (
+    options: ManagedRuntimeDataAdapterOptions,
+  ) => IObjectStorage = createManagedRuntimeObjectStorage;
+
+  expect(keyValueFactory).toBe(createManagedRuntimeKeyValueStoreDirect);
+  expect(objectStorageFactory).toBe(createManagedRuntimeObjectStorageDirect);
+});

--- a/src/backend/public.ts
+++ b/src/backend/public.ts
@@ -19,7 +19,10 @@ export {
 } from "./runtime/cloudflare.ts";
 export {
   ManagedRuntimeGatewayError,
+  createManagedRuntimeKeyValueStore,
+  createManagedRuntimeObjectStorage,
   createManagedRuntimeQueueProducer,
+  type ManagedRuntimeDataAdapterOptions,
   type ManagedRuntimeGateway,
   type ManagedRuntimeQueueProducerOptions,
 } from "./runtime/managed-runtime.ts";
@@ -27,6 +30,13 @@ export {
   createManagedRelationalDatabase,
   type ManagedRelationalDatabaseOptions,
 } from "./runtime/managed-relational.ts";
+export type {
+  IKeyValueStore,
+  IObjectStorage,
+  ListObjectsResult,
+  ObjectMetadata,
+  StorageObject,
+} from "./runtime/types.ts";
 export type {
   IQueueBatch,
   IQueueMessage,


### PR DESCRIPTION
## What changed

- exports the existing managed KeyValueStore and ObjectStorage adapters from `@takosjp/yurucommu-core/server`
- exports the associated public option and storage types
- verifies the exports from an actual packed consumer
- advances Core and API together to 3.4.2

## Why

The managed Yurucommu deployment must reuse the single Core implementation instead of duplicating provider-neutral runtime adapters in the app repository.

## Validation

- `bun run check` (877 tests passed)
- `bun run check:packed-consumer`
- TypeScript and formatting passed
