### PR TITLE
Run on Takoserver's portable binding facades

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -87,6 +87,9 @@ Takos core. See [`AGENTS.md`](AGENTS.md) for the full product boundary.
 
 ## Documentation
 
+- [Runtime lanes](docs/design/runtime-lanes.md) — how the bindings differ between
+  a direct Cloudflare deployment and a Takoserver-hosted (Takoform) one, and how
+  a deployment declares which it is
 - [Deployment guide](https://yurucommu.com/help/deployment.html)
 - [Getting started](https://yurucommu.com/help/getting-started.html)
 - [Help site](https://yurucommu.com/help/)

--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ Yurucommu は ActivityPub 連合・コンテンツ配送・ユーザー identity
 
 ## ドキュメント
 
+- [Runtime lanes](docs/design/runtime-lanes.md) — Cloudflare 直 deploy と
+  Takoserver-hosted (Takoform) で binding の形が変わる点と、その宣言方法
 - [Deployment guide](https://yurucommu.com/help/deployment.html)
 - [Getting started](https://yurucommu.com/help/getting-started.html)
 - [Help site](https://yurucommu.com/help/)

--- a/docs/design/runtime-lanes.md
+++ b/docs/design/runtime-lanes.md
@@ -65,8 +65,17 @@ export default {
 };
 ```
 
+core の published Worker default export (`@takosjp/yurucommu-core/server` の
+`default`) は既に lane-aware です。自前の entry を持たない product は、そのまま
+re-export すれば両 lane で動きます。
+
 `wrapCloudflareBindings` / `wrapCloudflareMessageBatch` はこれまで通り残ります。
 native binding だけを渡すと分かっている entry はそちらを直接呼んでも構いません。
+
+Durable Object binding (`CALL_SIGNALING` / `REALTIME_STREAM`) はどちらの lane でも
+wrapper を素通りします。ただし Takoform の Worker Version form には DO binding が
+無いため、`takoform-v1` では両方とも未 bind になり、call / realtime route は 503 を
+返してクライアントは polling に落ちます。
 
 ## lane ごとの差分（app が知っておくべきもの）
 

--- a/docs/design/runtime-lanes.md
+++ b/docs/design/runtime-lanes.md
@@ -1,0 +1,138 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+# Runtime lanes — 同じ bundle を Cloudflare と Takoserver の両方で動かす
+
+Status: **実装済み**（`src/backend/runtime/lane.ts` ほか。test は
+`src/backend/__tests__/runtime/`）
+Owner: `yurucommu-core`
+Consumers: `yurucommu`, `yurumeet`（Worker entry の composition）
+
+同一の Worker bundle が、内側からは見分けのつかない 2 つの backend で動きます。
+
+| lane | 出どころ | `env.DB` | `env.KV` | `env.MEDIA` | `env.DELIVERY_QUEUE` |
+| --- | --- | --- | --- | --- | --- |
+| `cloudflare` | Cloudflare Workers へ直接 deploy | `D1Database` | `KVNamespace` | `R2Bucket` | `Queue` |
+| `takoform-v1` | Takoform 経由で Takoserver Host へ publish | `edge.sql@1.0.0` | `edge.kv@1.0.0` | `edge.objects@1.0.0` | `edge.queue@1.0.0` |
+
+`takoform-v1` では Host が生成した entrypoint が module より先に `env` を差し替え、
+各 binding は Worker Version が宣言した Interface の **portable facade** になります。
+managed Cloudflare backend と self-host backend は同じ facade を projection します
+（同じ method、同じ option 名、同じ error 名）。Takoserver ADR 0005 が object storage
+について明言し、self-host wrapper が KV と SQL について同じことを繰り返しています。
+
+## lane は宣言する。推測しない
+
+binding の 5 つのうち **2 つは形で区別できません**。`edge.kv` と `KVNamespace` は
+同じ 5 つの method 名を持ち、queue producer はどちらも `send` / `sendBatch` です。
+推測した Worker は facade に `kv.get(key, {type:"json"})` を渡し、facade は第 2 引数を
+無視して bytes を返すので、失敗はずっと後から「壊れた session」「発火しない rate limit」
+として現れます。
+
+そこで lane は plain var `YURUCOMMU_RUNTIME_LANE` で宣言し、**識別できる binding で
+突き合わせます**。未設定は `cloudflare`（Takoform を経由していない Worker はそれです）。
+知らない値は default に落とさず起動を拒否します。
+
+- `DB` は両方向に decisive — `execute`/`query`/`transaction` と `prepare`/`batch` は
+  互いに素です。
+- `MEDIA` は片方向に decisive — `R2Bucket` は multipart helper で見分けられます。
+- 宣言と binding が食い違えば `RuntimeLaneError` で起動を拒否します。
+
+app 側の `deploy/takoform/main.tf` は既に
+`worker_plain_values = { YURUCOMMU_RUNTIME_LANE = "takoform-v1" }` を設定しています。
+
+## Worker entry からの使い方
+
+```ts
+import {
+  wrapRuntimeBindings,
+  wrapRuntimeMessageBatch,
+  resolveRuntimeLane,
+} from "@takosjp/yurucommu-core/server";
+
+export default {
+  async fetch(request, bindings, ctx) {
+    return app.fetch(request, wrapRuntimeBindings(bindings), ctx);
+  },
+  async queue(batch, bindings) {
+    const lane = resolveRuntimeLane(bindings.YURUCOMMU_RUNTIME_LANE);
+    return handleYurucommuQueueBatch(
+      wrapRuntimeMessageBatch(batch, lane),
+      wrapRuntimeBindings(bindings),
+    );
+  },
+};
+```
+
+`wrapCloudflareBindings` / `wrapCloudflareMessageBatch` はこれまで通り残ります。
+native binding だけを渡すと分かっている entry はそちらを直接呼んでも構いません。
+
+## lane ごとの差分（app が知っておくべきもの）
+
+### `edge.sql` — row は record であって配列ではない
+
+D1 は Drizzle に位置つき配列を渡し、`sqlite-proxy` は `rows[i][j]` を compile 済み
+field へ位置で対応させます。`edge.sql` が返すのは **result column 名を key とする
+record** です。Drizzle が生成する join はこうなります。
+
+```sql
+select "inbox"."actor_ap_id", ..., "activities"."actor_ap_id", ... from "inbox" inner join "activities" ...
+```
+
+SQLite はどちらの result column にも `actor_ap_id` という名前を付けるので、record は
+片方だけを残し、以降の field が 1 つずつずれます。**error ではなく静かな誤読**です。
+
+`edge-sql.ts` は送信前に projection list を書き換え、alias を持たない項目それぞれに
+一意で非数値な名前（`__c0`, `__c1`, ...）を与えます。Drizzle は result column 名を
+見ないので、この rename は Drizzle からは不可視です。さらに **guard** が付きます:
+返ってきた row の key 数が送った projection 項目数と一致しなければ、ずれた row を
+返す代わりに `EdgeSqlColumnMismatchError` を投げます。
+
+- `db.batch([...])` は facade の `transaction()`（all-or-none、1 往復）になります。
+- `begin` / `commit` / `savepoint` はこの request path にありません。`db.batch` を
+  使ってください（`managed-relational.ts` と同じ制約です）。
+- bound parameter は `null | number | string | {encoding:"base64", data}` のみ。
+  boolean は 0/1、`Uint8Array` / `ArrayBuffer` は base64 blob になります。
+- `select *` は rename できないため書き換えず、column 数の guard も効きません。
+  join を伴う `select *` を raw SQL で書かないでください。
+
+### `edge.kv` — 期限は相対 TTL ひとつだけ
+
+- read は常に bytes。`{type:"text"|"json"|"arrayBuffer"}` の decode は adapter が行います。
+- `expiration`（絶対秒）は現在時刻との差から `expirationTtlSeconds` に変換されます。
+- TTL の下限は 60 秒（Cloudflare KV 自身の下限でもある）。下回る指定は clamp せず拒否します。
+- metadata は **string 値のみ**。string でない値は stringify せず拒否します。
+- `list()` は **name しか返しません**。`expiration` と `metadata` は Host が返さないので、
+  この lane では常に absent です。「無い」ことから何も推論しないでください。
+
+### `edge.queue` — body は bytes
+
+- Cloudflare Queues と違い structured clone がありません。producer は body を JSON で
+  serialize し、consumer 側が同じ encoding で戻します。
+- consumer batch は別 object です: `acknowledge` / `acknowledgeAll` /
+  `timestampMillis`（`ack` / `ackAll` / `timestamp` ではない）。body は
+  `{encoding:"base64", data}` で届きます。
+- `retry({delaySeconds: 0})` は facade が拒否するので、0 は省略に変換されます。
+
+### `edge.objects` — R2 より狭い
+
+- `customMetadata` はありません。落とすのではなく拒否します（core は使っていません）。
+- streaming `put` には `contentLength` が必要です。ADR 0005 が「Host は宣言された
+  byte 数を streaming 中に enforce し、size を知るために body を buffer しない」と
+  定めているためです。`IObjectStorage.put` に optional な `contentLength` を足したので、
+  size が既に手元にある呼び出し（upload の `File.size`）は渡してください。無い場合は
+  Worker 側で buffer します。
+- `delete` は 1 key ずつ。配列形は逐次呼び出しになり、atomic ではありません。
+
+## self-host で無いもの
+
+Takoserver の self-host backend が projection するのは `edge.kv` と `edge.sql` **だけ**
+です（`selfhost-worker-wrapper.ts` の `projectEnv`）。したがって self-host された Worker
+には queue binding も object binding も存在せず、
+
+- `DELIVERY_QUEUE` / `DELIVERY_DLQ` 未 bind → 既存の同期 fallback delivery と readiness 報告
+- `MEDIA` 未 bind → 既存の "Object storage unavailable" (503)
+
+という、これまでと同じ挙動になります。managed Cloudflare backend では 4 つとも
+projection されます。

--- a/src/backend/__tests__/runtime/edge-kv.test.ts
+++ b/src/backend/__tests__/runtime/edge-kv.test.ts
@@ -1,0 +1,261 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  EdgeKeyValueOptionError,
+  resolveEdgeKvExpirationTtl,
+  wrapEdgeKv,
+} from "../../runtime/edge-kv.ts";
+import type {
+  EdgeKvBinding,
+  EdgeKvListOptions,
+  EdgeKvListResult,
+  EdgeKvPutOptions,
+} from "../../runtime/edge-facades.ts";
+
+interface Entry {
+  readonly bytes: Uint8Array;
+  readonly metadata?: Record<string, string>;
+  readonly expirationTtlSeconds?: number;
+}
+
+/**
+ * A stand-in that answers exactly like the Host: bytes out of `get`, a single
+ * `expirationTtlSeconds` on `put`, and a listing whose entries carry the NAME
+ * ONLY under a camelCase `listComplete`.
+ */
+function createFakeEdgeKv(): EdgeKvBinding & {
+  readonly store: Map<string, Entry>;
+  readonly puts: { key: string; options?: EdgeKvPutOptions }[];
+  readonly lists: (EdgeKvListOptions | undefined)[];
+} {
+  const store = new Map<string, Entry>();
+  const puts: { key: string; options?: EdgeKvPutOptions }[] = [];
+  const lists: (EdgeKvListOptions | undefined)[] = [];
+  const encoder = new TextEncoder();
+
+  const asBytes = (
+    value: string | ArrayBuffer | ArrayBufferView,
+  ): Uint8Array => {
+    if (typeof value === "string") return encoder.encode(value);
+    if (value instanceof ArrayBuffer) return new Uint8Array(value.slice(0));
+    return new Uint8Array(
+      value.buffer.slice(value.byteOffset, value.byteOffset + value.byteLength),
+    );
+  };
+
+  const toArrayBuffer = (bytes: Uint8Array): ArrayBuffer =>
+    bytes.buffer.slice(
+      bytes.byteOffset,
+      bytes.byteOffset + bytes.byteLength,
+    ) as ArrayBuffer;
+
+  return {
+    store,
+    puts,
+    lists,
+    get: async (key) => {
+      const entry = store.get(key);
+      return entry ? toArrayBuffer(entry.bytes) : null;
+    },
+    getWithMetadata: async (key) => {
+      const entry = store.get(key);
+      if (!entry) return null;
+      return entry.metadata === undefined
+        ? { value: toArrayBuffer(entry.bytes) }
+        : { value: toArrayBuffer(entry.bytes), metadata: entry.metadata };
+    },
+    put: async (key, value, options) => {
+      puts.push({ key, options });
+      store.set(key, {
+        bytes: asBytes(value),
+        metadata: options?.metadata,
+        expirationTtlSeconds: options?.expirationTtlSeconds,
+      });
+    },
+    delete: async (key) => {
+      store.delete(key);
+    },
+    list: async (options): Promise<EdgeKvListResult> => {
+      lists.push(options);
+      const names = [...store.keys()]
+        .filter((name) => !options?.prefix || name.startsWith(options.prefix))
+        .sort();
+      const start = options?.cursor ? Number(options.cursor) : 0;
+      const limit = options?.limit ?? names.length;
+      const page = names.slice(start, start + limit);
+      const complete = start + limit >= names.length;
+      return {
+        keys: page.map((name) => ({ name })),
+        listComplete: complete,
+        ...(complete ? {} : { cursor: String(start + limit) }),
+      };
+    },
+  };
+}
+
+describe("edge.kv expiration mapping", () => {
+  const now = () => 1_000_000;
+
+  test("passes a relative TTL through", () => {
+    expect(resolveEdgeKvExpirationTtl({ expirationTtl: 600 }, now)).toBe(600);
+  });
+
+  test("converts an absolute expiration into the remaining seconds", () => {
+    expect(resolveEdgeKvExpirationTtl({ expiration: 1_000_900 }, now)).toBe(
+      900,
+    );
+  });
+
+  test("prefers the relative TTL when both are given, as Cloudflare does", () => {
+    expect(
+      resolveEdgeKvExpirationTtl(
+        { expirationTtl: 120, expiration: 1_000_900 },
+        now,
+      ),
+    ).toBe(120);
+  });
+
+  test("is absent when neither is given", () => {
+    expect(resolveEdgeKvExpirationTtl(undefined, now)).toBeUndefined();
+    expect(resolveEdgeKvExpirationTtl({}, now)).toBeUndefined();
+  });
+
+  test("refuses a deadline under the 60s floor both backends enforce", () => {
+    expect(() =>
+      resolveEdgeKvExpirationTtl({ expirationTtl: 30 }, now),
+    ).toThrow(EdgeKeyValueOptionError);
+    // An absolute instant that has almost arrived resolves the same way rather
+    // than being clamped into a longer life than the caller asked for.
+    expect(() =>
+      resolveEdgeKvExpirationTtl({ expiration: 1_000_010 }, now),
+    ).toThrow(/60s floor/);
+  });
+
+  test("refuses a deadline past the ten-year ceiling", () => {
+    expect(() =>
+      resolveEdgeKvExpirationTtl({ expirationTtl: 315_360_001 }, now),
+    ).toThrow(EdgeKeyValueOptionError);
+  });
+});
+
+describe("edge.kv store adapter", () => {
+  test("reads bytes back as text, JSON, and an ArrayBuffer", async () => {
+    const facade = createFakeEdgeKv();
+    const kv = wrapEdgeKv(facade);
+
+    await kv.put("plain", "hello");
+    await kv.put("structured", JSON.stringify({ ok: true, count: 2 }));
+
+    expect(await kv.get("plain")).toBe("hello");
+    expect(
+      await kv.get<{ ok: boolean; count: number }>("structured", {
+        type: "json",
+      }),
+    ).toEqual({ ok: true, count: 2 });
+    const buffer = await kv.get("plain", { type: "arrayBuffer" });
+    expect(new TextDecoder().decode(buffer!)).toBe("hello");
+  });
+
+  test("answers a missing key with null on every read type", async () => {
+    const kv = wrapEdgeKv(createFakeEdgeKv());
+    expect(await kv.get("absent")).toBeNull();
+    expect(await kv.get("absent", { type: "json" })).toBeNull();
+    expect(await kv.get("absent", { type: "arrayBuffer" })).toBeNull();
+  });
+
+  test("reads a non-JSON value as null rather than throwing, like KV does", async () => {
+    const facade = createFakeEdgeKv();
+    const kv = wrapEdgeKv(facade);
+    await kv.put("poisoned", "not json");
+    expect(await kv.get("poisoned", { type: "json" })).toBeNull();
+  });
+
+  test("writes an ArrayBuffer and a stream body", async () => {
+    const facade = createFakeEdgeKv();
+    const kv = wrapEdgeKv(facade);
+
+    await kv.put("buffer", new TextEncoder().encode("from-buffer").buffer);
+    expect(await kv.get("buffer")).toBe("from-buffer");
+
+    await kv.put(
+      "stream",
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode("from-"));
+          controller.enqueue(new TextEncoder().encode("stream"));
+          controller.close();
+        },
+      }),
+    );
+    expect(await kv.get("stream")).toBe("from-stream");
+  });
+
+  test("sends only the option keys the facade accepts", async () => {
+    const facade = createFakeEdgeKv();
+    const kv = wrapEdgeKv(facade, () => 1_000_000);
+
+    await kv.put("a", "1", { expirationTtl: 600, metadata: { kind: "state" } });
+    expect(facade.puts.at(-1)!.options).toEqual({
+      expirationTtlSeconds: 600,
+      metadata: { kind: "state" },
+    });
+
+    await kv.put("b", "2");
+    expect(facade.puts.at(-1)!.options).toEqual({});
+
+    await kv.put("c", "3", { expiration: 1_000_600 });
+    expect(facade.puts.at(-1)!.options).toEqual({ expirationTtlSeconds: 600 });
+  });
+
+  test("refuses metadata the facade cannot store instead of stringifying it", async () => {
+    const kv = wrapEdgeKv(createFakeEdgeKv());
+    await expect(
+      kv.put("a", "1", { metadata: { attempts: 3 } }),
+    ).rejects.toThrow(EdgeKeyValueOptionError);
+  });
+
+  test("deletes a key", async () => {
+    const facade = createFakeEdgeKv();
+    const kv = wrapEdgeKv(facade);
+    await kv.put("gone", "x");
+    await kv.delete("gone");
+    expect(await kv.get("gone")).toBeNull();
+  });
+
+  test("lists with prefix, limit, and cursor in the shape the app expects", async () => {
+    const facade = createFakeEdgeKv();
+    const kv = wrapEdgeKv(facade);
+    for (const key of ["s:1", "s:2", "s:3", "other"]) await kv.put(key, "x");
+
+    const first = await kv.list({ prefix: "s:", limit: 2 });
+    expect(first.keys.map((key) => key.name)).toEqual(["s:1", "s:2"]);
+    expect(first.list_complete).toBe(false);
+    expect(first.cursor).toBe("2");
+    // The facade's option names went out unchanged.
+    expect(facade.lists.at(-1)).toEqual({ prefix: "s:", limit: 2 });
+
+    const second = await kv.list({
+      prefix: "s:",
+      limit: 2,
+      cursor: first.cursor,
+    });
+    expect(second.keys.map((key) => key.name)).toEqual(["s:3"]);
+    expect(second.list_complete).toBe(true);
+    expect(second.cursor).toBeUndefined();
+  });
+
+  test("reports no expiration or metadata on a listing, because the Host sends none", async () => {
+    const facade = createFakeEdgeKv();
+    const kv = wrapEdgeKv(facade);
+    await kv.put("k", "v", {
+      expirationTtl: 600,
+      metadata: { kind: "state" },
+    });
+    const listed = await kv.list();
+    expect(listed.keys).toEqual([{ name: "k" }]);
+    // The value and its metadata are still there — only the LISTING omits them.
+    expect(await facade.getWithMetadata("k")).toMatchObject({
+      metadata: { kind: "state" },
+    });
+  });
+});

--- a/src/backend/__tests__/runtime/edge-kv.test.ts
+++ b/src/backend/__tests__/runtime/edge-kv.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import {
   EdgeKeyValueOptionError,
+  EdgeKeyValueValueError,
   resolveEdgeKvExpirationTtl,
   wrapEdgeKv,
 } from "../../runtime/edge-kv.ts";
@@ -163,11 +164,15 @@ describe("edge.kv store adapter", () => {
     expect(await kv.get("absent", { type: "arrayBuffer" })).toBeNull();
   });
 
-  test("reads a non-JSON value as null rather than throwing, like KV does", async () => {
+  test("distinguishes an unparseable entry from a missing one", async () => {
     const facade = createFakeEdgeKv();
     const kv = wrapEdgeKv(facade);
     await kv.put("poisoned", "not json");
-    expect(await kv.get("poisoned", { type: "json" })).toBeNull();
+    // Reporting this as `null` would be indistinguishable from "no such key".
+    await expect(kv.get("poisoned", { type: "json" })).rejects.toThrow(
+      EdgeKeyValueValueError,
+    );
+    expect(await kv.get("absent", { type: "json" })).toBeNull();
   });
 
   test("writes an ArrayBuffer and a stream body", async () => {

--- a/src/backend/__tests__/runtime/edge-objects.test.ts
+++ b/src/backend/__tests__/runtime/edge-objects.test.ts
@@ -1,0 +1,235 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  EdgeObjectsShapeError,
+  wrapEdgeObjects,
+} from "../../runtime/edge-objects.ts";
+import type { EdgeObjectsBinding } from "../../runtime/edge-facades.ts";
+
+interface StoredObject {
+  readonly bytes: Uint8Array;
+  readonly contentType?: string;
+  readonly uploadedAtMillis: number;
+}
+
+/**
+ * A stand-in that keeps the facade's fixed arities and its narrow option set:
+ * `contentType` and `contentLength` only, no `customMetadata`, one key per
+ * `delete`, and a `list` page of `{objects, prefixes, truncated, cursor?}`.
+ */
+function createFakeEdgeObjects(): EdgeObjectsBinding & {
+  readonly store: Map<string, StoredObject>;
+  readonly puts: {
+    key: string;
+    streamed: boolean;
+    options: { contentLength?: number; contentType?: string } | undefined;
+  }[];
+  readonly deletes: string[];
+} {
+  const store = new Map<string, StoredObject>();
+  const puts: {
+    key: string;
+    streamed: boolean;
+    options: { contentLength?: number; contentType?: string } | undefined;
+  }[] = [];
+  const deletes: string[] = [];
+
+  const metadata = (key: string) => {
+    const found = store.get(key)!;
+    return {
+      etag: `"${key}-etag"`,
+      size: found.bytes.byteLength,
+      ...(found.contentType === undefined
+        ? {}
+        : { contentType: found.contentType }),
+      uploadedAtMillis: found.uploadedAtMillis,
+    };
+  };
+
+  return {
+    store,
+    puts,
+    deletes,
+    head: async function (key) {
+      // eslint-disable-next-line prefer-rest-params
+      expect(arguments.length).toBe(1);
+      return store.has(key) ? metadata(key) : null;
+    },
+    get: async function (key, options) {
+      expect(arguments.length).toBe(2);
+      expect(options).toBeUndefined();
+      const found = store.get(key);
+      if (!found) return null;
+      return {
+        ...metadata(key),
+        body: new Response(found.bytes as unknown as BodyInit).body!,
+        partial: false,
+      };
+    },
+    put: async function (key, body, options) {
+      expect(arguments.length).toBe(3);
+      const streamed =
+        typeof body !== "string" && !(body instanceof ArrayBuffer);
+      if (
+        body instanceof ReadableStream &&
+        options?.contentLength === undefined
+      ) {
+        const error = new Error("invalid_body");
+        error.name = "invalid_body";
+        throw error;
+      }
+      puts.push({ key, streamed, options });
+      const bytes =
+        typeof body === "string"
+          ? new TextEncoder().encode(body)
+          : body instanceof ArrayBuffer
+            ? new Uint8Array(body)
+            : body instanceof ReadableStream
+              ? new Uint8Array(await new Response(body).arrayBuffer())
+              : new Uint8Array(
+                  (body as ArrayBufferView).buffer.slice(
+                    (body as ArrayBufferView).byteOffset,
+                    (body as ArrayBufferView).byteOffset +
+                      (body as ArrayBufferView).byteLength,
+                  ),
+                );
+      store.set(key, {
+        bytes,
+        contentType: options?.contentType,
+        uploadedAtMillis: 1_700_000_000_000,
+      });
+      return { etag: `"${key}-etag"`, size: bytes.byteLength };
+    },
+    delete: async function (key) {
+      expect(arguments.length).toBe(1);
+      deletes.push(key);
+      store.delete(key);
+    },
+    list: async function (options) {
+      expect(arguments.length).toBe(1);
+      const keys = [...store.keys()]
+        .filter((key) => !options?.prefix || key.startsWith(options.prefix))
+        .sort();
+      const limit = options?.limit ?? keys.length;
+      const page = keys.slice(0, limit);
+      return {
+        objects: page.map((key) => ({ key, ...metadata(key) })),
+        prefixes: [],
+        truncated: page.length < keys.length,
+        ...(page.length < keys.length ? { cursor: String(limit) } : {}),
+      };
+    },
+  };
+}
+
+describe("edge.objects storage adapter", () => {
+  test("stores bytes with a content type and reads them back", async () => {
+    const facade = createFakeEdgeObjects();
+    const media = wrapEdgeObjects(facade);
+
+    const bytes = new TextEncoder().encode("image-bytes");
+    await media.put("uploads/a.png", bytes.buffer as ArrayBuffer, {
+      httpMetadata: { contentType: "image/png" },
+    });
+    expect(facade.puts.at(-1)!.options).toEqual({ contentType: "image/png" });
+
+    const object = await media.get("uploads/a.png");
+    expect(object).not.toBeNull();
+    expect(object!.httpEtag).toBe('"uploads/a.png-etag"');
+    expect(object!.httpMetadata?.contentType).toBe("image/png");
+    expect(await object!.text()).toBe("image-bytes");
+  });
+
+  test("forwards a declared contentLength so a stream is not buffered", async () => {
+    const facade = createFakeEdgeObjects();
+    const media = wrapEdgeObjects(facade);
+    const payload = new TextEncoder().encode("video-bytes");
+
+    await media.put(
+      "uploads/a.mp4",
+      new Response(payload as unknown as BodyInit).body!,
+      {
+        httpMetadata: { contentType: "video/mp4" },
+        contentLength: payload.byteLength,
+      },
+    );
+    expect(facade.puts.at(-1)).toMatchObject({
+      streamed: true,
+      options: { contentLength: payload.byteLength, contentType: "video/mp4" },
+    });
+    expect(await (await media.get("uploads/a.mp4"))!.text()).toBe(
+      "video-bytes",
+    );
+  });
+
+  test("buffers a stream that arrives with no declared length", async () => {
+    // The Host will not discover the size, so the adapter has to, and it must
+    // then declare it rather than passing the stream on undeclared.
+    const facade = createFakeEdgeObjects();
+    const media = wrapEdgeObjects(facade);
+    await media.put(
+      "uploads/b.mp4",
+      new Response(new TextEncoder().encode("no-length") as unknown as BodyInit)
+        .body!,
+    );
+    expect(facade.puts.at(-1)!.options).toEqual({ contentLength: 9 });
+    expect(facade.puts.at(-1)!.streamed).toBe(true);
+    expect(await (await media.get("uploads/b.mp4"))!.text()).toBe("no-length");
+  });
+
+  test("refuses customMetadata instead of dropping it", async () => {
+    const media = wrapEdgeObjects(createFakeEdgeObjects());
+    await expect(
+      media.put("k", "v", { customMetadata: { owner: "a1" } }),
+    ).rejects.toThrow(EdgeObjectsShapeError);
+    // An empty record is not a request to store anything.
+    await expect(media.put("k", "v", { customMetadata: {} })).resolves.toBe(
+      undefined,
+    );
+  });
+
+  test("answers a missing key with null on get and head", async () => {
+    const media = wrapEdgeObjects(createFakeEdgeObjects());
+    expect(await media.get("absent")).toBeNull();
+    expect(await media.head("absent")).toBeNull();
+  });
+
+  test("reports head metadata in the port's shape", async () => {
+    const facade = createFakeEdgeObjects();
+    const media = wrapEdgeObjects(facade);
+    await media.put("k", "12345", {
+      httpMetadata: { contentType: "text/plain" },
+    });
+    expect(await media.head("k")).toEqual({
+      contentType: "text/plain",
+      contentLength: 5,
+      etag: '"k-etag"',
+      httpMetadata: { contentType: "text/plain" },
+    });
+  });
+
+  test("deletes each key of an array, since the facade takes one at a time", async () => {
+    const facade = createFakeEdgeObjects();
+    const media = wrapEdgeObjects(facade);
+    for (const key of ["a", "b", "c"]) await media.put(key, key);
+    await media.delete(["a", "c"]);
+    expect(facade.deletes).toEqual(["a", "c"]);
+    expect([...facade.store.keys()]).toEqual(["b"]);
+  });
+
+  test("lists with prefix and limit and reports truncation", async () => {
+    const facade = createFakeEdgeObjects();
+    const media = wrapEdgeObjects(facade);
+    for (const key of ["u/1", "u/2", "u/3", "other"]) await media.put(key, key);
+
+    const page = await media.list({ prefix: "u/", limit: 2 });
+    expect(page.objects.map((object) => object.key)).toEqual(["u/1", "u/2"]);
+    expect(page.truncated).toBe(true);
+    expect(page.cursor).toBe("2");
+    expect(page.objects[0]!.uploaded).toEqual(new Date(1_700_000_000_000));
+
+    const rest = await media.list({ prefix: "u/" });
+    expect(rest.truncated).toBe(false);
+    expect(rest.cursor).toBeUndefined();
+  });
+});

--- a/src/backend/__tests__/runtime/edge-queue.test.ts
+++ b/src/backend/__tests__/runtime/edge-queue.test.ts
@@ -1,0 +1,218 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  EdgeQueueShapeError,
+  wrapEdgeMessageBatch,
+  wrapEdgeQueue,
+} from "../../runtime/edge-queue.ts";
+import {
+  encodeEdgeBytes,
+  type EdgeQueueBatch,
+  type EdgeQueueBatchItem,
+  type EdgeQueueBinding,
+  type EdgeQueueMessage,
+} from "../../runtime/edge-facades.ts";
+
+const decoder = new TextDecoder();
+
+function bodyText(value: string | ArrayBuffer | ArrayBufferView): string {
+  if (typeof value === "string") return value;
+  if (value instanceof ArrayBuffer) return decoder.decode(value);
+  return decoder.decode(value as Uint8Array);
+}
+
+function createFakeEdgeQueue(): EdgeQueueBinding & {
+  readonly sent: {
+    body: string;
+    options?: { delaySeconds?: number };
+  }[];
+  readonly batches: EdgeQueueBatchItem[][];
+} {
+  const sent: { body: string; options?: { delaySeconds?: number } }[] = [];
+  const batches: EdgeQueueBatchItem[][] = [];
+  return {
+    sent,
+    batches,
+    send: async (body, options) => {
+      // The Host rejects anything that is not bytes, so prove the adapter never
+      // hands it a live object.
+      if (typeof body === "object" && !(body instanceof ArrayBuffer)) {
+        if (!ArrayBuffer.isView(body)) {
+          const error = new Error("invalid_body");
+          error.name = "invalid_body";
+          throw error;
+        }
+      }
+      sent.push({ body: bodyText(body), options });
+      return "acceptance-1";
+    },
+    sendBatch: async (messages) => {
+      batches.push([...messages]);
+      return messages.map((_, index) => `acceptance-${index}`);
+    },
+  };
+}
+
+function facadeMessage(
+  id: string,
+  body: unknown,
+  settled: string[],
+): EdgeQueueMessage {
+  return {
+    id,
+    timestampMillis: 1_700_000_000_000,
+    attempts: 1,
+    body: encodeEdgeBytes(new TextEncoder().encode(JSON.stringify(body))),
+    acknowledge: () => settled.push(`ack:${id}`),
+    retry: (options) =>
+      settled.push(`retry:${id}:${JSON.stringify(options ?? {})}`),
+  };
+}
+
+describe("edge.queue producer", () => {
+  test("serializes a body the facade would otherwise refuse", async () => {
+    const facade = createFakeEdgeQueue();
+    const queue = wrapEdgeQueue<{ readonly to: string }>(facade);
+    await queue.send({ to: "https://remote.example/inbox" });
+    expect(facade.sent).toEqual([
+      {
+        body: JSON.stringify({ to: "https://remote.example/inbox" }),
+        options: {},
+      },
+    ]);
+  });
+
+  test("sends a positive delay and omits a zero one", async () => {
+    const facade = createFakeEdgeQueue();
+    const queue = wrapEdgeQueue<number>(facade);
+    await queue.send(1, { delaySeconds: 30 });
+    await queue.send(2, { delaySeconds: 0 });
+    await queue.send(3);
+    expect(facade.sent.map((entry) => entry.options)).toEqual([
+      { delaySeconds: 30 },
+      {},
+      {},
+    ]);
+  });
+
+  test("pushes a batch-wide delay onto each message the facade sees", async () => {
+    // `sendBatch` has no batch-level options slot, so a shared default has to
+    // become a per-message one or it would be silently dropped.
+    const facade = createFakeEdgeQueue();
+    const queue = wrapEdgeQueue<string>(facade);
+    await queue.sendBatch([{ body: "a" }, { body: "b", delaySeconds: 5 }], {
+      delaySeconds: 60,
+    });
+    expect(
+      facade.batches[0]!.map((item) => ({
+        body: bodyText(item.body),
+        delaySeconds: item.delaySeconds,
+      })),
+    ).toEqual([
+      { body: '"a"', delaySeconds: 60 },
+      { body: '"b"', delaySeconds: 5 },
+    ]);
+  });
+
+  test("does not call the Host for an empty batch", async () => {
+    const facade = createFakeEdgeQueue();
+    await wrapEdgeQueue<string>(facade).sendBatch([]);
+    expect(facade.batches).toHaveLength(0);
+  });
+
+  test("refuses a batch larger than the facade carries", async () => {
+    const facade = createFakeEdgeQueue();
+    const queue = wrapEdgeQueue<number>(facade);
+    await expect(
+      queue.sendBatch(Array.from({ length: 101 }, (_, i) => ({ body: i }))),
+    ).rejects.toThrow(EdgeQueueShapeError);
+  });
+
+  test("refuses a body that cannot be serialized", async () => {
+    const facade = createFakeEdgeQueue();
+    const cyclic: Record<string, unknown> = {};
+    cyclic.self = cyclic;
+    await expect(wrapEdgeQueue<unknown>(facade).send(cyclic)).rejects.toThrow(
+      EdgeQueueShapeError,
+    );
+  });
+});
+
+describe("edge.queue consumer batch", () => {
+  test("decodes bodies and maps the settle vocabulary", async () => {
+    const settled: string[] = [];
+    const facadeBatch: EdgeQueueBatch = {
+      batchId: "batch-1",
+      queue: "yurucommu-delivery",
+      messages: [
+        facadeMessage("m1", { activity: "Follow" }, settled),
+        facadeMessage("m2", { activity: "Like" }, settled),
+      ],
+      acknowledgeAll: () => settled.push("ackAll"),
+      retryAll: (options) =>
+        settled.push(`retryAll:${JSON.stringify(options ?? {})}`),
+    };
+
+    const batch = wrapEdgeMessageBatch<{ activity: string }>(facadeBatch);
+    expect(batch.queue).toBe("yurucommu-delivery");
+    expect(batch.messages.map((message) => message.body)).toEqual([
+      { activity: "Follow" },
+      { activity: "Like" },
+    ]);
+    expect(batch.messages[0]!.timestamp).toEqual(new Date(1_700_000_000_000));
+    expect(batch.messages[0]!.attempts).toBe(1);
+
+    batch.messages[0]!.ack();
+    batch.messages[1]!.retry({ delaySeconds: 120 });
+    batch.ackAll();
+    batch.retryAll({ delaySeconds: 30 });
+    expect(settled).toEqual([
+      "ack:m1",
+      'retry:m2:{"delaySeconds":120}',
+      "ackAll",
+      'retryAll:{"delaySeconds":30}',
+    ]);
+  });
+
+  test("omits a zero retry delay the facade would reject", async () => {
+    const settled: string[] = [];
+    const facadeBatch: EdgeQueueBatch = {
+      batchId: "batch-2",
+      queue: "q",
+      messages: [facadeMessage("m1", 1, settled)],
+      acknowledgeAll: () => settled.push("ackAll"),
+      retryAll: (options) =>
+        settled.push(`retryAll:${JSON.stringify(options ?? {})}`),
+    };
+    const batch = wrapEdgeMessageBatch<number>(facadeBatch);
+    batch.messages[0]!.retry({ delaySeconds: 0 });
+    batch.retryAll();
+    expect(settled).toEqual(["retry:m1:{}", "retryAll:{}"]);
+  });
+
+  test("round-trips a body between the producer and the consumer", async () => {
+    const facade = createFakeEdgeQueue();
+    const payload = { to: "https://remote.example/inbox", attempt: 2 };
+    await wrapEdgeQueue<typeof payload>(facade).send(payload);
+
+    const settled: string[] = [];
+    const wire = new TextEncoder().encode(facade.sent[0]!.body);
+    const batch = wrapEdgeMessageBatch<typeof payload>({
+      batchId: "b",
+      queue: "q",
+      messages: [
+        {
+          id: "m",
+          timestampMillis: 0,
+          attempts: 1,
+          body: encodeEdgeBytes(wire),
+          acknowledge: () => settled.push("ack"),
+          retry: () => settled.push("retry"),
+        },
+      ],
+      acknowledgeAll: () => {},
+      retryAll: () => {},
+    });
+    expect(batch.messages[0]!.body).toEqual(payload);
+  });
+});

--- a/src/backend/__tests__/runtime/edge-sql.test.ts
+++ b/src/backend/__tests__/runtime/edge-sql.test.ts
@@ -1,0 +1,417 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import { Database as BunSqlite } from "bun:sqlite";
+import { eq, sql } from "drizzle-orm";
+import { integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
+
+import {
+  EdgeSqlColumnMismatchError,
+  EdgeSqlShapeError,
+  createEdgeSqlDatabase,
+  rewriteProjection,
+} from "../../runtime/edge-sql.ts";
+import {
+  decodeEdgeBytes,
+  encodeEdgeBytes,
+  isEdgeEncodedBytes,
+  type EdgeSqlBinding,
+  type EdgeSqlResult,
+  type EdgeSqlValue,
+} from "../../runtime/edge-facades.ts";
+
+// Two tables that COLLIDE on column names, because that is the shape the
+// facade's record-per-row cannot represent and the adapter exists to survive.
+const authors = sqliteTable("authors", {
+  id: text("id").primaryKey(),
+  name: text("name").notNull(),
+  createdAt: text("created_at").notNull(),
+});
+
+const books = sqliteTable("books", {
+  id: text("id").primaryKey(),
+  authorId: text("author_id").notNull(),
+  title: text("title").notNull(),
+  pages: integer("pages"),
+  cover: text("cover", { mode: "json" }),
+  createdAt: text("created_at").notNull(),
+});
+
+const blobs = sqliteTable("blobs", {
+  id: text("id").primaryKey(),
+  payload: text("payload"),
+});
+
+const SCHEMA_SQL = [
+  `create table authors (id text primary key, name text not null, created_at text not null)`,
+  `create table books (id text primary key, author_id text not null, title text not null, pages integer, cover text, created_at text not null)`,
+  `create table blobs (id text primary key, payload blob)`,
+];
+
+/**
+ * A faithful stand-in for the Host's `edge.sql` binding.
+ *
+ * The important fidelity is that it returns ROWS AS RECORDS built by the
+ * SQLite driver itself, so a duplicate result-column name collapses here
+ * exactly as it does on a real Host — which is what makes the join test below
+ * a real test and not a restatement of the adapter.
+ */
+function createFakeEdgeSql(store: BunSqlite): EdgeSqlBinding & {
+  readonly statements: { sql: string; params: readonly EdgeSqlValue[] }[];
+} {
+  const statements: { sql: string; params: readonly EdgeSqlValue[] }[] = [];
+
+  const toNative = (value: EdgeSqlValue): unknown =>
+    isEdgeEncodedBytes(value) ? decodeEdgeBytes(value) : value;
+
+  const fromNative = (value: unknown): EdgeSqlValue => {
+    if (value === null || value === undefined) return null;
+    if (typeof value === "string" || typeof value === "number") return value;
+    if (typeof value === "bigint") return Number(value);
+    if (value instanceof Uint8Array) return encodeEdgeBytes(value);
+    throw new Error(`unsupported native value: ${String(value)}`);
+  };
+
+  const run = (sqlText: string, params?: readonly EdgeSqlValue[]) => {
+    statements.push({ sql: sqlText, params: params ?? [] });
+    const bound = (params ?? []).map(toNative) as never[];
+    const rows = store.query(sqlText).all(...bound) as Record<
+      string,
+      unknown
+    >[];
+    const writes = /^\s*(insert|update|delete|replace)\b/i.test(sqlText);
+    const changes = writes
+      ? Number((store.query("select changes() as c").get() as { c: number }).c)
+      : 0;
+    return {
+      rows: rows.map((row) => {
+        const projected: Record<string, EdgeSqlValue> = {};
+        for (const [key, value] of Object.entries(row)) {
+          projected[key] = fromNative(value);
+        }
+        return projected;
+      }),
+      rowsWritten: changes,
+    } satisfies EdgeSqlResult;
+  };
+
+  return {
+    statements,
+    execute: async (sqlText, params) => run(sqlText, params),
+    query: async (sqlText, params) => {
+      const result = run(sqlText, params);
+      if (result.rowsWritten !== 0) {
+        const error = new Error("backend_unavailable");
+        error.name = "backend_unavailable";
+        throw error;
+      }
+      return result;
+    },
+    transaction: async (input) => {
+      // All-or-none, exactly like the Host: one throw discards the whole set.
+      return store.transaction(() =>
+        input.map((entry) => run(entry.sql, entry.params)),
+      )();
+    },
+  };
+}
+
+describe("edge.sql projection rewrite", () => {
+  test("gives every unaliased column a distinct name and counts them", () => {
+    const rewritten = rewriteProjection(
+      `select "a"."id", "b"."id" from "a" inner join "b" on "a"."id" = "b"."id"`,
+    );
+    expect(rewritten.sql).toBe(
+      `select "a"."id" as "__c0", "b"."id" as "__c1" from "a" inner join "b" on "a"."id" = "b"."id"`,
+    );
+    expect(rewritten.columns).toBe(2);
+  });
+
+  test("leaves an item that already names itself alone", () => {
+    const rewritten = rewriteProjection(
+      `select "a" as "kept", "b" from "t" where "c" = ?`,
+    );
+    expect(rewritten.sql).toBe(
+      `select "a" as "kept", "b" as "__c1" from "t" where "c" = ?`,
+    );
+    expect(rewritten.columns).toBe(2);
+  });
+
+  test("rewrites a returning list and ignores a write without one", () => {
+    expect(
+      rewriteProjection(
+        `insert into "t" ("a", "b") values (?, ?) returning "a", "b"`,
+      ),
+    ).toEqual({
+      sql: `insert into "t" ("a", "b") values (?, ?) returning "a" as "__c0", "b" as "__c1"`,
+      columns: 2,
+    });
+    const update = `update "t" set "a" = ?, "b" = ? where "c" = ?`;
+    expect(rewriteProjection(update)).toEqual({
+      sql: update,
+      columns: undefined,
+    });
+  });
+
+  test("does not reach inside a subquery, a literal, or a cast", () => {
+    const source = `select "t"."a", (select count(*) from "b" where "b"."x" = ','), cast("c" as integer) from "t"`;
+    const rewritten = rewriteProjection(source);
+    expect(rewritten.columns).toBe(3);
+    expect(rewritten.sql).toContain(
+      `(select count(*) from "b" where "b"."x" = ',') as "__c1"`,
+    );
+    expect(rewritten.sql).toContain(`cast("c" as integer) as "__c2"`);
+  });
+
+  test("declines a shape it cannot rename rather than guessing", () => {
+    for (const statement of [
+      `select * from "t"`,
+      `pragma foreign_keys = off`,
+      `create table "t" ("a" text)`,
+    ]) {
+      expect(rewriteProjection(statement)).toEqual({
+        sql: statement,
+        columns: undefined,
+      });
+    }
+  });
+
+  test("skips distinct and stops at the first top-level clause keyword", () => {
+    expect(
+      rewriteProjection(`select distinct "a"."x" from "a" order by "a"."x"`),
+    ).toEqual({
+      sql: `select distinct "a"."x" as "__c0" from "a" order by "a"."x"`,
+      columns: 1,
+    });
+  });
+});
+
+describe("edge.sql drizzle round trip", () => {
+  let store: BunSqlite;
+  let facade: ReturnType<typeof createFakeEdgeSql>;
+  let db: ReturnType<typeof createEdgeSqlDatabase>;
+
+  beforeEach(() => {
+    store = new BunSqlite(":memory:");
+    for (const statement of SCHEMA_SQL) store.run(statement);
+    facade = createFakeEdgeSql(store);
+    db = createEdgeSqlDatabase(facade);
+  });
+
+  test("inserts and reads back through the facade", async () => {
+    await db
+      .insert(authors)
+      .values({ id: "a1", name: "Ada", createdAt: "2026-01-01" });
+    const rows = await db.select().from(authors);
+    expect(rows).toEqual([{ id: "a1", name: "Ada", createdAt: "2026-01-01" }]);
+  });
+
+  test("returns the RETURNING rows of a write", async () => {
+    const returned = await db
+      .insert(books)
+      .values({
+        id: "b1",
+        authorId: "a1",
+        title: "Notes",
+        pages: 12,
+        cover: null,
+        createdAt: "2026-01-02",
+      })
+      .returning({ id: books.id, title: books.title });
+    expect(returned).toEqual([{ id: "b1", title: "Notes" }]);
+  });
+
+  test("reports rows affected for a run so affectedRowCount can read it", async () => {
+    await db
+      .insert(authors)
+      .values({ id: "a1", name: "Ada", createdAt: "2026-01-01" });
+    const result = (await db
+      .update(authors)
+      .set({ name: "Ada L." })
+      .where(eq(authors.id, "a1"))) as unknown as {
+      meta: { changes: number };
+    };
+    expect(result.meta.changes).toBe(1);
+  });
+
+  test("maps a join whose result columns collide on both sides", async () => {
+    // Without the projection rewrite the facade's record keeps ONE `id` and one
+    // `created_at`, and every field after the collision shifts by one — the
+    // silent mis-read this whole adapter exists to prevent.
+    await db
+      .insert(authors)
+      .values({ id: "a1", name: "Ada", createdAt: "2026-01-01" });
+    await db.insert(books).values({
+      id: "b1",
+      authorId: "a1",
+      title: "Notes",
+      pages: 12,
+      cover: null,
+      createdAt: "2026-01-02",
+    });
+
+    const joined = await db
+      .select()
+      .from(books)
+      .innerJoin(authors, eq(books.authorId, authors.id));
+
+    expect(joined).toEqual([
+      {
+        books: {
+          id: "b1",
+          authorId: "a1",
+          title: "Notes",
+          pages: 12,
+          cover: null,
+          createdAt: "2026-01-02",
+        },
+        authors: { id: "a1", name: "Ada", createdAt: "2026-01-01" },
+      },
+    ]);
+
+    // Prove the rewrite really happened rather than the driver having been
+    // lucky: the statement that went out carries the generated names.
+    const select = facade.statements.at(-1)!.sql;
+    expect(select).toContain(`as "__c0"`);
+    expect(select).toContain(`as "__c6"`);
+  });
+
+  test("get() on an empty result is undefined, not a row of undefineds", async () => {
+    const missing = await db
+      .select()
+      .from(authors)
+      .where(eq(authors.id, "nobody"))
+      .get();
+    expect(missing).toBeUndefined();
+  });
+
+  test("keeps column names reachable for a raw statement with no fields", async () => {
+    // `db.get(sql`...`)` is handed the driver's row untouched, and call sites
+    // in this repo read it by NAME (`match.matched`). On D1 that is a record;
+    // sqlite-proxy would hand over a bare array.
+    await db
+      .insert(authors)
+      .values({ id: "a1", name: "Ada", createdAt: "2026-01-01" });
+    const row = (await db.get(sql`
+      SELECT CASE WHEN EXISTS (SELECT 1 FROM ${authors}) THEN 1 ELSE 0 END AS matched
+    `)) as { matched: number } | undefined;
+    expect(row?.matched).toBe(1);
+  });
+
+  test("carries a blob parameter and reads it back as bytes", async () => {
+    const payload = new Uint8Array([0, 1, 2, 250, 255]);
+    await db.run(
+      sql`insert into ${blobs} (${sql.raw('"id"')}, ${sql.raw('"payload"')}) values (${"one"}, ${payload})`,
+    );
+    const row = (await db.get(
+      sql`select "payload" as "payload" from ${blobs} where "id" = ${"one"}`,
+    )) as { payload: Uint8Array } | undefined;
+    expect(row?.payload).toBeInstanceOf(Uint8Array);
+    expect([...(row?.payload ?? [])]).toEqual([...payload]);
+  });
+
+  test("batch commits every statement as one Host transaction", async () => {
+    await db.batch([
+      db.insert(authors).values({
+        id: "a1",
+        name: "Ada",
+        createdAt: "2026-01-01",
+      }),
+      db.insert(authors).values({
+        id: "a2",
+        name: "Grace",
+        createdAt: "2026-01-01",
+      }),
+    ]);
+    expect(await db.select().from(authors)).toHaveLength(2);
+    // One round trip, not two: the whole batch went out as `transaction`.
+    expect(facade.statements).toHaveLength(3); // 2 inserts + the select
+  });
+
+  test("batch rolls the whole set back when one statement fails", async () => {
+    await db
+      .insert(authors)
+      .values({ id: "a1", name: "Ada", createdAt: "2026-01-01" });
+
+    await expect(
+      db.batch([
+        db.insert(authors).values({
+          id: "a2",
+          name: "Grace",
+          createdAt: "2026-01-01",
+        }),
+        // Duplicate primary key: the Host aborts the transaction.
+        db.insert(authors).values({
+          id: "a1",
+          name: "Clash",
+          createdAt: "2026-01-01",
+        }),
+      ]),
+    ).rejects.toThrow();
+
+    const remaining = await db.select().from(authors);
+    expect(remaining.map((row) => row.id)).toEqual(["a1"]);
+    expect(remaining[0]!.name).toBe("Ada");
+  });
+});
+
+describe("edge.sql fail-closed guards", () => {
+  const emptyFacade = (result: EdgeSqlResult): EdgeSqlBinding => ({
+    execute: async () => result,
+    query: async () => result,
+    transaction: async () => [result],
+  });
+
+  /**
+   * Drizzle wraps a driver throw in `DrizzleQueryError` and keeps the original
+   * as `cause`. The adapter's refusal is what these tests are about, so unwrap
+   * one layer before asserting.
+   */
+  async function refusal(run: () => Promise<unknown>): Promise<Error> {
+    try {
+      await run();
+    } catch (error) {
+      const cause = (error as { cause?: unknown }).cause;
+      return cause instanceof Error ? cause : (error as Error);
+    }
+    throw new Error("expected the statement to be refused");
+  }
+
+  test("refuses a row whose column count does not match the projection", async () => {
+    const db = createEdgeSqlDatabase(
+      // The statement projects three columns; the Host answered with two,
+      // which is exactly what a collapsed duplicate name looks like.
+      emptyFacade({ rows: [{ __c0: "a", __c1: "b" }], rowsWritten: 0 }),
+    );
+    const error = await refusal(async () => await db.select().from(authors));
+    expect(error).toBeInstanceOf(EdgeSqlColumnMismatchError);
+    expect(error.message).toContain("returned 2 columns");
+  });
+
+  test("refuses transaction-control SQL and names the alternative", async () => {
+    const db = createEdgeSqlDatabase(emptyFacade({ rows: [], rowsWritten: 0 }));
+    const error = await refusal(
+      async () => await db.run(sql.raw("begin immediate")),
+    );
+    expect(error).toBeInstanceOf(EdgeSqlShapeError);
+    expect(error.message).toMatch(/db\.batch/);
+  });
+
+  test("refuses a parameter with no portable encoding", async () => {
+    const db = createEdgeSqlDatabase(emptyFacade({ rows: [], rowsWritten: 0 }));
+    const error = await refusal(
+      async () =>
+        await db.run(sql`select ${{ nested: true } as unknown as string}`),
+    );
+    expect(error).toBeInstanceOf(EdgeSqlShapeError);
+    expect(error.message).toContain("no portable encoding");
+  });
+
+  test("refuses more bound parameters than the facade carries", async () => {
+    const db = createEdgeSqlDatabase(emptyFacade({ rows: [], rowsWritten: 0 }));
+    const many = Array.from({ length: 101 }, (_, index) => sql`${index}`);
+    const error = await refusal(
+      async () => await db.run(sql`select ${sql.join(many, sql.raw(", "))}`),
+    );
+    expect(error).toBeInstanceOf(EdgeSqlShapeError);
+    expect(error.message).toContain("exceed the facade limit of 100");
+  });
+});

--- a/src/backend/__tests__/runtime/lane.test.ts
+++ b/src/backend/__tests__/runtime/lane.test.ts
@@ -11,6 +11,7 @@ import {
   wrapRuntimeMessageBatch,
   wrapTakoserverBindings,
 } from "../../runtime/lane.ts";
+import worker from "../../public.ts";
 import {
   encodeEdgeBytes,
   isEdgeObjectsBinding,
@@ -315,5 +316,47 @@ describe("wrapRuntimeMessageBatch", () => {
     expect(() => wrapRuntimeMessageBatch(facadeBatch(), "cloudflare")).toThrow(
       RuntimeLaneError,
     );
+  });
+});
+
+describe("the published Worker export", () => {
+  const hostedBindings = () => ({
+    YURUCOMMU_RUNTIME_LANE: "takoform-v1",
+    APP_URL: "https://example.test",
+    DB: edgeSql(),
+    KV: edgeKv(),
+  });
+
+  // A queue name the app does not own: `handleYurucommuQueueBatch` settles the
+  // batch and returns, which is enough to prove the whole hosted path — lane
+  // resolution, batch adaptation, and binding wrapping — ran.
+  const foreignBatch = (settle: () => void): EdgeQueueBatch => ({
+    batchId: "b",
+    queue: "not-a-yurucommu-queue",
+    messages: [],
+    acknowledgeAll: settle,
+    retryAll: () => {},
+  });
+
+  test("routes a Takoserver queue event through the hosted lane", async () => {
+    let settled = false;
+    await worker.queue(
+      foreignBatch(() => {
+        settled = true;
+      }),
+      hostedBindings() as never,
+    );
+    expect(settled).toBe(true);
+  });
+
+  test("refuses a Takoserver queue event when the lane is not declared", async () => {
+    const bindings = hostedBindings() as Record<string, unknown>;
+    delete bindings.YURUCOMMU_RUNTIME_LANE;
+    await expect(
+      worker.queue(
+        foreignBatch(() => {}),
+        bindings as never,
+      ),
+    ).rejects.toThrow(RuntimeLaneError);
   });
 });

--- a/src/backend/__tests__/runtime/lane.test.ts
+++ b/src/backend/__tests__/runtime/lane.test.ts
@@ -1,0 +1,319 @@
+import { describe, expect, test } from "bun:test";
+import type { MessageBatch } from "@cloudflare/workers-types";
+
+import {
+  DEFAULT_RUNTIME_LANE,
+  RUNTIME_LANE_VAR,
+  RuntimeLaneError,
+  assertRuntimeLaneBindings,
+  resolveRuntimeLane,
+  wrapRuntimeBindings,
+  wrapRuntimeMessageBatch,
+  wrapTakoserverBindings,
+} from "../../runtime/lane.ts";
+import {
+  encodeEdgeBytes,
+  isEdgeObjectsBinding,
+  isEdgeSqlBinding,
+  isNativeD1Database,
+  isNativeR2Bucket,
+  type EdgeQueueBatch,
+} from "../../runtime/edge-facades.ts";
+
+// --- binding doubles -------------------------------------------------------
+// Each one carries only the method names that make it identifiable, because
+// identification is the whole subject of this file.
+
+const edgeSql = () => ({
+  execute: async () => ({ rows: [], rowsWritten: 0 }),
+  query: async () => ({ rows: [], rowsWritten: 0 }),
+  transaction: async () => [],
+});
+
+const nativeD1 = () => ({
+  prepare: () => ({}),
+  batch: async () => [],
+  exec: async () => ({}),
+  dump: async () => new ArrayBuffer(0),
+});
+
+const edgeKv = () => ({
+  get: async () => null,
+  getWithMetadata: async () => null,
+  put: async () => {},
+  delete: async () => {},
+  list: async () => ({ keys: [], listComplete: true }),
+});
+
+const nativeKv = () => ({
+  // Structurally IDENTICAL to `edgeKv` — that is the point.
+  get: async () => null,
+  getWithMetadata: async () => null,
+  put: async () => {},
+  delete: async () => {},
+  list: async () => ({ keys: [], list_complete: true }),
+});
+
+const edgeObjects = () => ({
+  head: async () => null,
+  get: async (_key: string, _options: unknown) => null,
+  put: async () => ({ etag: "e", size: 0 }),
+  delete: async () => {},
+  list: async () => ({ objects: [], prefixes: [], truncated: false }),
+});
+
+const nativeR2 = () => ({
+  head: async () => null,
+  get: async () => null,
+  put: async () => ({}),
+  delete: async () => {},
+  list: async () => ({ objects: [], truncated: false }),
+  createMultipartUpload: async () => ({}),
+  resumeMultipartUpload: () => ({}),
+});
+
+const edgeQueue = () => ({
+  send: async () => "id",
+  sendBatch: async () => ["id"],
+});
+
+const nativeQueue = () => ({ send: async () => {}, sendBatch: async () => {} });
+
+describe("runtime lane declaration", () => {
+  test("an absent declaration is the Cloudflare lane", () => {
+    expect(resolveRuntimeLane(undefined)).toBe(DEFAULT_RUNTIME_LANE);
+    expect(resolveRuntimeLane(null)).toBe("cloudflare");
+    expect(resolveRuntimeLane("")).toBe("cloudflare");
+  });
+
+  test("accepts the value the app's Takoform module already sets", () => {
+    // deploy/takoform/main.tf sets YURUCOMMU_RUNTIME_LANE = "takoform-v1".
+    expect(resolveRuntimeLane("takoform-v1")).toBe("takoform-v1");
+    expect(resolveRuntimeLane("  takoform-v1  ")).toBe("takoform-v1");
+    expect(resolveRuntimeLane("cloudflare")).toBe("cloudflare");
+  });
+
+  test("refuses a lane it has never heard of rather than defaulting", () => {
+    expect(() => resolveRuntimeLane("takoform-v2")).toThrow(RuntimeLaneError);
+    expect(() => resolveRuntimeLane("takoform-v2")).toThrow(
+      /not a runtime lane this build supports/,
+    );
+    expect(() => resolveRuntimeLane(7)).toThrow(RuntimeLaneError);
+  });
+});
+
+describe("binding identification", () => {
+  test("the database binding is decisive in both directions", () => {
+    expect(isEdgeSqlBinding(edgeSql())).toBe(true);
+    expect(isEdgeSqlBinding(nativeD1())).toBe(false);
+    expect(isNativeD1Database(nativeD1())).toBe(true);
+    expect(isNativeD1Database(edgeSql())).toBe(false);
+  });
+
+  test("an R2 bucket is decisive, and the facade is not mistaken for one", () => {
+    expect(isNativeR2Bucket(nativeR2())).toBe(true);
+    expect(isNativeR2Bucket(edgeObjects())).toBe(false);
+    expect(isEdgeObjectsBinding(edgeObjects())).toBe(true);
+    expect(isEdgeObjectsBinding(nativeR2())).toBe(false);
+  });
+
+  test("the KV and queue bindings CANNOT be told apart, which is why the lane is declared", () => {
+    const shape = (value: object) =>
+      Object.keys(value)
+        .filter((key) => typeof (value as never)[key] === "function")
+        .sort();
+    expect(shape(edgeKv())).toEqual(shape(nativeKv()));
+    expect(shape(edgeQueue())).toEqual(shape(nativeQueue()));
+  });
+});
+
+describe("lane and bindings must agree", () => {
+  test("accepts a matched Takoserver deployment", () => {
+    expect(() =>
+      assertRuntimeLaneBindings("takoform-v1", {
+        DB: edgeSql(),
+        MEDIA: edgeObjects(),
+      }),
+    ).not.toThrow();
+  });
+
+  test("accepts a matched Cloudflare deployment", () => {
+    expect(() =>
+      assertRuntimeLaneBindings("cloudflare", {
+        DB: nativeD1(),
+        MEDIA: nativeR2(),
+      }),
+    ).not.toThrow();
+  });
+
+  test("refuses the hosted lane declared over native Cloudflare bindings", () => {
+    expect(() =>
+      assertRuntimeLaneBindings("takoform-v1", { DB: nativeD1() }),
+    ).toThrow(/native D1Database/);
+    expect(() =>
+      assertRuntimeLaneBindings("takoform-v1", {
+        DB: edgeSql(),
+        MEDIA: nativeR2(),
+      }),
+    ).toThrow(/native R2Bucket/);
+  });
+
+  test("refuses a facade that arrived without its lane declared", () => {
+    expect(() =>
+      assertRuntimeLaneBindings("cloudflare", { DB: edgeSql() }),
+    ).toThrow(RuntimeLaneError);
+    expect(() =>
+      assertRuntimeLaneBindings("cloudflare", { DB: edgeSql() }),
+    ).toThrow(new RegExp(RUNTIME_LANE_VAR));
+  });
+
+  test("refuses a database binding that is neither", () => {
+    expect(() => assertRuntimeLaneBindings("cloudflare", { DB: {} })).toThrow(
+      /neither a D1Database nor/,
+    );
+    expect(() => assertRuntimeLaneBindings("takoform-v1", { DB: {} })).toThrow(
+      /requires env\.DB to be the/,
+    );
+  });
+});
+
+describe("wrapRuntimeBindings", () => {
+  const takoserverEnv = () => ({
+    YURUCOMMU_RUNTIME_LANE: "takoform-v1",
+    APP_URL: "https://example.test",
+    ENCRYPTION_KEY: "k",
+    DB: edgeSql(),
+    KV: edgeKv(),
+    MEDIA: edgeObjects(),
+    DELIVERY_QUEUE: edgeQueue(),
+    DELIVERY_DLQ: edgeQueue(),
+  });
+
+  test("builds every runtime port from the facades", () => {
+    const env = wrapRuntimeBindings(takoserverEnv() as never) as Record<
+      string,
+      unknown
+    >;
+    expect(env.DB_INSTANCE).toBeDefined();
+    expect(typeof (env.KV as { get: unknown }).get).toBe("function");
+    expect(typeof (env.MEDIA as { head: unknown }).head).toBe("function");
+    expect(typeof (env.DELIVERY_QUEUE as { send: unknown }).send).toBe(
+      "function",
+    );
+    expect(typeof (env.DELIVERY_DLQ as { send: unknown }).send).toBe(
+      "function",
+    );
+    // Plain variables, including the lane marker itself, pass through.
+    expect(env.APP_URL).toBe("https://example.test");
+    expect(env.YURUCOMMU_RUNTIME_LANE).toBe("takoform-v1");
+    // The raw bindings do not survive into app-visible Env.
+    expect(env.DB).toBeUndefined();
+  });
+
+  test("leaves an unbound optional binding unbound", () => {
+    const bindings = takoserverEnv() as Record<string, unknown>;
+    delete bindings.MEDIA;
+    delete bindings.DELIVERY_QUEUE;
+    delete bindings.DELIVERY_DLQ;
+    const env = wrapTakoserverBindings(bindings as never) as Record<
+      string,
+      unknown
+    >;
+    expect(env.MEDIA).toBeUndefined();
+    expect(env.DELIVERY_QUEUE).toBeUndefined();
+    expect(env.DELIVERY_DLQ).toBeUndefined();
+    expect(env.KV).toBeDefined();
+  });
+
+  test("wraps native bindings when no lane is declared", () => {
+    const env = wrapRuntimeBindings({
+      APP_URL: "https://example.test",
+      DB: nativeD1(),
+      KV: nativeKv(),
+    } as never) as Record<string, unknown>;
+    expect(env.DB_INSTANCE).toBeDefined();
+    expect(env.KV).toBeDefined();
+  });
+
+  test("refuses to start when the declaration and the bindings disagree", () => {
+    expect(() =>
+      wrapRuntimeBindings({
+        YURUCOMMU_RUNTIME_LANE: "takoform-v1",
+        DB: nativeD1(),
+        KV: nativeKv(),
+      } as never),
+    ).toThrow(RuntimeLaneError);
+
+    expect(() =>
+      wrapRuntimeBindings({
+        DB: edgeSql(),
+        KV: edgeKv(),
+      } as never),
+    ).toThrow(RuntimeLaneError);
+
+    expect(() =>
+      wrapRuntimeBindings({
+        YURUCOMMU_RUNTIME_LANE: "somewhere-else",
+        DB: edgeSql(),
+        KV: edgeKv(),
+      } as never),
+    ).toThrow(/not a runtime lane this build supports/);
+  });
+});
+
+describe("wrapRuntimeMessageBatch", () => {
+  const facadeBatch = (): EdgeQueueBatch => ({
+    batchId: "b",
+    queue: "yurucommu-delivery",
+    messages: [
+      {
+        id: "m",
+        timestampMillis: 1,
+        attempts: 1,
+        body: encodeEdgeBytes(new TextEncoder().encode('{"n":1}')),
+        acknowledge: () => {},
+        retry: () => {},
+      },
+    ],
+    acknowledgeAll: () => {},
+    retryAll: () => {},
+  });
+
+  const cloudflareBatch = () =>
+    ({
+      queue: "yurucommu-delivery",
+      messages: [
+        {
+          id: "m",
+          timestamp: new Date(1),
+          body: { n: 1 },
+          attempts: 1,
+          ack: () => {},
+          retry: () => {},
+        },
+      ],
+      ackAll: () => {},
+      retryAll: () => {},
+    }) as unknown as MessageBatch<{ n: number }>;
+
+  test("adapts each lane's own batch", () => {
+    const hosted = wrapRuntimeMessageBatch<{ n: number }>(
+      facadeBatch(),
+      "takoform-v1",
+    );
+    expect(hosted.queue).toBe("yurucommu-delivery");
+    expect(hosted.messages[0]!.body).toEqual({ n: 1 });
+
+    const native = wrapRuntimeMessageBatch<{ n: number }>(cloudflareBatch());
+    expect(native.messages[0]!.body).toEqual({ n: 1 });
+  });
+
+  test("refuses a batch from the other lane", () => {
+    expect(() =>
+      wrapRuntimeMessageBatch(cloudflareBatch(), "takoform-v1"),
+    ).toThrow(RuntimeLaneError);
+    expect(() => wrapRuntimeMessageBatch(facadeBatch(), "cloudflare")).toThrow(
+      RuntimeLaneError,
+    );
+  });
+});

--- a/src/backend/index.ts
+++ b/src/backend/index.ts
@@ -5,9 +5,12 @@ import type { Env, EnvVars, Variables } from "./types.ts";
 import { extractActorFromSession } from "./lib/session-actor.ts";
 import { isBackendPath } from "./lib/backend-paths.ts";
 import {
-  wrapCloudflareBindings,
-  wrapCloudflareMessageBatch,
-} from "./runtime/cloudflare.ts";
+  resolveRuntimeLane,
+  wrapRuntimeBindings,
+  wrapRuntimeMessageBatch,
+  type TakoserverWorkerBindings,
+} from "./runtime/lane.ts";
+import type { EdgeQueueBatch } from "./runtime/edge-facades.ts";
 import {
   getMobileOidcAudience,
   getOidcClientCredentials,
@@ -992,15 +995,17 @@ export async function handleYurucommuQueueBatch(
   batch.ackAll();
 }
 
-type WorkerBindings = EnvVars & {
-  DB: D1Database;
-  MEDIA?: R2Bucket;
-  KV: KVNamespace;
+/**
+ * Bindings that are not the runtime ports, and so pass through whichever lane
+ * wrapper runs. Durable Objects live here: Takoform's Worker Version has no
+ * Durable Object binding, so on the Takoserver lane both are simply unbound and
+ * the routes that need them answer 503, exactly as on a Cloudflare deployment
+ * that did not declare them.
+ */
+type PassthroughBindings = EnvVars & {
   ASSETS?: Fetcher;
-  DELIVERY_QUEUE?: Queue<DeliveryQueueMessageV1>;
-  DELIVERY_DLQ?: Queue<DeliveryDlqMessageV1>;
-  // Signaling hub Durable Object namespace (call feature). wrapCloudflareBindings
-  // spreads it through untouched (it is not DB/MEDIA/KV/ASSETS) so app code and
+  // Signaling hub Durable Object namespace (call feature). The lane wrappers
+  // spread it through untouched (it is not DB/MEDIA/KV/ASSETS) so app code and
   // the rtc routes read it as c.env.CALL_SIGNALING.
   CALL_SIGNALING?: DurableObjectNamespace;
   // Per-user realtime event stream Durable Object namespace. Same pass-through
@@ -1008,6 +1013,26 @@ type WorkerBindings = EnvVars & {
   // and clients fall back to polling.
   REALTIME_STREAM?: DurableObjectNamespace;
 };
+
+/**
+ * What this Worker may be handed.
+ *
+ * Native Cloudflare bindings, or the portable facades a Takoserver Host
+ * projects. `wrapRuntimeBindings` decides which by reading the deployment's
+ * declared `YURUCOMMU_RUNTIME_LANE` and proving it against the bindings that
+ * actually arrived; see runtime/lane.ts.
+ */
+type WorkerBindings = PassthroughBindings &
+  (
+    | {
+        DB: D1Database;
+        MEDIA?: R2Bucket;
+        KV: KVNamespace;
+        DELIVERY_QUEUE?: Queue<DeliveryQueueMessageV1>;
+        DELIVERY_DLQ?: Queue<DeliveryDlqMessageV1>;
+      }
+    | TakoserverWorkerBindings
+  );
 
 function isMaterializedRuntimeEnv(
   bindings: WorkerBindings | Env,
@@ -1021,16 +1046,19 @@ export default {
     bindings: WorkerBindings,
     ctx: ExecutionContext,
   ): Promise<Response> {
-    return app.fetch(request, wrapCloudflareBindings(bindings), ctx);
+    return app.fetch(request, wrapRuntimeBindings(bindings), ctx);
   },
 
   async queue(
-    batch: MessageBatch<DeliveryQueueMessageV1 | DeliveryDlqMessageV1>,
+    batch:
+      | MessageBatch<DeliveryQueueMessageV1 | DeliveryDlqMessageV1>
+      | EdgeQueueBatch,
     bindings: WorkerBindings,
   ): Promise<void> {
+    const lane = resolveRuntimeLane(bindings.YURUCOMMU_RUNTIME_LANE);
     return handleYurucommuQueueBatch(
-      wrapCloudflareMessageBatch(batch),
-      wrapCloudflareBindings(bindings),
+      wrapRuntimeMessageBatch(batch, lane),
+      wrapRuntimeBindings(bindings),
     );
   },
 
@@ -1041,7 +1069,7 @@ export default {
   ): Promise<void> {
     const env = isMaterializedRuntimeEnv(bindings)
       ? bindings
-      : wrapCloudflareBindings(bindings);
+      : wrapRuntimeBindings(bindings);
     await runYurucommuRetention(env);
   },
 };

--- a/src/backend/public.ts
+++ b/src/backend/public.ts
@@ -36,6 +36,60 @@ export {
   createManagedRelationalDatabase,
   type ManagedRelationalDatabaseOptions,
 } from "./runtime/managed-relational.ts";
+// Takoserver-hosted lane: the portable binding facades a Worker Version
+// published through Takoform receives, and the lane selector that proves a
+// deployment's declared lane against the bindings that actually arrived.
+export {
+  DEFAULT_RUNTIME_LANE,
+  RUNTIME_LANE_VAR,
+  RUNTIME_LANES,
+  RuntimeLaneError,
+  assertRuntimeLaneBindings,
+  resolveRuntimeLane,
+  type CloudflareWorkerBindings,
+  type RuntimeLane,
+  type TakoserverWorkerBindings,
+  wrapRuntimeBindings,
+  wrapRuntimeMessageBatch,
+  wrapTakoserverBindings,
+} from "./runtime/lane.ts";
+export {
+  EDGE_KV_MAX_EXPIRATION_TTL_SECONDS,
+  EDGE_KV_MIN_EXPIRATION_TTL_SECONDS,
+  isEdgeObjectsBinding,
+  isEdgeQueueBatch,
+  isEdgeSqlBinding,
+  isNativeD1Database,
+  isNativeR2Bucket,
+  type EdgeKvBinding,
+  type EdgeObjectsBinding,
+  type EdgeQueueBatch,
+  type EdgeQueueBinding,
+  type EdgeSqlBinding,
+  type EdgeSqlResult,
+  type EdgeSqlValue,
+} from "./runtime/edge-facades.ts";
+export {
+  EdgeKeyValueOptionError,
+  EdgeKeyValueStore,
+  wrapEdgeKv,
+} from "./runtime/edge-kv.ts";
+export {
+  EdgeSqlColumnMismatchError,
+  EdgeSqlShapeError,
+  createEdgeSqlDatabase,
+  rewriteProjection,
+} from "./runtime/edge-sql.ts";
+export {
+  EdgeQueueShapeError,
+  wrapEdgeMessageBatch,
+  wrapEdgeQueue,
+} from "./runtime/edge-queue.ts";
+export {
+  EdgeObjectStorage,
+  EdgeObjectsShapeError,
+  wrapEdgeObjects,
+} from "./runtime/edge-objects.ts";
 export type {
   IKeyValueStore,
   IObjectStorage,

--- a/src/backend/public.ts
+++ b/src/backend/public.ts
@@ -72,6 +72,7 @@ export {
 export {
   EdgeKeyValueOptionError,
   EdgeKeyValueStore,
+  EdgeKeyValueValueError,
   wrapEdgeKv,
 } from "./runtime/edge-kv.ts";
 export {

--- a/src/backend/routes/media.ts
+++ b/src/backend/routes/media.ts
@@ -236,6 +236,9 @@ media.post("/upload", async (c) => {
     if (isVideo) {
       await media.put(r2Key, file.stream(), {
         httpMetadata: { contentType },
+        // Declared so a portable object-storage binding can enforce the length
+        // while streaming instead of buffering the whole video to discover it.
+        contentLength: file.size,
       });
     } else {
       const original = new Uint8Array(await file.arrayBuffer());

--- a/src/backend/runtime/edge-facades.ts
+++ b/src/backend/runtime/edge-facades.ts
@@ -1,0 +1,336 @@
+/**
+ * The portable binding facades a Takoserver-hosted Worker receives.
+ *
+ * A Worker Version published through Takoform onto a Takoserver Host does not
+ * get Cloudflare's native `KVNamespace` / `D1Database` / `Queue` / `R2Bucket`
+ * objects. The Host's generated entrypoint replaces `env` with an object whose
+ * bindings are the exact facades named by the Interface the Version declared —
+ * `edge.kv@1.0.0`, `edge.sql@1.0.0`, `edge.queue@1.0.0`, `edge.objects@1.0.0`.
+ * The managed Cloudflare backend and the self-host backend project the SAME
+ * facade: same methods, same option keys, same error names. Takoserver's
+ * ADR 0005 states this explicitly for object storage, and its self-host wrapper
+ * repeats it for KV and SQL.
+ *
+ * This module is a TYPE MIRROR of that contract plus the structural probes the
+ * lane selector uses. It deliberately contains no behaviour: the adapters that
+ * map a facade onto this repo's runtime ports live in `edge-kv.ts`,
+ * `edge-sql.ts`, `edge-queue.ts`, and `edge-objects.ts`.
+ *
+ * Source of truth (read, do not re-derive from memory):
+ *   takoserver `src/providers/cloudflare-managed-worker-wrapper.ts`
+ *     — `projectEnv`, `createKvAdapter`, `createSqlAdapter`,
+ *       `createQueueAdapter`, `createEdgeObjectsR2Adapter`
+ *   takoserver `src/providers/selfhost-worker-wrapper.ts`
+ *     — `projectEnv`, `createKvAdapter`, `createSqlAdapter`
+ *
+ * Every method rejects with an `Error` whose `name` is the portable error code
+ * (`invalid_key`, `invalid_value`, `value_too_large`, `metadata_too_large`,
+ * `invalid_cursor`, `invalid_argument`, `sql_error`, `numeric_out_of_range`,
+ * `busy`, `not_found`, `precondition_failed`, `range_not_satisfiable`,
+ * `invalid_body`, `message_too_large`, `batch_too_large`, `invalid_part`,
+ * `already_settled`, `backend_unavailable`). The adapters let those propagate
+ * unchanged so a caller sees the Host's own vocabulary.
+ */
+
+/** Limits the facades enforce. Mirrored so the adapters can fail before the
+ *  round-trip instead of surfacing an opaque `invalid_*` from the Host. */
+export const EDGE_KV_MAX_KEY_BYTES = 467;
+export const EDGE_KV_MAX_VALUE_BYTES = 26214400;
+/** `expirationTtlSeconds` is rejected outside this range by both backends. */
+export const EDGE_KV_MIN_EXPIRATION_TTL_SECONDS = 60;
+export const EDGE_KV_MAX_EXPIRATION_TTL_SECONDS = 315360000;
+export const EDGE_KV_MAX_LIST_LIMIT = 1000;
+export const EDGE_SQL_MAX_STATEMENTS = 100;
+export const EDGE_SQL_MAX_PARAMETERS = 100;
+export const EDGE_SQL_MAX_ROWS = 10000;
+export const EDGE_SQL_MAX_COLUMNS = 100;
+export const EDGE_QUEUE_MAX_MESSAGES = 100;
+
+/** A byte string on the wire. The facades never hand out raw `Uint8Array`. */
+export interface EdgeEncodedBytes {
+  readonly encoding: "base64";
+  readonly data: string;
+}
+
+/** Exactly what `edge.sql` accepts as a bound parameter and returns in a row. */
+export type EdgeSqlValue = null | number | string | EdgeEncodedBytes;
+
+export interface EdgeSqlStatement {
+  readonly sql: string;
+  readonly params?: readonly EdgeSqlValue[];
+}
+
+/**
+ * One statement's result. `rows` are RECORDS keyed by result-column name, not
+ * positional arrays — the single most consequential difference from D1, and the
+ * reason `edge-sql.ts` has to rewrite the projection list before it can hand
+ * anything to Drizzle.
+ */
+export interface EdgeSqlResult {
+  readonly rows: readonly Readonly<Record<string, EdgeSqlValue>>[];
+  readonly rowsWritten: number;
+}
+
+/** `edge.sql@1.0.0`. */
+export interface EdgeSqlBinding {
+  execute(
+    sql: string,
+    params?: readonly EdgeSqlValue[],
+  ): Promise<EdgeSqlResult>;
+  /** `execute` restricted to statements that write nothing. */
+  query(sql: string, params?: readonly EdgeSqlValue[]): Promise<EdgeSqlResult>;
+  /** All-or-none. 1..100 statements, ordered, one Host round trip. */
+  transaction(
+    statements: readonly EdgeSqlStatement[],
+  ): Promise<readonly EdgeSqlResult[]>;
+}
+
+export interface EdgeKvPutOptions {
+  readonly expirationTtlSeconds?: number;
+  /** String values only; the Host projects a record of strings. */
+  readonly metadata?: Record<string, string>;
+}
+
+export interface EdgeKvListOptions {
+  readonly prefix?: string;
+  readonly cursor?: string;
+  readonly limit?: number;
+}
+
+/**
+ * A listed key carries its NAME ONLY. Neither backend returns the expiration or
+ * the metadata it stored, so `IKeyValueStore.list` reports those as absent on
+ * this lane.
+ */
+export interface EdgeKvListResult {
+  readonly keys: readonly { readonly name: string }[];
+  readonly listComplete: boolean;
+  readonly cursor?: string;
+}
+
+/** `edge.kv@1.0.0`. Values are always bytes; there is no `type` option. */
+export interface EdgeKvBinding {
+  get(key: string): Promise<ArrayBuffer | null>;
+  getWithMetadata(key: string): Promise<{
+    readonly value: ArrayBuffer;
+    readonly metadata?: Record<string, string>;
+  } | null>;
+  put(
+    key: string,
+    value: string | ArrayBuffer | ArrayBufferView,
+    options?: EdgeKvPutOptions,
+  ): Promise<void>;
+  delete(key: string): Promise<void>;
+  list(options?: EdgeKvListOptions): Promise<EdgeKvListResult>;
+}
+
+export interface EdgeQueueSendOptions {
+  readonly delaySeconds?: number;
+}
+
+export interface EdgeQueueBatchItem {
+  readonly body: string | ArrayBuffer | ArrayBufferView;
+  readonly delaySeconds?: number;
+}
+
+/**
+ * `edge.queue@1.0.0` producer. Bodies are BYTES — there is no structured-clone
+ * path, so a JavaScript object has to be serialized by the caller. `send`
+ * returns the Host's acceptance id, which is not a provider dedupe id.
+ */
+export interface EdgeQueueBinding {
+  send(
+    body: string | ArrayBuffer | ArrayBufferView,
+    options?: EdgeQueueSendOptions,
+  ): Promise<string>;
+  sendBatch(
+    messages: readonly EdgeQueueBatchItem[],
+  ): Promise<readonly string[]>;
+}
+
+/** One message as the Host hands it to a declared `queue` handler. */
+export interface EdgeQueueMessage {
+  readonly id: string;
+  readonly timestampMillis: number;
+  readonly attempts: number;
+  readonly body: EdgeEncodedBytes;
+  acknowledge(): void;
+  /** `delaySeconds`, when given, must be >= 1. */
+  retry(options?: { readonly delaySeconds?: number }): void;
+}
+
+export interface EdgeQueueBatch {
+  readonly batchId: string;
+  readonly queue: string;
+  readonly messages: readonly EdgeQueueMessage[];
+  acknowledgeAll(): void;
+  retryAll(options?: { readonly delaySeconds?: number }): void;
+}
+
+export interface EdgeObjectMetadata {
+  readonly etag: string;
+  readonly size: number;
+  readonly contentType?: string;
+  readonly uploadedAtMillis?: number;
+}
+
+export interface EdgeObjectBody extends EdgeObjectMetadata {
+  readonly body: ReadableStream;
+  readonly partial: boolean;
+  readonly range?: { readonly offset: number; readonly length: number };
+}
+
+export interface EdgeObjectListResult {
+  readonly objects: readonly (EdgeObjectMetadata & { readonly key: string })[];
+  readonly prefixes: readonly string[];
+  readonly truncated: boolean;
+  readonly cursor?: string;
+}
+
+/**
+ * `edge.objects@1.0.0`. Note the fixed arities — the Host counts
+ * `arguments.length`, so `get(key)` with one argument is a type error and the
+ * adapter must pass `undefined` explicitly. There is no `customMetadata`, and a
+ * streaming `put` requires `contentLength`.
+ */
+export interface EdgeObjectsBinding {
+  head(key: string): Promise<EdgeObjectMetadata | null>;
+  get(
+    key: string,
+    options:
+      undefined | { readonly range?: { offset: number; length?: number } },
+  ): Promise<EdgeObjectBody | null>;
+  put(
+    key: string,
+    body: string | ArrayBuffer | ArrayBufferView | ReadableStream,
+    options:
+      | undefined
+      | {
+          readonly contentLength?: number;
+          readonly contentType?: string;
+        },
+  ): Promise<{ readonly etag: string; readonly size: number }>;
+  delete(key: string): Promise<void>;
+  list(
+    options:
+      | undefined
+      | {
+          readonly prefix?: string;
+          readonly delimiter?: string;
+          readonly cursor?: string;
+          readonly limit?: number;
+        },
+  ): Promise<EdgeObjectListResult>;
+}
+
+function hasMethods(value: unknown, names: readonly string[]): boolean {
+  if (typeof value !== "object" || value === null) return false;
+  const record = value as Record<string, unknown>;
+  for (const name of names) {
+    if (typeof record[name] !== "function") return false;
+  }
+  return true;
+}
+
+/**
+ * Structural probes.
+ *
+ * Only SOME bindings can be told apart by shape, and the difference matters:
+ *
+ *   decisive   `DB`     — `execute`/`query`/`transaction` (facade) against
+ *                         `prepare`/`batch` (D1). Disjoint method sets.
+ *   decisive   `MEDIA`  — R2 carries the multipart helpers the facade omits.
+ *   decisive   a queue *batch* — `acknowledgeAll` (facade) against `ackAll`
+ *                         (Cloudflare `MessageBatch`).
+ *   AMBIGUOUS  `KV`     — `edge.kv` and `KVNamespace` expose the same five
+ *                         method names.
+ *   AMBIGUOUS  a queue *producer* — both are `send`/`sendBatch`.
+ *
+ * That is why the lane is a DECLARED variable rather than something sniffed:
+ * two of the five bindings cannot be identified at all. The declaration is then
+ * cross-checked against the decisive bindings, so a Worker whose var and whose
+ * bindings disagree refuses to start instead of calling `kv.get(key, {type})`
+ * on a facade that would silently treat the options object as nothing.
+ */
+export function isEdgeSqlBinding(value: unknown): value is EdgeSqlBinding {
+  return (
+    hasMethods(value, ["execute", "query", "transaction"]) &&
+    typeof (value as Record<string, unknown>).prepare !== "function"
+  );
+}
+
+/** Cloudflare's `D1Database` is the `prepare`/`batch`/`exec` shape. */
+export function isNativeD1Database(value: unknown): boolean {
+  return (
+    hasMethods(value, ["prepare", "batch"]) &&
+    typeof (value as Record<string, unknown>).execute !== "function"
+  );
+}
+
+export function isEdgeQueueBatch(value: unknown): value is EdgeQueueBatch {
+  return (
+    hasMethods(value, ["acknowledgeAll", "retryAll"]) &&
+    Array.isArray((value as Record<string, unknown>).messages)
+  );
+}
+
+export function isEdgeObjectsBinding(
+  value: unknown,
+): value is EdgeObjectsBinding {
+  return (
+    hasMethods(value, ["head", "get", "put", "delete", "list"]) &&
+    // R2 exposes multipart helpers on the binding itself; the facade does not
+    // give a bucket-shaped object those names.
+    typeof (value as Record<string, unknown>).createMultipartUpload !==
+      "function" &&
+    // An already-adapted `IObjectStorage` has the same five names. The facade
+    // is told apart by arity, which is part of its contract: the Host checks
+    // `arguments.length`, so `get` and `list` take their options slot even when
+    // it is `undefined`, while the port's `get(key)` takes one argument.
+    (value as { get: (...args: unknown[]) => unknown }).get.length === 2
+  );
+}
+
+/** Cloudflare's `R2Bucket`. */
+export function isNativeR2Bucket(value: unknown): boolean {
+  return hasMethods(value, [
+    "head",
+    "get",
+    "put",
+    "delete",
+    "list",
+    "createMultipartUpload",
+  ]);
+}
+
+/** Decode one `{encoding:"base64"}` value into bytes. */
+export function decodeEdgeBytes(value: EdgeEncodedBytes): Uint8Array {
+  const binary = atob(value.data);
+  const bytes = new Uint8Array(binary.length);
+  for (let index = 0; index < binary.length; index += 1) {
+    bytes[index] = binary.charCodeAt(index);
+  }
+  return bytes;
+}
+
+/** Encode bytes into the facade's wire value. */
+export function encodeEdgeBytes(bytes: Uint8Array): EdgeEncodedBytes {
+  let binary = "";
+  // Chunked so a large blob does not blow the argument limit of `apply`.
+  const CHUNK = 0x8000;
+  for (let index = 0; index < bytes.length; index += CHUNK) {
+    binary += String.fromCharCode(
+      ...bytes.subarray(index, Math.min(index + CHUNK, bytes.length)),
+    );
+  }
+  return { encoding: "base64", data: btoa(binary) };
+}
+
+export function isEdgeEncodedBytes(value: unknown): value is EdgeEncodedBytes {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    (value as EdgeEncodedBytes).encoding === "base64" &&
+    typeof (value as EdgeEncodedBytes).data === "string"
+  );
+}

--- a/src/backend/runtime/edge-kv.ts
+++ b/src/backend/runtime/edge-kv.ts
@@ -1,0 +1,193 @@
+/**
+ * `edge.kv@1.0.0` → {@link IKeyValueStore}.
+ *
+ * The app's port and the facade disagree in three places, and each disagreement
+ * is resolved here rather than at the call sites:
+ *
+ *  - READS. `IKeyValueStore.get` selects `text` / `json` / `arrayBuffer`; the
+ *    facade always returns bytes. The decode happens here.
+ *  - EXPIRY. The port carries Cloudflare's pair (`expirationTtl` relative,
+ *    `expiration` absolute); the facade accepts only `expirationTtlSeconds`. An
+ *    absolute instant is converted against the current clock.
+ *  - LISTING. The facade returns `{name}` only and calls the flag
+ *    `listComplete`; the port expects `list_complete` and optional
+ *    `expiration` / `metadata`. Those two fields are ABSENT on this lane — the
+ *    Host does not return them — so nothing may be inferred from their absence.
+ */
+
+import type { IKeyValueStore } from "./types.ts";
+import {
+  EDGE_KV_MAX_EXPIRATION_TTL_SECONDS,
+  EDGE_KV_MIN_EXPIRATION_TTL_SECONDS,
+  type EdgeKvBinding,
+  type EdgeKvPutOptions,
+} from "./edge-facades.ts";
+import { nowSeconds, readStream } from "./shared.ts";
+
+/** A put option the facade cannot express. */
+export class EdgeKeyValueOptionError extends TypeError {
+  constructor(message: string) {
+    super(message);
+    this.name = "EdgeKeyValueOptionError";
+  }
+}
+
+/**
+ * Resolve the port's expiry pair into the single value `edge.kv` takes.
+ *
+ * `expiration` is an absolute UNIX second; the facade has no equivalent, so it
+ * becomes the remaining seconds from now. Both backends reject a TTL under 60
+ * seconds (as does Cloudflare KV itself), so a shorter one is refused here with
+ * a message that names the caller's own value instead of surfacing the Host's
+ * bare `invalid_value`.
+ */
+export function resolveEdgeKvExpirationTtl(
+  options?: { readonly expirationTtl?: number; readonly expiration?: number },
+  now: () => number = nowSeconds,
+): number | undefined {
+  const ttl =
+    options?.expirationTtl !== undefined
+      ? options.expirationTtl
+      : options?.expiration !== undefined
+        ? Math.ceil(options.expiration - now())
+        : undefined;
+  if (ttl === undefined) return undefined;
+  const seconds = Math.ceil(ttl);
+  if (!Number.isSafeInteger(seconds)) {
+    throw new EdgeKeyValueOptionError(
+      `edge.kv: expiration resolves to ${ttl}, which is not a whole number of seconds`,
+    );
+  }
+  if (seconds < EDGE_KV_MIN_EXPIRATION_TTL_SECONDS) {
+    throw new EdgeKeyValueOptionError(
+      `edge.kv: expiration resolves to ${seconds}s, under the ` +
+        `${EDGE_KV_MIN_EXPIRATION_TTL_SECONDS}s floor both Takoserver and ` +
+        `Cloudflare KV enforce; store a longer-lived entry or carry the ` +
+        `deadline inside the value`,
+    );
+  }
+  if (seconds > EDGE_KV_MAX_EXPIRATION_TTL_SECONDS) {
+    throw new EdgeKeyValueOptionError(
+      `edge.kv: expiration resolves to ${seconds}s, over the ` +
+        `${EDGE_KV_MAX_EXPIRATION_TTL_SECONDS}s ceiling`,
+    );
+  }
+  return seconds;
+}
+
+/**
+ * The facade stores a record of STRINGS. The port's `Record<string, unknown>`
+ * is therefore only usable when every value already is one; anything else is
+ * refused rather than stringified, because a silent `String(value)` would round
+ * -trip differently on the two lanes.
+ */
+function projectMetadata(
+  metadata: Record<string, unknown> | undefined,
+): Record<string, string> | undefined {
+  if (metadata === undefined) return undefined;
+  const projected: Record<string, string> = {};
+  for (const [key, value] of Object.entries(metadata)) {
+    if (typeof value !== "string") {
+      throw new EdgeKeyValueOptionError(
+        `edge.kv: metadata."${key}" is ${typeof value}; the facade stores ` +
+          `string values only`,
+      );
+    }
+    projected[key] = value;
+  }
+  return projected;
+}
+
+async function toBytes(
+  value: string | ArrayBuffer | ReadableStream,
+): Promise<string | ArrayBuffer | Uint8Array> {
+  if (typeof value === "string" || value instanceof ArrayBuffer) return value;
+  return await readStream(value as ReadableStream<Uint8Array>);
+}
+
+export class EdgeKeyValueStore implements IKeyValueStore {
+  constructor(
+    private readonly kv: EdgeKvBinding,
+    private readonly now: () => number = nowSeconds,
+  ) {}
+
+  get(key: string, options?: { type?: "text" }): Promise<string | null>;
+  get<T = unknown>(key: string, options: { type: "json" }): Promise<T | null>;
+  get(
+    key: string,
+    options: { type: "arrayBuffer" },
+  ): Promise<ArrayBuffer | null>;
+  async get(
+    key: string,
+    options?: { type?: "text" | "json" | "arrayBuffer" },
+  ): Promise<string | ArrayBuffer | unknown | null> {
+    const value = await this.kv.get(key);
+    if (value === null) return null;
+    const type = options?.type ?? "text";
+    if (type === "arrayBuffer") return value;
+    const text = new TextDecoder().decode(value);
+    if (type === "json") {
+      // Cloudflare KV returns null for a stored value that is not JSON; the
+      // facade has no typed read, so the same tolerance is reproduced here
+      // rather than turning a poisoned entry into a request failure.
+      try {
+        return JSON.parse(text) as unknown;
+      } catch {
+        return null;
+      }
+    }
+    return text;
+  }
+
+  async put(
+    key: string,
+    value: string | ArrayBuffer | ReadableStream,
+    options?: {
+      expirationTtl?: number;
+      expiration?: number;
+      metadata?: Record<string, unknown>;
+    },
+  ): Promise<void> {
+    const expirationTtlSeconds = resolveEdgeKvExpirationTtl(options, this.now);
+    const metadata = projectMetadata(options?.metadata);
+    const put: EdgeKvPutOptions = {
+      ...(expirationTtlSeconds === undefined ? {} : { expirationTtlSeconds }),
+      ...(metadata === undefined ? {} : { metadata }),
+    };
+    await this.kv.put(key, await toBytes(value), put);
+  }
+
+  async delete(key: string): Promise<void> {
+    await this.kv.delete(key);
+  }
+
+  async list(options?: {
+    prefix?: string;
+    limit?: number;
+    cursor?: string;
+  }): Promise<{
+    keys: Array<{ name: string; expiration?: number; metadata?: unknown }>;
+    list_complete: boolean;
+    cursor?: string;
+  }> {
+    const result = await this.kv.list({
+      ...(options?.prefix === undefined ? {} : { prefix: options.prefix }),
+      ...(options?.cursor === undefined ? {} : { cursor: options.cursor }),
+      ...(options?.limit === undefined ? {} : { limit: options.limit }),
+    });
+    return {
+      keys: result.keys.map((entry) => ({ name: entry.name })),
+      list_complete: result.listComplete,
+      // The facade omits the cursor once the listing is complete; the port
+      // says the same thing with `undefined`.
+      cursor: result.listComplete ? undefined : result.cursor,
+    };
+  }
+}
+
+export function wrapEdgeKv(
+  kv: EdgeKvBinding,
+  now?: () => number,
+): IKeyValueStore {
+  return new EdgeKeyValueStore(kv, now);
+}

--- a/src/backend/runtime/edge-kv.ts
+++ b/src/backend/runtime/edge-kv.ts
@@ -32,6 +32,14 @@ export class EdgeKeyValueOptionError extends TypeError {
   }
 }
 
+/** A stored value could not be read back in the requested shape. */
+export class EdgeKeyValueValueError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "EdgeKeyValueValueError";
+  }
+}
+
 /**
  * Resolve the port's expiry pair into the single value `edge.kv` takes.
  *
@@ -127,13 +135,16 @@ export class EdgeKeyValueStore implements IKeyValueStore {
     if (type === "arrayBuffer") return value;
     const text = new TextDecoder().decode(value);
     if (type === "json") {
-      // Cloudflare KV returns null for a stored value that is not JSON; the
-      // facade has no typed read, so the same tolerance is reproduced here
-      // rather than turning a poisoned entry into a request failure.
+      // A present-but-unparseable entry is a fault, not a miss: reporting it as
+      // `null` would be indistinguishable from "no such key" and would silently
+      // reset whatever state the entry held. The other lanes in this repo
+      // (MemoryKV, the managed runtime) both raise here too.
       try {
         return JSON.parse(text) as unknown;
-      } catch {
-        return null;
+      } catch (error) {
+        throw new EdgeKeyValueValueError(
+          `edge.kv: "${key}" is present but is not JSON: ${String(error)}`,
+        );
       }
     }
     return text;

--- a/src/backend/runtime/edge-objects.ts
+++ b/src/backend/runtime/edge-objects.ts
@@ -1,0 +1,165 @@
+/**
+ * `edge.objects@1.0.0` → {@link IObjectStorage}.
+ *
+ * The facade is deliberately narrower than R2, and the narrow spots are the
+ * interesting ones:
+ *
+ *  - NO `customMetadata`. Only `contentType` survives a round trip. Nothing in
+ *    this repo writes custom metadata, so rather than dropping it silently a
+ *    caller that starts is refused.
+ *  - FIXED ARITIES. The Host counts `arguments.length`, so `get`, `put`, and
+ *    `list` are always called with their full argument list even when the
+ *    options are absent.
+ *  - A STREAMING `put` NEEDS `contentLength`. ADR 0005 is explicit that a Host
+ *    enforces the declared count while streaming and never buffers a body to
+ *    discover its size. `IObjectStorage.put` therefore carries an optional
+ *    `contentLength`; a stream that arrives without one is buffered HERE, in
+ *    the Worker, which is the honest cost of not knowing the size.
+ *  - `delete` TAKES ONE KEY. The port's array form becomes a sequence of calls,
+ *    which is not atomic — the same as R2's, which also has no transaction.
+ *
+ * AVAILABILITY: `edge.objects` is projected by the managed Cloudflare backend
+ * (`createEdgeObjectsR2Adapter`). The self-host backend projects only
+ * `edge.kv` and `edge.sql`, so a self-hosted Worker has no object binding and
+ * the core's existing "object storage unavailable" behaviour applies.
+ */
+
+import type {
+  IObjectStorage,
+  ListObjectsResult,
+  ObjectMetadata,
+  StorageObject,
+} from "./types.ts";
+import type { EdgeObjectMetadata, EdgeObjectsBinding } from "./edge-facades.ts";
+import { readStream } from "./shared.ts";
+
+/** A request the facade cannot express. */
+export class EdgeObjectsShapeError extends TypeError {
+  constructor(message: string) {
+    super(message);
+    this.name = "EdgeObjectsShapeError";
+  }
+}
+
+function metadataOf(value: EdgeObjectMetadata): ObjectMetadata {
+  return {
+    contentType: value.contentType,
+    contentLength: value.size,
+    etag: value.etag,
+    httpMetadata: value.contentType
+      ? { contentType: value.contentType }
+      : undefined,
+  };
+}
+
+export class EdgeObjectStorage implements IObjectStorage {
+  constructor(private readonly bucket: EdgeObjectsBinding) {}
+
+  async put(
+    key: string,
+    value: ReadableStream | ArrayBuffer | string,
+    options?: {
+      httpMetadata?: ObjectMetadata["httpMetadata"];
+      customMetadata?: Record<string, string>;
+      contentLength?: number;
+    },
+  ): Promise<void> {
+    if (
+      options?.customMetadata !== undefined &&
+      Object.keys(options.customMetadata).length > 0
+    ) {
+      throw new EdgeObjectsShapeError(
+        "edge.objects: customMetadata has no portable equivalent; carry the " +
+          "attribute in the database row that owns the key instead",
+      );
+    }
+    const contentType = options?.httpMetadata?.contentType;
+    let body: string | ArrayBuffer | Uint8Array | ReadableStream = value;
+    let contentLength = options?.contentLength;
+    if (
+      typeof value !== "string" &&
+      !(value instanceof ArrayBuffer) &&
+      contentLength === undefined
+    ) {
+      // No declared length and a stream: the size has to come from somewhere,
+      // and the Host will not discover it. Buffering is the only remaining
+      // option, so it happens where the memory cost is visible.
+      body = await readStream(value as ReadableStream<Uint8Array>);
+      contentLength = (body as Uint8Array).byteLength;
+    }
+    await this.bucket.put(key, body, {
+      ...(contentLength === undefined ? {} : { contentLength }),
+      ...(contentType === undefined ? {} : { contentType }),
+    });
+  }
+
+  async get(key: string): Promise<StorageObject | null> {
+    const found = await this.bucket.get(key, undefined);
+    if (!found) return null;
+    const body = found.body;
+    // The facade hands out exactly one stream. `arrayBuffer`/`text`/`json` are
+    // served from it, so a caller may use the body OR the helpers, never both —
+    // which is also true of R2.
+    const buffered = async () => await new Response(body).arrayBuffer();
+    return {
+      key,
+      body,
+      bodyUsed: false,
+      httpEtag: found.etag,
+      arrayBuffer: buffered,
+      text: async () => new TextDecoder().decode(await buffered()),
+      json: async <T>() =>
+        JSON.parse(new TextDecoder().decode(await buffered())) as T,
+      httpMetadata: found.contentType
+        ? { contentType: found.contentType }
+        : undefined,
+      customMetadata: undefined,
+    };
+  }
+
+  async delete(key: string | string[]): Promise<void> {
+    const keys = Array.isArray(key) ? key : [key];
+    for (const one of keys) await this.bucket.delete(one);
+  }
+
+  async list(options?: {
+    prefix?: string;
+    limit?: number;
+    cursor?: string;
+    delimiter?: string;
+  }): Promise<ListObjectsResult> {
+    const page = await this.bucket.list({
+      ...(options?.prefix === undefined ? {} : { prefix: options.prefix }),
+      ...(options?.delimiter === undefined
+        ? {}
+        : { delimiter: options.delimiter }),
+      ...(options?.cursor === undefined ? {} : { cursor: options.cursor }),
+      ...(options?.limit === undefined ? {} : { limit: options.limit }),
+    });
+    return {
+      objects: page.objects.map((object) => ({
+        key: object.key,
+        size: object.size,
+        // The Host omits the upload instant when the provider did not record
+        // one; the port's `Date` is not optional, so it reads as the epoch.
+        uploaded: new Date(object.uploadedAtMillis ?? 0),
+        etag: object.etag,
+        httpMetadata: object.contentType
+          ? { contentType: object.contentType }
+          : undefined,
+      })),
+      truncated: page.truncated,
+      cursor: page.truncated ? page.cursor : undefined,
+      delimitedPrefixes: [...page.prefixes],
+    };
+  }
+
+  async head(key: string): Promise<ObjectMetadata | null> {
+    const found = await this.bucket.head(key);
+    return found ? metadataOf(found) : null;
+  }
+}
+
+export function wrapEdgeObjects(bucket: EdgeObjectsBinding): IObjectStorage {
+  return new EdgeObjectStorage(bucket);
+}

--- a/src/backend/runtime/edge-queue.ts
+++ b/src/backend/runtime/edge-queue.ts
@@ -1,0 +1,135 @@
+/**
+ * `edge.queue@1.0.0` → {@link IQueueProducer} / {@link IQueueBatch}.
+ *
+ * Two differences from Cloudflare Queues, both of which would otherwise be
+ * discovered in production:
+ *
+ *  - BODIES ARE BYTES. `queue.send(object)` works on Cloudflare because the
+ *    runtime structured-clones the value. The facade runs the body through a
+ *    bytes projection and rejects anything that is not a string, ArrayBuffer,
+ *    or view, so a delivery message has to be serialized. JSON is the encoding
+ *    on both ends, and the consumer side undoes it.
+ *  - THE CONSUMER BATCH IS A DIFFERENT OBJECT. It is `acknowledge` /
+ *    `acknowledgeAll` / `timestampMillis`, not `ack` / `ackAll` / `timestamp`,
+ *    and the body arrives as `{encoding:"base64", data}`. `retry` also refuses
+ *    `delaySeconds: 0`, which Cloudflare accepts as "no delay".
+ *
+ * AVAILABILITY: the managed Cloudflare backend projects queue bindings; the
+ * self-host backend projects only `edge.kv` and `edge.sql` today (see
+ * takoserver `selfhost-worker-wrapper.ts` `projectEnv`). A self-hosted Worker
+ * therefore has no queue binding at all, and the core's existing behaviour for
+ * an unbound `DELIVERY_QUEUE` — synchronous fallback delivery, reported by the
+ * readiness surface — is what applies there.
+ */
+
+import {
+  EDGE_QUEUE_MAX_MESSAGES,
+  decodeEdgeBytes,
+  type EdgeQueueBatch,
+  type EdgeQueueBinding,
+} from "./edge-facades.ts";
+import type {
+  IQueueBatch,
+  IQueueMessage,
+  IQueueProducer,
+  QueueBatchItem,
+  QueueSendOptions,
+} from "./queue.ts";
+
+/** A message cannot be carried over the facade. */
+export class EdgeQueueShapeError extends TypeError {
+  constructor(message: string) {
+    super(message);
+    this.name = "EdgeQueueShapeError";
+  }
+}
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+function encodeBody(body: unknown): Uint8Array {
+  let json: string;
+  try {
+    json = JSON.stringify(body);
+  } catch (error) {
+    throw new EdgeQueueShapeError(
+      `edge.queue: the message body is not JSON-serializable: ${String(error)}`,
+    );
+  }
+  if (json === undefined) {
+    throw new EdgeQueueShapeError(
+      "edge.queue: the message body serialized to nothing",
+    );
+  }
+  return encoder.encode(json);
+}
+
+/**
+ * The facade takes `delaySeconds` only as a positive whole number; Cloudflare's
+ * `0` means the same as omitting it, so it is omitted.
+ */
+function delayOption(
+  delaySeconds: number | undefined,
+): { delaySeconds: number } | Record<string, never> {
+  if (delaySeconds === undefined || delaySeconds <= 0) return {};
+  return { delaySeconds: Math.ceil(delaySeconds) };
+}
+
+class EdgeQueueProducer<T> implements IQueueProducer<T> {
+  constructor(private readonly queue: EdgeQueueBinding) {}
+
+  async send(body: T, options?: QueueSendOptions): Promise<void> {
+    await this.queue.send(encodeBody(body), delayOption(options?.delaySeconds));
+  }
+
+  async sendBatch(
+    messages: readonly QueueBatchItem<T>[],
+    options?: QueueSendOptions,
+  ): Promise<void> {
+    if (messages.length === 0) return;
+    if (messages.length > EDGE_QUEUE_MAX_MESSAGES) {
+      throw new EdgeQueueShapeError(
+        `edge.queue: ${messages.length} messages exceed the facade limit of ` +
+          `${EDGE_QUEUE_MAX_MESSAGES}`,
+      );
+    }
+    // `sendBatch` takes no batch-wide options, so a shared default delay is
+    // pushed down onto each message that did not set its own.
+    await this.queue.sendBatch(
+      messages.map(({ body, delaySeconds }) => ({
+        body: encodeBody(body),
+        ...delayOption(delaySeconds ?? options?.delaySeconds),
+      })),
+    );
+  }
+}
+
+export function wrapEdgeQueue<T>(queue: EdgeQueueBinding): IQueueProducer<T> {
+  return new EdgeQueueProducer<T>(queue);
+}
+
+/**
+ * Adapt one consumer batch. The body is decoded with the same JSON encoding
+ * {@link wrapEdgeQueue} writes, so a producer and consumer on this lane agree
+ * even though the Host only ever sees opaque bytes.
+ */
+export function wrapEdgeMessageBatch<T>(batch: EdgeQueueBatch): IQueueBatch<T> {
+  const messages: readonly IQueueMessage<T>[] = batch.messages.map(
+    (message) => ({
+      id: message.id,
+      timestamp: new Date(message.timestampMillis),
+      body: JSON.parse(decoder.decode(decodeEdgeBytes(message.body))) as T,
+      attempts: message.attempts,
+      ack: () => message.acknowledge(),
+      // The facade rejects `delaySeconds: 0` on a retry; omitting it is the
+      // same request.
+      retry: (options) => message.retry(delayOption(options?.delaySeconds)),
+    }),
+  );
+  return {
+    queue: batch.queue,
+    messages,
+    ackAll: () => batch.acknowledgeAll(),
+    retryAll: (options) => batch.retryAll(delayOption(options?.delaySeconds)),
+  };
+}

--- a/src/backend/runtime/edge-sql.ts
+++ b/src/backend/runtime/edge-sql.ts
@@ -1,0 +1,479 @@
+/**
+ * `edge.sql@1.0.0` → Drizzle, through `drizzle-orm/sqlite-proxy`.
+ *
+ * Same seam as `managed-relational.ts`: one bounded prepared statement per
+ * callback, `batch()` as one ordered-atomic Host call. What is different, and
+ * what most of this file is about, is the ROW SHAPE.
+ *
+ * D1 hands Drizzle positional arrays (`stmt.raw()`), and `sqlite-proxy` maps
+ * `rows[i][j]` positionally onto the fields it compiled. `edge.sql` returns
+ * RECORDS keyed by result-column name. Turning a record back into a positional
+ * array is only sound when the column names are DISTINCT and ORDERED, and
+ * Drizzle's own SQL guarantees neither:
+ *
+ *     select "inbox"."actor_ap_id", ..., "activities"."actor_ap_id", ...
+ *       from "inbox" inner join "activities" on ...
+ *
+ * SQLite names both result columns `actor_ap_id`, so the record keeps one of
+ * them and every field after it shifts by one — a silent mis-read, not an
+ * error. (`created_at` collides in the same query.) JavaScript's own key
+ * ordering adds a second trap: an integer-like column name such as the `1` of
+ * `select 1` sorts ahead of every other key regardless of insertion order.
+ *
+ * So this adapter rewrites the statement's projection list before sending it,
+ * giving every unaliased item a unique, non-numeric name (`__c0`, `__c1`, ...).
+ * Drizzle never looks at result-column names, so renaming them is invisible to
+ * it. The rewrite is then BACKED BY A GUARD: the number of keys a row comes
+ * back with must equal the number of projection items that were sent, and a
+ * mismatch throws instead of returning a shifted row.
+ */
+
+import {
+  drizzle as drizzleProxy,
+  type AsyncBatchRemoteCallback,
+  type AsyncRemoteCallback,
+} from "drizzle-orm/sqlite-proxy";
+
+import * as schema from "../../db/schema.ts";
+import {
+  EDGE_SQL_MAX_PARAMETERS,
+  EDGE_SQL_MAX_STATEMENTS,
+  decodeEdgeBytes,
+  encodeEdgeBytes,
+  isEdgeEncodedBytes,
+  type EdgeSqlBinding,
+  type EdgeSqlResult,
+  type EdgeSqlValue,
+} from "./edge-facades.ts";
+
+/** The statement, or a value in it, cannot be expressed over `edge.sql`. */
+export class EdgeSqlShapeError extends TypeError {
+  constructor(message: string) {
+    super(message);
+    this.name = "EdgeSqlShapeError";
+  }
+}
+
+/** A row came back with a different column count than the statement projected. */
+export class EdgeSqlColumnMismatchError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "EdgeSqlColumnMismatchError";
+  }
+}
+
+const PROJECTION_ALIAS_PREFIX = "__c";
+
+const SELECT_LIST_TERMINATORS = new Set([
+  "from",
+  "where",
+  "group",
+  "having",
+  "window",
+  "order",
+  "limit",
+  "offset",
+  "union",
+  "except",
+  "intersect",
+]);
+
+interface ScannedWord {
+  readonly word: string;
+  readonly start: number;
+  readonly end: number;
+}
+
+interface Scan {
+  readonly words: readonly ScannedWord[];
+  readonly commas: readonly number[];
+}
+
+function isWordChar(ch: string): boolean {
+  return /[A-Za-z0-9_$]/.test(ch);
+}
+
+/**
+ * Walk the statement recording the bare words and commas that sit at
+ * parenthesis depth zero. Quoted identifiers, string literals, and comments are
+ * skipped whole, so a `,` inside `'a,b'` or a `from` inside a subquery is never
+ * mistaken for structure.
+ */
+function scanTopLevel(sql: string): Scan {
+  const words: ScannedWord[] = [];
+  const commas: number[] = [];
+  let depth = 0;
+  let index = 0;
+  while (index < sql.length) {
+    const ch = sql[index]!;
+    if (ch === "'" || ch === '"' || ch === "`") {
+      index += 1;
+      while (index < sql.length) {
+        if (sql[index] === ch) {
+          if (sql[index + 1] === ch) index += 2;
+          else {
+            index += 1;
+            break;
+          }
+        } else index += 1;
+      }
+      continue;
+    }
+    if (ch === "[") {
+      const close = sql.indexOf("]", index + 1);
+      index = close === -1 ? sql.length : close + 1;
+      continue;
+    }
+    if (ch === "-" && sql[index + 1] === "-") {
+      const newline = sql.indexOf("\n", index);
+      index = newline === -1 ? sql.length : newline + 1;
+      continue;
+    }
+    if (ch === "/" && sql[index + 1] === "*") {
+      const close = sql.indexOf("*/", index + 2);
+      index = close === -1 ? sql.length : close + 2;
+      continue;
+    }
+    if (ch === "(") {
+      depth += 1;
+      index += 1;
+      continue;
+    }
+    if (ch === ")") {
+      depth -= 1;
+      index += 1;
+      continue;
+    }
+    if (ch === ",") {
+      if (depth === 0) commas.push(index);
+      index += 1;
+      continue;
+    }
+    if (isWordChar(ch) && !/[0-9]/.test(ch)) {
+      const start = index;
+      while (index < sql.length && isWordChar(sql[index]!)) index += 1;
+      if (depth === 0) {
+        words.push({
+          word: sql.slice(start, index).toLowerCase(),
+          start,
+          end: index,
+        });
+      }
+      continue;
+    }
+    if (/[0-9]/.test(ch)) {
+      while (index < sql.length && isWordChar(sql[index]!)) index += 1;
+      continue;
+    }
+    index += 1;
+  }
+  return { words, commas };
+}
+
+/** Does this projection item already carry its own `as "name"` alias? */
+function hasOwnAlias(item: string): boolean {
+  return scanTopLevel(item).words.some((word) => word.word === "as");
+}
+
+export interface RewrittenStatement {
+  readonly sql: string;
+  /**
+   * How many result columns the statement projects, when that could be
+   * determined. `undefined` means the guard cannot check this statement — a
+   * `select *`, or a shape with no projection list at all.
+   */
+  readonly columns: number | undefined;
+}
+
+/**
+ * Give every projected column a distinct, non-numeric name.
+ *
+ * Handles the two shapes Drizzle emits: a `select` list (including one that
+ * follows a `with` clause, whose CTE bodies are parenthesized and therefore
+ * invisible to a depth-zero scan) and a `returning` list on a write. For a
+ * compound `select ... union select ...` only the first arm is rewritten, which
+ * is sufficient: SQLite takes a compound select's result-column names from its
+ * first arm.
+ *
+ * Anything else — a `pragma`, a `create table`, a `select *` — is returned
+ * untouched with no column count, because there is nothing safe to rename.
+ */
+export function rewriteProjection(sql: string): RewrittenStatement {
+  const scan = scanTopLevel(sql);
+  const first = scan.words[0];
+  if (!first) return { sql, columns: undefined };
+
+  let listStart: number;
+  let listEnd: number;
+
+  if (first.word === "select" || first.word === "with") {
+    const selectAt = scan.words.findIndex((word) => word.word === "select");
+    if (selectAt === -1) return { sql, columns: undefined };
+    const select = scan.words[selectAt]!;
+    // The list begins right after the keyword, NOT at the next bare word: an
+    // item usually opens with a quoted identifier, which the scanner skips.
+    listStart = select.end;
+    let cursor = selectAt + 1;
+    const next = scan.words[cursor];
+    if (
+      next &&
+      (next.word === "distinct" || next.word === "all") &&
+      sql.slice(select.end, next.start).trim() === ""
+    ) {
+      listStart = next.end;
+      cursor += 1;
+    }
+    const terminator = scan.words
+      .slice(cursor)
+      .find((word) => SELECT_LIST_TERMINATORS.has(word.word));
+    listEnd = terminator ? terminator.start : sql.length;
+  } else {
+    // insert / update / delete: only a `returning` list is projected.
+    const returning = [...scan.words]
+      .reverse()
+      .find((word) => word.word === "returning");
+    if (!returning) return { sql, columns: undefined };
+    listStart = returning.end;
+    listEnd = sql.length;
+  }
+
+  if (listEnd <= listStart) return { sql, columns: undefined };
+
+  const boundaries = [
+    listStart,
+    ...scan.commas.filter((at) => at > listStart && at < listEnd),
+    listEnd,
+  ];
+  const items: { text: string; start: number; end: number }[] = [];
+  for (let index = 0; index + 1 < boundaries.length; index += 1) {
+    const start = index === 0 ? boundaries[0]! : boundaries[index]! + 1;
+    const end = boundaries[index + 1]!;
+    items.push({ text: sql.slice(start, end), start, end });
+  }
+  if (items.length === 0) return { sql, columns: undefined };
+
+  // `select *` and `"t".*` cannot take an alias, and their column count is not
+  // knowable from the text. Leave the whole statement alone.
+  if (items.some((item) => /(^|\.)\s*\*\s*$/.test(item.text.trim()))) {
+    return { sql, columns: undefined };
+  }
+
+  let out = "";
+  let cursor = 0;
+  items.forEach((item, position) => {
+    out += sql.slice(cursor, item.end);
+    if (!hasOwnAlias(item.text)) {
+      const trailing = item.text.length - item.text.trimEnd().length;
+      // Insert before the item's own trailing whitespace so the statement keeps
+      // its shape.
+      out =
+        out.slice(0, out.length - trailing) +
+        ` as "${PROJECTION_ALIAS_PREFIX}${position}"` +
+        out.slice(out.length - trailing);
+    }
+    cursor = item.end;
+  });
+  out += sql.slice(cursor);
+  return { sql: out, columns: items.length };
+}
+
+/** Project one bound parameter into the facade's closed value vocabulary. */
+export function toEdgeSqlValue(value: unknown): EdgeSqlValue {
+  if (value === null || value === undefined) return null;
+  if (typeof value === "string") return value;
+  if (typeof value === "boolean") return value ? 1 : 0;
+  if (typeof value === "number") {
+    if (!Number.isFinite(value) || Math.abs(value) > Number.MAX_SAFE_INTEGER) {
+      throw new EdgeSqlShapeError(
+        `edge.sql: ${value} is outside the range the facade carries`,
+      );
+    }
+    return value;
+  }
+  if (typeof value === "bigint") {
+    if (
+      value > BigInt(Number.MAX_SAFE_INTEGER) ||
+      value < BigInt(Number.MIN_SAFE_INTEGER)
+    ) {
+      throw new EdgeSqlShapeError(
+        `edge.sql: bigint ${value} is outside the safe-integer range`,
+      );
+    }
+    return Number(value);
+  }
+  if (value instanceof ArrayBuffer)
+    return encodeEdgeBytes(new Uint8Array(value));
+  if (ArrayBuffer.isView(value)) {
+    const view = value as ArrayBufferView;
+    return encodeEdgeBytes(
+      new Uint8Array(view.buffer, view.byteOffset, view.byteLength),
+    );
+  }
+  throw new EdgeSqlShapeError(
+    `edge.sql: a ${typeof value} parameter has no portable encoding`,
+  );
+}
+
+/** Turn a returned value back into what the D1 driver would have produced. */
+function fromEdgeSqlValue(value: EdgeSqlValue): unknown {
+  return isEdgeEncodedBytes(value) ? decodeEdgeBytes(value) : value;
+}
+
+/** Array indices and `length` are the only names an array cannot also carry. */
+function canCarryName(key: string): boolean {
+  return key !== "length" && String(Number(key)) !== key;
+}
+
+/**
+ * Build a row that answers to BOTH access styles.
+ *
+ * Drizzle reads a row positionally, so the array part is what it needs. But
+ * `db.get(sql\`... AS matched\`)` — a raw statement with no compiled fields —
+ * is handed the driver's row untouched, and on D1 that is a record: call sites
+ * read `row.matched`. `sqlite-proxy` gives them the bare array instead, so on
+ * this lane those reads would come back `undefined` — and several of them gate
+ * block/mute enforcement, where `undefined` reads as "not blocked".
+ *
+ * Attaching the column names to the array satisfies both without asking the
+ * callback to know which one Drizzle compiled.
+ */
+function makeRow(
+  keys: readonly string[],
+  values: readonly unknown[],
+): unknown[] {
+  const row = [...values];
+  for (let index = 0; index < keys.length; index += 1) {
+    const key = keys[index]!;
+    if (canCarryName(key)) {
+      Object.defineProperty(row, key, {
+        value: values[index],
+        enumerable: false,
+        configurable: true,
+        writable: true,
+      });
+    }
+  }
+  return row;
+}
+
+function projectRows(
+  result: EdgeSqlResult,
+  columns: number | undefined,
+  sql: string,
+): unknown[][] {
+  return result.rows.map((row) => {
+    const keys = Object.keys(row);
+    if (columns !== undefined && keys.length !== columns) {
+      throw new EdgeSqlColumnMismatchError(
+        `edge.sql returned ${keys.length} columns for a statement projecting ` +
+          `${columns}; the row cannot be mapped positionally. Statement: ${sql}`,
+      );
+    }
+    return makeRow(
+      keys,
+      keys.map((key) => fromEdgeSqlValue(row[key]!)),
+    );
+  });
+}
+
+const TRANSACTION_CONTROL =
+  /^\s*(begin|commit|end|rollback|savepoint|release)\b/i;
+
+interface PreparedStatement {
+  readonly sql: string;
+  readonly params: readonly EdgeSqlValue[];
+  readonly columns: number | undefined;
+  readonly original: string;
+}
+
+function prepare(sql: string, params: readonly unknown[]): PreparedStatement {
+  if (TRANSACTION_CONTROL.test(sql)) {
+    throw new EdgeSqlShapeError(
+      `edge.sql: transaction control ("${sql.trim()}") is not on this request ` +
+        `path. Use db.batch([...]) — the facade's transaction() commits it ` +
+        `all-or-none in one Host call.`,
+    );
+  }
+  if (params.length > EDGE_SQL_MAX_PARAMETERS) {
+    throw new EdgeSqlShapeError(
+      `edge.sql: ${params.length} bound parameters exceed the facade limit of ` +
+        `${EDGE_SQL_MAX_PARAMETERS}; chunk the write (see src/db/d1-write.ts)`,
+    );
+  }
+  const rewritten = rewriteProjection(sql);
+  return {
+    sql: rewritten.sql,
+    params: params.map(toEdgeSqlValue),
+    columns: rewritten.columns,
+    original: sql,
+  };
+}
+
+/**
+ * Every statement goes through `execute`, never `query`.
+ *
+ * `query` is `execute` with an added refusal when the statement wrote anything,
+ * and Drizzle's read methods do not mean "reads nothing": an
+ * `insert ... returning` is compiled with method `all`. Choosing the method
+ * from Drizzle's would reject a legitimate write.
+ */
+export function createEdgeSqlDatabase(binding: EdgeSqlBinding) {
+  const one = async (
+    statement: PreparedStatement,
+    method: "run" | "all" | "values" | "get",
+  ) => {
+    const result = await binding.execute(statement.sql, statement.params);
+    return shape(result, statement, method);
+  };
+
+  const callback: AsyncRemoteCallback = async (sql, params, method) =>
+    await one(prepare(sql, params), method);
+
+  const batchCallback: AsyncBatchRemoteCallback = async (batch) => {
+    if (batch.length > EDGE_SQL_MAX_STATEMENTS) {
+      throw new EdgeSqlShapeError(
+        `edge.sql: a batch of ${batch.length} statements exceeds the facade ` +
+          `limit of ${EDGE_SQL_MAX_STATEMENTS}`,
+      );
+    }
+    const prepared = batch.map((entry) => prepare(entry.sql, entry.params));
+    const results = await binding.transaction(
+      prepared.map((entry) => ({ sql: entry.sql, params: entry.params })),
+    );
+    if (results.length !== prepared.length) {
+      throw new EdgeSqlColumnMismatchError(
+        `edge.sql: transaction returned ${results.length} results for ` +
+          `${prepared.length} statements`,
+      );
+    }
+    return results.map((result, index) =>
+      shape(result, prepared[index]!, batch[index]!.method),
+    );
+  };
+
+  return drizzleProxy(callback, batchCallback, { schema });
+}
+
+/**
+ * `sqlite-proxy` wants a flat row for `get` and an array of rows otherwise, and
+ * reads `run`'s result straight back to the caller — which is where
+ * `affectedRowCount` looks for `meta.changes`.
+ *
+ * A `get` that matched nothing must yield `undefined`, not an empty array:
+ * Drizzle's `mapGetResult` short-circuits on a falsy row, and an empty array is
+ * truthy, so `[]` would be mapped into an object whose every field is
+ * `undefined` — a "row" for a query that found none.
+ */
+function shape(
+  result: EdgeSqlResult,
+  statement: PreparedStatement,
+  method: "run" | "all" | "values" | "get",
+): { rows: unknown[]; meta: { changes: number } } {
+  const rows = projectRows(result, statement.columns, statement.original);
+  return {
+    rows: (method === "get" ? rows[0] : rows) as unknown[],
+    meta: { changes: result.rowsWritten },
+  };
+}
+
+export type EdgeSqlDatabase = ReturnType<typeof createEdgeSqlDatabase>;

--- a/src/backend/runtime/lane.ts
+++ b/src/backend/runtime/lane.ts
@@ -1,0 +1,283 @@
+/**
+ * Which runtime the Worker was published onto, and the bindings that follow.
+ *
+ * The same bundle runs on two backends that look identical from inside:
+ *
+ *   `cloudflare`   — published straight to Cloudflare Workers. `env.DB` is a
+ *                    `D1Database`, `env.KV` a `KVNamespace`, `env.MEDIA` an
+ *                    `R2Bucket`, `env.DELIVERY_QUEUE` a `Queue`.
+ *   `takoform-v1`  — published through Takoform onto a Takoserver Host, managed
+ *                    Cloudflare backend or self-host. The Host's generated
+ *                    entrypoint replaces `env` before the module sees it, and
+ *                    each binding is the portable facade its Interface names:
+ *                    `edge.sql`, `edge.kv`, `edge.objects`, `edge.queue`.
+ *
+ * THE LANE IS DECLARED, NOT SNIFFED. Two of the bindings cannot be told apart
+ * by shape at all — `edge.kv` and `KVNamespace` expose the same five method
+ * names, and both queue producers are `send`/`sendBatch`. A Worker that guessed
+ * would call `kv.get(key, {type:"json"})` on a facade that ignores the second
+ * argument and returns bytes, and the failure would surface much later as a
+ * corrupt session or a rate-limit that never trips.
+ *
+ * So the lane comes from `YURUCOMMU_RUNTIME_LANE`, which the app's Takoform
+ * module already sets (`deploy/takoform/main.tf`, `worker_plain_values`), and
+ * the declaration is then cross-checked against the bindings that ARE decisive
+ * — `DB` always, `MEDIA` when it is bound. A disagreement refuses to start.
+ */
+
+import type {
+  D1Database,
+  Fetcher,
+  KVNamespace,
+  MessageBatch,
+  Queue,
+  R2Bucket,
+} from "@cloudflare/workers-types";
+
+import type { Database } from "../../db/index.ts";
+import {
+  isEdgeObjectsBinding,
+  isEdgeQueueBatch,
+  isEdgeSqlBinding,
+  isNativeD1Database,
+  isNativeR2Bucket,
+  type EdgeKvBinding,
+  type EdgeObjectsBinding,
+  type EdgeQueueBatch,
+  type EdgeQueueBinding,
+  type EdgeSqlBinding,
+} from "./edge-facades.ts";
+import { createEdgeSqlDatabase } from "./edge-sql.ts";
+import { wrapEdgeKv } from "./edge-kv.ts";
+import { wrapEdgeMessageBatch, wrapEdgeQueue } from "./edge-queue.ts";
+import { wrapEdgeObjects } from "./edge-objects.ts";
+import {
+  wrapCloudflareBindings,
+  wrapCloudflareMessageBatch,
+} from "./cloudflare.ts";
+import type { IKeyValueStore, IObjectStorage, IStaticAssets } from "./types.ts";
+import type { IQueueBatch, IQueueProducer } from "./queue.ts";
+
+/** The variable that names the lane. Set it in the deployment's plain vars. */
+export const RUNTIME_LANE_VAR = "YURUCOMMU_RUNTIME_LANE";
+
+/** Every lane this build knows how to run on. */
+export const RUNTIME_LANES = ["cloudflare", "takoform-v1"] as const;
+
+export type RuntimeLane = (typeof RUNTIME_LANES)[number];
+
+/** The lane when the variable is absent: a plain Cloudflare Worker. */
+export const DEFAULT_RUNTIME_LANE: RuntimeLane = "cloudflare";
+
+/** The declared lane is unknown, or disagrees with the bindings that arrived. */
+export class RuntimeLaneError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "RuntimeLaneError";
+  }
+}
+
+/**
+ * Read the declared lane.
+ *
+ * An unset variable is the Cloudflare lane, because that is what a Worker
+ * deployed without Takoform is. An UNRECOGNISED value is refused rather than
+ * defaulted: a future Host that names a lane this build has never heard of must
+ * not be served by guessing that its bindings are Cloudflare's.
+ */
+export function resolveRuntimeLane(declared: unknown): RuntimeLane {
+  if (declared === undefined || declared === null || declared === "") {
+    return DEFAULT_RUNTIME_LANE;
+  }
+  if (typeof declared !== "string") {
+    throw new RuntimeLaneError(
+      `${RUNTIME_LANE_VAR} must be a string; received ${typeof declared}`,
+    );
+  }
+  const lane = declared.trim();
+  if ((RUNTIME_LANES as readonly string[]).includes(lane)) {
+    return lane as RuntimeLane;
+  }
+  throw new RuntimeLaneError(
+    `${RUNTIME_LANE_VAR}="${declared}" is not a runtime lane this build ` +
+      `supports (${RUNTIME_LANES.join(", ")}). Refusing to start rather than ` +
+      `assume a binding shape.`,
+  );
+}
+
+interface LaneBindings {
+  readonly DB?: unknown;
+  readonly MEDIA?: unknown;
+}
+
+/**
+ * Prove the declared lane against the bindings that can actually be identified.
+ *
+ * `DB` is always decisive: `execute`/`query`/`transaction` and
+ * `prepare`/`batch` are disjoint. `MEDIA` is decisive only in one direction —
+ * an `R2Bucket` is recognisable by its multipart helpers, whereas a plain
+ * five-method object could be the facade or an adapter a host repository
+ * supplied — so only the direction that can be proven is checked.
+ */
+export function assertRuntimeLaneBindings(
+  lane: RuntimeLane,
+  bindings: LaneBindings,
+): void {
+  const { DB, MEDIA } = bindings;
+  if (lane === "takoform-v1") {
+    if (isNativeD1Database(DB)) {
+      throw new RuntimeLaneError(
+        `${RUNTIME_LANE_VAR}="takoform-v1" declares the Takoserver-hosted ` +
+          `lane, but env.DB is a native D1Database (prepare/batch). A Takoform ` +
+          `sqlite binding arrives as the edge.sql facade. Either the variable ` +
+          `is set on a direct Cloudflare deployment, or the Worker Version ` +
+          `declared a binding it did not receive.`,
+      );
+    }
+    if (!isEdgeSqlBinding(DB)) {
+      throw new RuntimeLaneError(
+        `${RUNTIME_LANE_VAR}="takoform-v1" requires env.DB to be the ` +
+          `edge.sql@1.0.0 facade (execute/query/transaction); it exposes ` +
+          `neither that nor D1's prepare/batch.`,
+      );
+    }
+    if (MEDIA !== undefined && isNativeR2Bucket(MEDIA)) {
+      throw new RuntimeLaneError(
+        `${RUNTIME_LANE_VAR}="takoform-v1" declares the Takoserver-hosted ` +
+          `lane, but env.MEDIA is a native R2Bucket. A Takoform bucket ` +
+          `binding arrives as the edge.objects@1.0.0 facade.`,
+      );
+    }
+    return;
+  }
+  if (isEdgeSqlBinding(DB)) {
+    throw new RuntimeLaneError(
+      `env.DB is the edge.sql@1.0.0 facade (execute/query/transaction), but ` +
+        `${RUNTIME_LANE_VAR} does not declare the takoform-v1 lane. A ` +
+        `Takoserver-hosted Worker must declare it; without that this build ` +
+        `would hand the facade to drizzle-orm/d1 and every query would fail ` +
+        `at the first prepare().`,
+    );
+  }
+  if (!isNativeD1Database(DB)) {
+    throw new RuntimeLaneError(
+      `env.DB is neither a D1Database nor the edge.sql@1.0.0 facade; the ` +
+        `Cloudflare lane cannot build a database client from it.`,
+    );
+  }
+}
+
+/** Bindings a Takoserver-hosted Worker Version receives. */
+export interface TakoserverWorkerBindings {
+  DB: EdgeSqlBinding;
+  KV: EdgeKvBinding;
+  MEDIA?: EdgeObjectsBinding;
+  ASSETS?: IStaticAssets;
+  DELIVERY_QUEUE?: EdgeQueueBinding;
+  DELIVERY_DLQ?: EdgeQueueBinding;
+}
+
+/** Bindings a Worker deployed straight to Cloudflare receives. */
+export interface CloudflareWorkerBindings {
+  DB: D1Database;
+  KV: KVNamespace;
+  MEDIA?: R2Bucket;
+  ASSETS?: Fetcher;
+  DELIVERY_QUEUE?: Queue<unknown>;
+  DELIVERY_DLQ?: Queue<unknown>;
+}
+
+type WrappedRuntime<T> = Omit<
+  T,
+  "DB" | "MEDIA" | "KV" | "ASSETS" | "DELIVERY_QUEUE" | "DELIVERY_DLQ"
+> & {
+  DB_INSTANCE: Database;
+  MEDIA?: IObjectStorage;
+  KV: IKeyValueStore;
+  ASSETS?: IStaticAssets;
+  DELIVERY_QUEUE?: IQueueProducer<unknown>;
+  DELIVERY_DLQ?: IQueueProducer<unknown>;
+};
+
+/**
+ * Wrap Takoserver's portable facades into the runtime ports the app speaks.
+ *
+ * `ASSETS` passes through: a Takoform `external_services` entry is projected as
+ * a `{fetch}` adapter, which is already the port's whole surface.
+ */
+export function wrapTakoserverBindings<T extends TakoserverWorkerBindings>(
+  bindings: T,
+): WrappedRuntime<T> {
+  const { DB, MEDIA, KV, ASSETS, DELIVERY_QUEUE, DELIVERY_DLQ, ...rest } =
+    bindings;
+  return {
+    ...rest,
+    DB_INSTANCE: createEdgeSqlDatabase(DB),
+    MEDIA: MEDIA ? wrapEdgeObjects(MEDIA) : undefined,
+    KV: wrapEdgeKv(KV),
+    ASSETS,
+    DELIVERY_QUEUE: DELIVERY_QUEUE ? wrapEdgeQueue(DELIVERY_QUEUE) : undefined,
+    DELIVERY_DLQ: DELIVERY_DLQ ? wrapEdgeQueue(DELIVERY_DLQ) : undefined,
+  } as unknown as WrappedRuntime<T>;
+}
+
+/**
+ * The single entry point a Worker should call.
+ *
+ * Reads {@link RUNTIME_LANE_VAR} off the bindings themselves — on both lanes it
+ * is an ordinary plain-text variable that arrives alongside them — proves the
+ * lane against the decisive bindings, and then wraps.
+ */
+export function wrapRuntimeBindings<
+  T extends
+    | (TakoserverWorkerBindings & Record<string, unknown>)
+    | (CloudflareWorkerBindings & Record<string, unknown>),
+>(bindings: T): WrappedRuntime<T> {
+  const lane = resolveRuntimeLane(
+    (bindings as Record<string, unknown>)[RUNTIME_LANE_VAR],
+  );
+  assertRuntimeLaneBindings(lane, bindings as LaneBindings);
+  return lane === "takoform-v1"
+    ? (wrapTakoserverBindings(
+        bindings as unknown as TakoserverWorkerBindings,
+      ) as unknown as WrappedRuntime<T>)
+    : (wrapCloudflareBindings(
+        bindings as unknown as CloudflareWorkerBindings & {
+          DB: D1Database;
+          KV: KVNamespace;
+        },
+      ) as unknown as WrappedRuntime<T>);
+}
+
+/**
+ * Adapt one consumer batch for whichever lane produced it.
+ *
+ * A queue batch IS decisive — the facade settles with `acknowledgeAll`, the
+ * Cloudflare `MessageBatch` with `ackAll` — so the shape is checked against the
+ * declared lane rather than trusted on its own.
+ */
+export function wrapRuntimeMessageBatch<T>(
+  batch: MessageBatch<T> | EdgeQueueBatch,
+  lane: RuntimeLane = DEFAULT_RUNTIME_LANE,
+): IQueueBatch<T> {
+  const isFacade = isEdgeQueueBatch(batch);
+  if (lane === "takoform-v1") {
+    if (!isFacade) {
+      throw new RuntimeLaneError(
+        `${RUNTIME_LANE_VAR}="takoform-v1" declares the Takoserver-hosted ` +
+          `lane, but the queue event is a Cloudflare MessageBatch (ackAll).`,
+      );
+    }
+    return wrapEdgeMessageBatch<T>(batch);
+  }
+  if (isFacade) {
+    throw new RuntimeLaneError(
+      `The queue event is a Takoserver batch (acknowledgeAll), but ` +
+        `${RUNTIME_LANE_VAR} does not declare the takoform-v1 lane.`,
+    );
+  }
+  return wrapCloudflareMessageBatch(batch as MessageBatch<T>);
+}
+
+/** Re-exported so a Worker entry can probe MEDIA without importing internals. */
+export { isEdgeObjectsBinding };

--- a/src/backend/runtime/lane.ts
+++ b/src/backend/runtime/lane.ts
@@ -229,9 +229,10 @@ export function wrapTakoserverBindings<T extends TakoserverWorkerBindings>(
  * lane against the decisive bindings, and then wraps.
  */
 export function wrapRuntimeBindings<
-  T extends
-    | (TakoserverWorkerBindings & Record<string, unknown>)
-    | (CloudflareWorkerBindings & Record<string, unknown>),
+  // Deliberately structural. Which of the two binding sets this actually is,
+  // is the runtime question this function answers; a static union here would
+  // only force every caller to assert the answer before asking it.
+  T extends { DB: unknown; KV: unknown },
 >(bindings: T): WrappedRuntime<T> {
   const lane = resolveRuntimeLane(
     (bindings as Record<string, unknown>)[RUNTIME_LANE_VAR],

--- a/src/backend/runtime/types.ts
+++ b/src/backend/runtime/types.ts
@@ -119,6 +119,16 @@ export interface IObjectStorage {
     options?: {
       httpMetadata?: ObjectMetadata["httpMetadata"];
       customMetadata?: Record<string, string>;
+      /**
+       * Byte length of `value`, when the caller already knows it.
+       *
+       * R2 discovers the size while streaming and ignores this. The portable
+       * `edge.objects` facade does not: ADR 0005 fixes that a Host enforces a
+       * declared length rather than buffering a body to find one, so a
+       * ReadableStream without this has to be buffered in the Worker. Pass it
+       * wherever the size is already in hand (an upload's `File.size`).
+       */
+      contentLength?: number;
     },
   ): Promise<void>;
 

--- a/src/backend/server.ts
+++ b/src/backend/server.ts
@@ -89,6 +89,11 @@ type LocalRuntimeEnvKey = Exclude<keyof EnvVars, "APP_URL">;
 // setting without an explicit local-runtime decision, instead of silently
 // dropping authority/security configuration such as OIDC_OWNER_SUB.
 const ENV_PASSTHROUGH_KEY_SET: Record<LocalRuntimeEnvKey, true> = {
+  // Carried so a shared env file reads the same everywhere, but nothing here
+  // consults it: this server builds the runtime ports directly from its own
+  // compat classes rather than wrapping a Worker's bindings, so it is neither
+  // the `cloudflare` nor the `takoform-v1` lane. See runtime/lane.ts.
+  YURUCOMMU_RUNTIME_LANE: true,
   ENABLE_TAKOS_TOOLS: true,
   AUTH_PASSWORD_HASH: true,
   GOOGLE_CLIENT_ID: true,

--- a/src/backend/types.ts
+++ b/src/backend/types.ts
@@ -16,6 +16,14 @@ import type {
 export interface EnvVars {
   APP_URL: string;
 
+  // Which runtime the Worker was published onto, and therefore what shape its
+  // bindings arrive in. Unset (or "cloudflare") = native Cloudflare bindings;
+  // "takoform-v1" = the portable edge.sql / edge.kv / edge.objects / edge.queue
+  // facades a Takoserver-hosted Worker Version receives. The value is checked
+  // against the bindings and a disagreement refuses to start — see
+  // runtime/lane.ts and docs/design/runtime-lanes.md.
+  YURUCOMMU_RUNTIME_LANE?: string;
+
   // Takos-specific endpoints are opt-in (fail-close by default).
   ENABLE_TAKOS_TOOLS?: string;
 

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -18,12 +18,13 @@ import { drizzle as drizzleD1, type DrizzleD1Database } from "drizzle-orm/d1";
 import type { LibSQLDatabase } from "drizzle-orm/libsql";
 import type { BaseSQLiteDatabase } from "drizzle-orm/sqlite-core";
 import type { ResultSet } from "@libsql/client";
+import type { SqliteRemoteResult } from "drizzle-orm/sqlite-proxy";
 import { isNull } from "drizzle-orm";
 import * as schema from "./schema.ts";
 
 export type Database = BaseSQLiteDatabase<
   "async",
-  D1Result | ResultSet,
+  D1Result | ResultSet | SqliteRemoteResult,
   typeof schema
 >;
 


### PR DESCRIPTION
Adds a Takoserver-hosted runtime lane selected by the existing `YURUCOMMU_RUNTIME_LANE` var: adapters for `edge.kv`, `edge.sql` (drizzle through sqlite-proxy with a positional projection rewrite so duplicate join column names cannot shift rows), `edge.queue`, and `edge.objects`, with fail-closed lane/binding shape checks. The default Cloudflare lane is unchanged. Version untouched (3.4.4); publishing is a separate step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013SB7CxTvxopFWhZLHfUKx4