### PR TITLE
feat: expose managed retention scheduling

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -26,7 +26,7 @@
     },
     "packages/api": {
       "name": "@takosjp/yurucommu-api",
-      "version": "3.4.2",
+      "version": "3.4.3",
       "devDependencies": {
         "typescript": "^5.7.0",
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@takosjp/yurucommu-core",
-  "version": "3.4.2",
+  "version": "3.4.3",
   "license": "AGPL-3.0-only",
   "type": "module",
   "workspaces": [

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@takosjp/yurucommu-api",
-  "version": "3.4.2",
+  "version": "3.4.3",
   "description": "Typed client SDK and public API contract for yurucommu-server clients.",
   "license": "AGPL-3.0-only",
   "type": "module",

--- a/scripts/check-packed-consumer.mjs
+++ b/scripts/check-packed-consumer.mjs
@@ -74,7 +74,9 @@ import {
 import {
   createManagedRuntimeKeyValueStore,
   createManagedRuntimeObjectStorage,
+  runYurucommuRetention,
 } from "@takosjp/yurucommu-core/server";
+import yurucommuCoreWorker from "@takosjp/yurucommu-core/server";
 import { applyMigrations } from "@takosjp/yurucommu-core/migrations";
 
 const coreEntry = Bun.resolveSync("@takosjp/yurucommu-core", import.meta.dir);
@@ -87,6 +89,7 @@ for (const [name, value] of Object.entries({
   clearBrowserNotificationPush,
   createManagedRuntimeKeyValueStore,
   createManagedRuntimeObjectStorage,
+  runYurucommuRetention,
   disableBrowserNotificationPush,
   enableBrowserNotificationPush,
   fetchNotificationPusherPublicConfig,
@@ -94,6 +97,9 @@ for (const [name, value] of Object.entries({
   refreshBrowserNotificationPush,
 })) {
   if (typeof value !== "function") throw new Error(name + " is not exported");
+}
+if (typeof yurucommuCoreWorker.scheduled !== "function") {
+  throw new Error("core default export has no scheduled retention handler");
 }
 console.log("packed core/API consumer verified");
 `,

--- a/src/backend/__tests__/retention.test.ts
+++ b/src/backend/__tests__/retention.test.ts
@@ -1,0 +1,64 @@
+import { expect, test } from "bun:test";
+import type {
+  ExecutionContext,
+  ScheduledController,
+} from "@cloudflare/workers-types";
+
+import worker, {
+  runYurucommuRetention,
+  YurucommuRetentionError,
+} from "../public.ts";
+import type { Env } from "../types.ts";
+import { createTestDb } from "./helpers/d1-semantics.ts";
+
+test("one bounded retention pass reuses the canonical empty-ledger cleanup paths", async () => {
+  const { db } = await createTestDb();
+
+  await expect(
+    runYurucommuRetention({ DB_INSTANCE: db } as Env),
+  ).resolves.toEqual({
+    expiredStories: 0,
+    reapedTombstones: 0,
+    enqueuedNotificationPushJobs: 0,
+  });
+});
+
+test("retention fails closed when its database authority is missing", async () => {
+  await expect(runYurucommuRetention({} as Env)).rejects.toThrow(
+    "Yurucommu retention requires DB_INSTANCE",
+  );
+});
+
+test("retention reports and rethrows the exact failing step", async () => {
+  const invalidDatabase = {} as Env["DB_INSTANCE"];
+
+  try {
+    await runYurucommuRetention({
+      DB_INSTANCE: invalidDatabase,
+    } as Env);
+    throw new Error("expected retention to reject");
+  } catch (error) {
+    expect(error).toBeInstanceOf(YurucommuRetentionError);
+    expect(error).toMatchObject({
+      name: "YurucommuRetentionError",
+      step: "expired_stories",
+    });
+    expect((error as YurucommuRetentionError).cause).toBeInstanceOf(TypeError);
+  }
+});
+
+test("published Worker default exposes the scheduled retention handler", () => {
+  expect(typeof worker.scheduled).toBe("function");
+});
+
+test("scheduled accepts the materialized runtime used by product wrappers", async () => {
+  const { db } = await createTestDb();
+
+  await expect(
+    worker.scheduled(
+      {} as ScheduledController,
+      { DB_INSTANCE: db } as Env,
+      {} as ExecutionContext,
+    ),
+  ).resolves.toBeUndefined();
+});

--- a/src/backend/index.ts
+++ b/src/backend/index.ts
@@ -56,6 +56,7 @@ import type {
   MessageBatch,
   Queue,
   R2Bucket,
+  ScheduledController,
 } from "@cloudflare/workers-types";
 import type {
   DeliveryDlqMessageV1,
@@ -66,6 +67,7 @@ import {
   handleDeliveryQueueBatch,
 } from "./lib/delivery/queue.ts";
 import { enqueuePendingNotificationPushJobs } from "./lib/notification-push.ts";
+import { runYurucommuRetention } from "./retention.ts";
 
 type YurucommuApp = Hono<{ Bindings: Env; Variables: Variables }>;
 
@@ -994,6 +996,12 @@ type WorkerBindings = EnvVars & {
   REALTIME_STREAM?: DurableObjectNamespace;
 };
 
+function isMaterializedRuntimeEnv(
+  bindings: WorkerBindings | Env,
+): bindings is Env {
+  return "DB_INSTANCE" in bindings && !!bindings.DB_INSTANCE;
+}
+
 export default {
   async fetch(
     request: Request,
@@ -1011,5 +1019,16 @@ export default {
       wrapCloudflareMessageBatch(batch),
       wrapCloudflareBindings(bindings),
     );
+  },
+
+  async scheduled(
+    _controller: ScheduledController,
+    bindings: WorkerBindings | Env,
+    _ctx: ExecutionContext,
+  ): Promise<void> {
+    const env = isMaterializedRuntimeEnv(bindings)
+      ? bindings
+      : wrapCloudflareBindings(bindings);
+    await runYurucommuRetention(env);
   },
 };

--- a/src/backend/public.ts
+++ b/src/backend/public.ts
@@ -9,6 +9,12 @@ export {
   type YurucommuBackendDiscoveryOptionsV1,
   type YurucommuBackendPluginV1,
 } from "./index.ts";
+export {
+  runYurucommuRetention,
+  YurucommuRetentionError,
+  type YurucommuRetentionResult,
+  type YurucommuRetentionStep,
+} from "./retention.ts";
 export { default } from "./index.ts";
 export { default as app } from "./index.ts";
 export { type Database, getDb, getDbSQLite } from "../db/index.ts";

--- a/src/backend/retention.ts
+++ b/src/backend/retention.ts
@@ -1,0 +1,78 @@
+import type { Env } from "./types.ts";
+import { enqueuePendingNotificationPushJobs } from "./lib/notification-push.ts";
+import { reapDrainedTombstones } from "./routes/actors.ts";
+import { cleanupExpiredStories } from "./routes/stories/query-helpers.ts";
+
+export type YurucommuRetentionStep =
+  "expired_stories" | "drained_tombstones" | "notification_push";
+
+export interface YurucommuRetentionResult {
+  readonly expiredStories: number;
+  readonly reapedTombstones: number;
+  readonly enqueuedNotificationPushJobs: number;
+}
+
+/**
+ * Identifies the exact bounded retention step that failed. Scheduled callers
+ * must reject the invocation instead of treating a partial or skipped sweep as
+ * success; the original database/runtime error remains available as `cause`.
+ */
+export class YurucommuRetentionError extends Error {
+  constructor(
+    readonly step: YurucommuRetentionStep,
+    cause: unknown,
+  ) {
+    super(`yurucommu retention failed at ${step}`, { cause });
+    this.name = "YurucommuRetentionError";
+  }
+}
+
+/**
+ * Run one bounded retention pass against the already-materialized runtime.
+ *
+ * This deliberately reuses the same race-safe cleanup paths as request/queue
+ * handling:
+ * - Story expiry uses the canonical object cascade and purges its media last.
+ * - Tombstones remain until every Delete delivery has drained.
+ * - Notification push performs bounded pusher/job retention, stale-job
+ *   recovery, and enqueues due durable outbox rows when a queue is available.
+ *
+ * Steps are awaited sequentially because D1 is the shared authority. Any
+ * failure rejects with its exact step; callers must retry the cron invocation
+ * rather than silently acknowledging incomplete retention.
+ */
+export async function runYurucommuRetention(
+  env: Env,
+): Promise<YurucommuRetentionResult> {
+  if (!env?.DB_INSTANCE) {
+    throw new TypeError("Yurucommu retention requires DB_INSTANCE");
+  }
+
+  const expiredStories = await retentionStep("expired_stories", () =>
+    cleanupExpiredStories(env.DB_INSTANCE, env.MEDIA),
+  );
+  const reapedTombstones = await retentionStep("drained_tombstones", () =>
+    reapDrainedTombstones(env.DB_INSTANCE),
+  );
+  const enqueuedNotificationPushJobs = await retentionStep(
+    "notification_push",
+    () => enqueuePendingNotificationPushJobs(env),
+  );
+
+  return {
+    expiredStories,
+    reapedTombstones,
+    enqueuedNotificationPushJobs,
+  };
+}
+
+async function retentionStep<T>(
+  step: YurucommuRetentionStep,
+  run: () => Promise<T>,
+): Promise<T> {
+  try {
+    return await run();
+  } catch (cause) {
+    throw new YurucommuRetentionError(step, cause);
+  }
+}

--- a/src/backend/routes/actors.ts
+++ b/src/backend/routes/actors.ts
@@ -286,11 +286,11 @@ export async function cancelTombstoneDelete(
   return deleteActivityIds.length;
 }
 
-// Best-effort, opportunistic tombstone reaping on the read path. This Worker
-// has no `scheduled` handler, so (mirroring maybeCleanupExpiredStories) the
-// sweep is triggered probabilistically and guarded so at most one runs per
-// isolate at a time. Tombstones are already excluded from every serving query,
-// so a missed sweep only delays storage/key-material reclamation.
+// Best-effort, opportunistic tombstone reaping on the read path. The public
+// Worker has a scheduled retention handler too; this remains as a fallback for
+// self-hosted runtimes without cron. It is guarded so at most one pass runs per
+// isolate. Tombstones are already excluded from every serving query, so a
+// missed sweep only delays storage/key-material reclamation.
 let tombstoneReapInFlight = false;
 
 export function maybeReapDrainedTombstones(db: Database): void {

--- a/src/backend/routes/stories/routes.ts
+++ b/src/backend/routes/stories/routes.ts
@@ -62,13 +62,11 @@ const stories = new Hono<{ Bindings: Env; Variables: Variables }>();
 
 // Best-effort, opportunistic retention of expired stories.
 //
-// This is NOT a substitute for a scheduled job: this Worker has no `scheduled`
-// handler / cron trigger, so expiry cleanup is triggered probabilistically on
-// the read path. Expired stories are already excluded from every read query
-// (the feed/single-story handlers filter on `endTime`), so the only impact of
-// a missed sweep is storage growth, not stale data leaking to users. The guard
-// below ensures at most one sweep runs at a time per isolate, so a burst of
-// feed requests cannot kick off several concurrent full-table delete sweeps.
+// The public Worker also exposes a scheduled retention handler. Keep this
+// probabilistic read-path pass as a self-hosting fallback for runtimes that do
+// not configure a cron trigger. Expired stories are already excluded from every
+// read query, so a missed sweep affects storage only. The guard below ensures
+// at most one fallback pass runs at a time per isolate.
 let expiredStoryCleanupInFlight = false;
 
 function maybeCleanupExpiredStories(


### PR DESCRIPTION
## Summary
- expose runtime-neutral retention execution for managed hosts
- wire the default Worker scheduled handler
- validate the packed public surface and fail-closed sequencing

## Verification
- bun run check (882 tests)
- packed consumer check
- format and diff checks