### PR TITLE
Correct the managed relational row shape and name the portable lane

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -88,8 +88,8 @@ Takos core. See [`AGENTS.md`](AGENTS.md) for the full product boundary.
 ## Documentation
 
 - [Runtime lanes](docs/design/runtime-lanes.md) — how the bindings differ between
-  a direct Cloudflare deployment and a Takoserver-hosted (Takoform) one, and how
-  a deployment declares which it is
+  a raw-Cloudflare deployment and one on a host that projects the portable
+  facades, and how a deployment declares which it is
 - [Deployment guide](https://yurucommu.com/help/deployment.html)
 - [Getting started](https://yurucommu.com/help/getting-started.html)
 - [Help site](https://yurucommu.com/help/)

--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ Yurucommu は ActivityPub 連合・コンテンツ配送・ユーザー identity
 
 ## ドキュメント
 
-- [Runtime lanes](docs/design/runtime-lanes.md) — Cloudflare 直 deploy と
-  Takoserver-hosted (Takoform) で binding の形が変わる点と、その宣言方法
+- [Runtime lanes](docs/design/runtime-lanes.md) — raw Cloudflare binding と
+  portable facade で binding の形が変わる点と、その宣言方法
 - [Deployment guide](https://yurucommu.com/help/deployment.html)
 - [Getting started](https://yurucommu.com/help/getting-started.html)
 - [Help site](https://yurucommu.com/help/)

--- a/docs/design/runtime-lanes.md
+++ b/docs/design/runtime-lanes.md
@@ -2,7 +2,7 @@
 SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 
-# Runtime lanes — 同じ bundle を Cloudflare と Takoserver の両方で動かす
+# Runtime lanes — 同じ bundle を raw binding と portable facade の両方で動かす
 
 Status: **実装済み**（`src/backend/runtime/lane.ts` ほか。test は
 `src/backend/__tests__/runtime/`）
@@ -11,16 +11,23 @@ Consumers: `yurucommu`, `yurumeet`（Worker entry の composition）
 
 同一の Worker bundle が、内側からは見分けのつかない 2 つの backend で動きます。
 
-| lane | 出どころ | `env.DB` | `env.KV` | `env.MEDIA` | `env.DELIVERY_QUEUE` |
+| lane | binding を projection する host | `env.DB` | `env.KV` | `env.MEDIA` | `env.DELIVERY_QUEUE` |
 | --- | --- | --- | --- | --- | --- |
-| `cloudflare` | Cloudflare Workers へ直接 deploy | `D1Database` | `KVNamespace` | `R2Bucket` | `Queue` |
-| `takoform-v1` | Takoform 経由で Takoserver Host へ publish | `edge.sql@1.0.0` | `edge.kv@1.0.0` | `edge.objects@1.0.0` | `edge.queue@1.0.0` |
+| `cloudflare` | Cloudflare Workers へ直接 deploy、および ordinary Workers の Takoserver backend | `D1Database` | `KVNamespace` | `R2Bucket` | `Queue` |
+| `portable` | wrapper host（self-host、managed Workers-for-Platforms） | `edge.sql@1.0.0` | `edge.kv@1.0.0` | `edge.objects@1.0.0` | `edge.queue@1.0.0` |
 
-`takoform-v1` では Host が生成した entrypoint が module より先に `env` を差し替え、
-各 binding は Worker Version が宣言した Interface の **portable facade** になります。
-managed Cloudflare backend と self-host backend は同じ facade を projection します
+**lane が名指すのは binding の形であって、Worker を publish した道具ではありません。**
+本番の Takoserver backend は ordinary Workers なので `kv_namespace` / `d1` /
+`r2_bucket` / `queue` / `service` を **そのまま** projection します。これは
+`cloudflare` lane です。facade が現れるのは wrapper host、つまり self-host と managed
+Workers-for-Platforms だけで、そこでは host が生成した entrypoint が module より先に
+`env` を差し替え、各 binding は Worker Version が宣言した Interface の
+**portable facade** になります。両 wrapper は同じ facade を projection します
 （同じ method、同じ option 名、同じ error 名）。Takoserver ADR 0005 が object storage
 について明言し、self-host wrapper が KV と SQL について同じことを繰り返しています。
+
+Takoform で書いた deployment はどちらの host にも着地しうるので、lane を IaC の語彙で
+呼ぶことはできません。
 
 ## lane は宣言する。推測しない
 
@@ -31,16 +38,21 @@ binding の 5 つのうち **2 つは形で区別できません**。`edge.kv` �
 として現れます。
 
 そこで lane は plain var `YURUCOMMU_RUNTIME_LANE` で宣言し、**識別できる binding で
-突き合わせます**。未設定は `cloudflare`（Takoform を経由していない Worker はそれです）。
-知らない値は default に落とさず起動を拒否します。
+突き合わせます**。値は `cloudflare` と `portable` の 2 つだけで、未設定は
+`cloudflare` です。知らない値は default に落とさず起動を拒否します。alias はありません
+——旧称 `takoform-v1` もいまは「知らない値」であり、まだそれを宣言している deployment は
+黙って別の binding 形で動かされるのではなく、起動に失敗します。
 
 - `DB` は両方向に decisive — `execute`/`query`/`transaction` と `prepare`/`batch` は
   互いに素です。
 - `MEDIA` は片方向に decisive — `R2Bucket` は multipart helper で見分けられます。
 - 宣言と binding が食い違えば `RuntimeLaneError` で起動を拒否します。
 
-app 側の `deploy/takoform/main.tf` は既に
-`worker_plain_values = { YURUCOMMU_RUNTIME_LANE = "takoform-v1" }` を設定しています。
+設定するのは wrapper host に置くときだけです。self-host と managed
+Workers-for-Platforms の deployment は
+`worker_plain_values = { YURUCOMMU_RUNTIME_LANE = "portable" }` を設定し、ordinary
+Workers の Takoserver backend と Cloudflare 直 deploy は未設定のまま（または
+`cloudflare`）にします。
 
 ## Worker entry からの使い方
 
@@ -74,7 +86,7 @@ native binding だけを渡すと分かっている entry はそちらを直接�
 
 Durable Object binding (`CALL_SIGNALING` / `REALTIME_STREAM`) はどちらの lane でも
 wrapper を素通りします。ただし Takoform の Worker Version form には DO binding が
-無いため、`takoform-v1` では両方とも未 bind になり、call / realtime route は 503 を
+無いため、`portable` では両方とも未 bind になり、call / realtime route は 503 を
 返してクライアントは polling に落ちます。
 
 ## lane ごとの差分（app が知っておくべきもの）

--- a/docs/design/runtime-lanes.md
+++ b/docs/design/runtime-lanes.md
@@ -92,11 +92,18 @@ select "inbox"."actor_ap_id", ..., "activities"."actor_ap_id", ... from "inbox" 
 SQLite はどちらの result column にも `actor_ap_id` という名前を付けるので、record は
 片方だけを残し、以降の field が 1 つずつずれます。**error ではなく静かな誤読**です。
 
-`edge-sql.ts` は送信前に projection list を書き換え、alias を持たない項目それぞれに
-一意で非数値な名前（`__c0`, `__c1`, ...）を与えます。Drizzle は result column 名を
-見ないので、この rename は Drizzle からは不可視です。さらに **guard** が付きます:
-返ってきた row の key 数が送った projection 項目数と一致しなければ、ずれた row を
-返す代わりに `EdgeSqlColumnMismatchError` を投げます。
+`sqlite-proxy-rows.ts` は送信前に projection list を書き換え、alias を持たない項目
+それぞれに一意で非数値な名前（`__c0`, `__c1`, ...）を与えます。Drizzle は result
+column 名を見ないので、この rename は Drizzle からは不可視です。さらに **guard** が
+付きます: 返ってきた row の column 数が送った projection 項目数と一致しなければ、
+ずれた row を返す代わりに `ProxyColumnMismatchError` を投げます。
+
+``db.get(sql`...`)`` のような compile 済み field を持たない raw statement は、driver の
+row がそのまま呼び出し側に渡ります。D1 ではそれは record なので、call site は
+`row.matched` のように **名前で** 読みます（block / mute の gate がそうしています）。
+`sqlite-proxy` が渡すのは素の配列なので、この shared module は column 名を配列に
+非列挙 property として付け、位置と名前の両方の読み方が成立するようにします。名前が
+無いままだと `undefined` が「block されていない」と読まれます。
 
 - `db.batch([...])` は facade の `transaction()`（all-or-none、1 往復）になります。
 - `begin` / `commit` / `savepoint` はこの request path にありません。`db.batch` を
@@ -105,6 +112,19 @@ SQLite はどちらの result column にも `actor_ap_id` という名前を付�
   boolean は 0/1、`Uint8Array` / `ArrayBuffer` は base64 blob になります。
 - `select *` は rename できないため書き換えず、column 数の guard も効きません。
   join を伴う `select *` を raw SQL で書かないでください。
+
+### managed relational — 同じ row shape を共有する
+
+Takosumi の managed RelationalDatabase lane（`managed-relational.ts`）は、transport は
+`{columns, rows}` の位置つきですが、Drizzle との接続は同じ `sqlite-proxy` です。
+projection の書き換え・column 数 guard・名前つき row は `sqlite-proxy-rows.ts` を
+`edge.sql` lane と共有します。この lane だけの追加制約は次の 2 つです。
+
+- runtime contract は **trim 済みの statement しか受け取りません**。Drizzle は raw の
+  `sql` template を trim しないので、lane が送信前に trim します。
+- 結果が 0 行の `get` は空配列ではなく `undefined` を返さなければなりません。Drizzle の
+  `mapGetResult` は falsy な row でだけ short-circuit するので、`[]` は「全 field が
+  undefined の row」に化けます。
 
 ### `edge.kv` — 期限は相対 TTL ひとつだけ
 

--- a/src/backend/__tests__/runtime/edge-sql.test.ts
+++ b/src/backend/__tests__/runtime/edge-sql.test.ts
@@ -4,11 +4,13 @@ import { eq, sql } from "drizzle-orm";
 import { integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
 
 import {
-  EdgeSqlColumnMismatchError,
   EdgeSqlShapeError,
   createEdgeSqlDatabase,
-  rewriteProjection,
 } from "../../runtime/edge-sql.ts";
+import {
+  ProxyColumnMismatchError,
+  rewriteProjection,
+} from "../../runtime/sqlite-proxy-rows.ts";
 import {
   decodeEdgeBytes,
   encodeEdgeBytes,
@@ -382,7 +384,7 @@ describe("edge.sql fail-closed guards", () => {
       emptyFacade({ rows: [{ __c0: "a", __c1: "b" }], rowsWritten: 0 }),
     );
     const error = await refusal(async () => await db.select().from(authors));
-    expect(error).toBeInstanceOf(EdgeSqlColumnMismatchError);
+    expect(error).toBeInstanceOf(ProxyColumnMismatchError);
     expect(error.message).toContain("returned 2 columns");
   });
 

--- a/src/backend/__tests__/runtime/lane.test.ts
+++ b/src/backend/__tests__/runtime/lane.test.ts
@@ -9,7 +9,7 @@ import {
   resolveRuntimeLane,
   wrapRuntimeBindings,
   wrapRuntimeMessageBatch,
-  wrapTakoserverBindings,
+  wrapPortableBindings,
 } from "../../runtime/lane.ts";
 import worker from "../../public.ts";
 import {
@@ -87,18 +87,24 @@ describe("runtime lane declaration", () => {
     expect(resolveRuntimeLane("")).toBe("cloudflare");
   });
 
-  test("accepts the value the app's Takoform module already sets", () => {
-    // deploy/takoform/main.tf sets YURUCOMMU_RUNTIME_LANE = "takoform-v1".
-    expect(resolveRuntimeLane("takoform-v1")).toBe("takoform-v1");
-    expect(resolveRuntimeLane("  takoform-v1  ")).toBe("takoform-v1");
+  test("accepts the value a wrapper-host deployment sets", () => {
+    // A self-host or managed Workers-for-Platforms deployment sets
+    // YURUCOMMU_RUNTIME_LANE = "portable".
+    expect(resolveRuntimeLane("portable")).toBe("portable");
+    expect(resolveRuntimeLane("  portable  ")).toBe("portable");
     expect(resolveRuntimeLane("cloudflare")).toBe("cloudflare");
   });
 
   test("refuses a lane it has never heard of rather than defaulting", () => {
-    expect(() => resolveRuntimeLane("takoform-v2")).toThrow(RuntimeLaneError);
-    expect(() => resolveRuntimeLane("takoform-v2")).toThrow(
-      /not a runtime lane this build supports/,
-    );
+    // The lane names the binding shape, so the retired IaC-flavoured spelling
+    // is not an alias for it: a deployment still declaring it must be fixed,
+    // not silently served with a guessed binding shape.
+    for (const declared of ["takoform-v1", "takoform-v2"]) {
+      expect(() => resolveRuntimeLane(declared)).toThrow(RuntimeLaneError);
+      expect(() => resolveRuntimeLane(declared)).toThrow(
+        /not a runtime lane this build supports/,
+      );
+    }
     expect(() => resolveRuntimeLane(7)).toThrow(RuntimeLaneError);
   });
 });
@@ -129,9 +135,9 @@ describe("binding identification", () => {
 });
 
 describe("lane and bindings must agree", () => {
-  test("accepts a matched Takoserver deployment", () => {
+  test("accepts a matched portable-facade deployment", () => {
     expect(() =>
-      assertRuntimeLaneBindings("takoform-v1", {
+      assertRuntimeLaneBindings("portable", {
         DB: edgeSql(),
         MEDIA: edgeObjects(),
       }),
@@ -147,12 +153,12 @@ describe("lane and bindings must agree", () => {
     ).not.toThrow();
   });
 
-  test("refuses the hosted lane declared over native Cloudflare bindings", () => {
+  test("refuses the portable lane declared over raw Cloudflare bindings", () => {
     expect(() =>
-      assertRuntimeLaneBindings("takoform-v1", { DB: nativeD1() }),
+      assertRuntimeLaneBindings("portable", { DB: nativeD1() }),
     ).toThrow(/native D1Database/);
     expect(() =>
-      assertRuntimeLaneBindings("takoform-v1", {
+      assertRuntimeLaneBindings("portable", {
         DB: edgeSql(),
         MEDIA: nativeR2(),
       }),
@@ -172,15 +178,15 @@ describe("lane and bindings must agree", () => {
     expect(() => assertRuntimeLaneBindings("cloudflare", { DB: {} })).toThrow(
       /neither a D1Database nor/,
     );
-    expect(() => assertRuntimeLaneBindings("takoform-v1", { DB: {} })).toThrow(
+    expect(() => assertRuntimeLaneBindings("portable", { DB: {} })).toThrow(
       /requires env\.DB to be the/,
     );
   });
 });
 
 describe("wrapRuntimeBindings", () => {
-  const takoserverEnv = () => ({
-    YURUCOMMU_RUNTIME_LANE: "takoform-v1",
+  const portableEnv = () => ({
+    YURUCOMMU_RUNTIME_LANE: "portable",
     APP_URL: "https://example.test",
     ENCRYPTION_KEY: "k",
     DB: edgeSql(),
@@ -191,7 +197,7 @@ describe("wrapRuntimeBindings", () => {
   });
 
   test("builds every runtime port from the facades", () => {
-    const env = wrapRuntimeBindings(takoserverEnv() as never) as Record<
+    const env = wrapRuntimeBindings(portableEnv() as never) as Record<
       string,
       unknown
     >;
@@ -206,17 +212,17 @@ describe("wrapRuntimeBindings", () => {
     );
     // Plain variables, including the lane marker itself, pass through.
     expect(env.APP_URL).toBe("https://example.test");
-    expect(env.YURUCOMMU_RUNTIME_LANE).toBe("takoform-v1");
+    expect(env.YURUCOMMU_RUNTIME_LANE).toBe("portable");
     // The raw bindings do not survive into app-visible Env.
     expect(env.DB).toBeUndefined();
   });
 
   test("leaves an unbound optional binding unbound", () => {
-    const bindings = takoserverEnv() as Record<string, unknown>;
+    const bindings = portableEnv() as Record<string, unknown>;
     delete bindings.MEDIA;
     delete bindings.DELIVERY_QUEUE;
     delete bindings.DELIVERY_DLQ;
-    const env = wrapTakoserverBindings(bindings as never) as Record<
+    const env = wrapPortableBindings(bindings as never) as Record<
       string,
       unknown
     >;
@@ -239,7 +245,7 @@ describe("wrapRuntimeBindings", () => {
   test("refuses to start when the declaration and the bindings disagree", () => {
     expect(() =>
       wrapRuntimeBindings({
-        YURUCOMMU_RUNTIME_LANE: "takoform-v1",
+        YURUCOMMU_RUNTIME_LANE: "portable",
         DB: nativeD1(),
         KV: nativeKv(),
       } as never),
@@ -298,12 +304,12 @@ describe("wrapRuntimeMessageBatch", () => {
     }) as unknown as MessageBatch<{ n: number }>;
 
   test("adapts each lane's own batch", () => {
-    const hosted = wrapRuntimeMessageBatch<{ n: number }>(
+    const portable = wrapRuntimeMessageBatch<{ n: number }>(
       facadeBatch(),
-      "takoform-v1",
+      "portable",
     );
-    expect(hosted.queue).toBe("yurucommu-delivery");
-    expect(hosted.messages[0]!.body).toEqual({ n: 1 });
+    expect(portable.queue).toBe("yurucommu-delivery");
+    expect(portable.messages[0]!.body).toEqual({ n: 1 });
 
     const native = wrapRuntimeMessageBatch<{ n: number }>(cloudflareBatch());
     expect(native.messages[0]!.body).toEqual({ n: 1 });
@@ -311,7 +317,7 @@ describe("wrapRuntimeMessageBatch", () => {
 
   test("refuses a batch from the other lane", () => {
     expect(() =>
-      wrapRuntimeMessageBatch(cloudflareBatch(), "takoform-v1"),
+      wrapRuntimeMessageBatch(cloudflareBatch(), "portable"),
     ).toThrow(RuntimeLaneError);
     expect(() => wrapRuntimeMessageBatch(facadeBatch(), "cloudflare")).toThrow(
       RuntimeLaneError,
@@ -320,15 +326,15 @@ describe("wrapRuntimeMessageBatch", () => {
 });
 
 describe("the published Worker export", () => {
-  const hostedBindings = () => ({
-    YURUCOMMU_RUNTIME_LANE: "takoform-v1",
+  const portableBindings = () => ({
+    YURUCOMMU_RUNTIME_LANE: "portable",
     APP_URL: "https://example.test",
     DB: edgeSql(),
     KV: edgeKv(),
   });
 
   // A queue name the app does not own: `handleYurucommuQueueBatch` settles the
-  // batch and returns, which is enough to prove the whole hosted path — lane
+  // batch and returns, which is enough to prove the whole portable path — lane
   // resolution, batch adaptation, and binding wrapping — ran.
   const foreignBatch = (settle: () => void): EdgeQueueBatch => ({
     batchId: "b",
@@ -338,19 +344,19 @@ describe("the published Worker export", () => {
     retryAll: () => {},
   });
 
-  test("routes a Takoserver queue event through the hosted lane", async () => {
+  test("routes a portable queue event through the portable lane", async () => {
     let settled = false;
     await worker.queue(
       foreignBatch(() => {
         settled = true;
       }),
-      hostedBindings() as never,
+      portableBindings() as never,
     );
     expect(settled).toBe(true);
   });
 
-  test("refuses a Takoserver queue event when the lane is not declared", async () => {
-    const bindings = hostedBindings() as Record<string, unknown>;
+  test("refuses a portable queue event when the lane is not declared", async () => {
+    const bindings = portableBindings() as Record<string, unknown>;
     delete bindings.YURUCOMMU_RUNTIME_LANE;
     await expect(
       worker.queue(

--- a/src/backend/__tests__/runtime/managed-relational.test.ts
+++ b/src/backend/__tests__/runtime/managed-relational.test.ts
@@ -1,8 +1,15 @@
-import { expect, test } from "bun:test";
+import { beforeEach, describe, expect, test } from "bun:test";
+import { Database as BunSqlite } from "bun:sqlite";
 import { eq, sql } from "drizzle-orm";
 
-import { actors } from "../../../db/schema.ts";
+import type { Database } from "../../../db/index.ts";
+import { actors, blocks, mutes } from "../../../db/schema.ts";
+import {
+  personalActorIsBlockedBy,
+  resolveRetainedPersonalBlockTarget,
+} from "../../lib/personal-actor-moderation.ts";
 import { createManagedRelationalDatabase } from "../../runtime/managed-relational.ts";
+import { ProxyColumnMismatchError } from "../../runtime/sqlite-proxy-rows.ts";
 
 const materialization = {
   contract: "takosumi.managed-runtime-connection/v1",
@@ -160,3 +167,256 @@ function meta(overrides: Record<string, unknown> = {}) {
     ...overrides,
   };
 }
+
+// Two moderation tables that COLLIDE on column names once they are joined:
+// `created_at` and `updated_at` are projected twice. That is the shape the
+// lane's row mapping has to survive, and the shape the tests below are about.
+const MODERATION_SCHEMA_SQL = [
+  `create table blocks (
+     blocker_ap_id text not null,
+     blocked_ap_id text not null,
+     created_at text not null,
+     updated_at text,
+     primary key (blocker_ap_id, blocked_ap_id)
+   )`,
+  `create table mutes (
+     muter_ap_id text not null,
+     muted_ap_id text not null,
+     created_at text not null,
+     updated_at text,
+     primary key (muter_ap_id, muted_ap_id)
+   )`,
+];
+
+const OWNER = "https://local.example/ap/users/owner";
+const SPAM_RETAINED = "https://Remote.example/ap/users/spam/";
+const SPAM_CANONICAL = "https://remote.example/ap/users/spam";
+const STRANGER = "https://remote.example/ap/users/stranger";
+
+/**
+ * A stand-in for the managed relational Host, answering out of in-memory
+ * SQLite.
+ *
+ * The fidelity that matters is how it builds one result: the driver's own
+ * column-name list beside the driver's positional cells, which is exactly the
+ * `{columns, rows}` the runtime contract carries. `bun:sqlite` reports the
+ * column names of a join with duplicates COLLAPSED — six names for eight cells
+ * — because it derives them from a record, which is what every record-shaped
+ * materialization anywhere in a Host's path does. So a join that has not had
+ * its projection list rewritten cannot come back through this seam at all,
+ * and that is not an artifact of the fake: it is the hazard the runtime
+ * contract's own "duplicate labels are valid for joins" comment warns about.
+ */
+function createFakeRelationalHost(store: BunSqlite) {
+  const statements: { sql: string; params: readonly unknown[] }[] = [];
+
+  const run = (sqlText: string, params: readonly unknown[]) => {
+    statements.push({ sql: sqlText, params });
+    const query = store.query(sqlText);
+    // `values()` answers null, not [], for a statement that returns no rows.
+    const rows = (query.values(...(params as never[])) ?? []) as unknown[][];
+    const writes = /^\s*(insert|update|delete|replace)\b/i.test(sqlText);
+    const changes = writes
+      ? Number((store.query("select changes() as c").get() as { c: number }).c)
+      : 0;
+    return {
+      success: true,
+      columns: query.columnNames,
+      rows,
+      meta: {
+        changed_db: writes && changes > 0,
+        changes,
+        duration: 0,
+        last_row_id: 0,
+        size_after: 4096,
+        rows_read: rows.length,
+        rows_written: changes,
+      },
+    };
+  };
+
+  return {
+    statements,
+    gateway: {
+      async fetch(request: Request): Promise<Response> {
+        const body = (await request.json()) as {
+          statements: { sql: string; params: unknown[] }[];
+        };
+        try {
+          // Ordered-atomic, exactly like the Host: one throw discards the set.
+          const results = store.transaction(() =>
+            body.statements.map((entry) => run(entry.sql, entry.params)),
+          )();
+          return Response.json({
+            contract: "takosumi.managed-relational-runtime/v1",
+            results,
+          });
+        } catch (error) {
+          return Response.json(
+            { error: "relational_statement_failed", detail: String(error) },
+            { status: 400 },
+          );
+        }
+      },
+    },
+  };
+}
+
+describe("managed relational row shape", () => {
+  let store: BunSqlite;
+  let host: ReturnType<typeof createFakeRelationalHost>;
+  let db: Database;
+
+  beforeEach(() => {
+    store = new BunSqlite(":memory:");
+    for (const statement of MODERATION_SCHEMA_SQL) store.run(statement);
+    host = createFakeRelationalHost(store);
+    db = createManagedRelationalDatabase({
+      materialization,
+      alias: "database",
+      idempotencyKey: () => "relational:row-shape",
+      gateway: host.gateway,
+    });
+  });
+
+  const block = async (blockedApId: string) =>
+    await db.insert(blocks).values({
+      blockerApId: OWNER,
+      blockedApId,
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+    });
+
+  test("inserts and reads back through the Host", async () => {
+    await block(SPAM_CANONICAL);
+    expect(await db.select().from(blocks)).toEqual([
+      {
+        blockerApId: OWNER,
+        blockedApId: SPAM_CANONICAL,
+        createdAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+      },
+    ]);
+  });
+
+  test("maps a join whose result columns collide on both sides", async () => {
+    // Without the projection rewrite `created_at` and `updated_at` are each
+    // projected twice, the Host's column list collapses to six names for eight
+    // cells, and every field after the first collision reads one place over —
+    // a silent mis-read wherever a Host tolerates the shorter list.
+    await block(SPAM_CANONICAL);
+    await db.insert(mutes).values({
+      muterApId: OWNER,
+      mutedApId: SPAM_CANONICAL,
+      createdAt: "2026-01-02T00:00:00.000Z",
+      updatedAt: "2026-01-02T00:00:00.000Z",
+    });
+
+    const joined = await db
+      .select()
+      .from(blocks)
+      .innerJoin(mutes, eq(blocks.blockedApId, mutes.mutedApId));
+
+    expect(joined).toEqual([
+      {
+        blocks: {
+          blockerApId: OWNER,
+          blockedApId: SPAM_CANONICAL,
+          createdAt: "2026-01-01T00:00:00.000Z",
+          updatedAt: "2026-01-01T00:00:00.000Z",
+        },
+        mutes: {
+          muterApId: OWNER,
+          mutedApId: SPAM_CANONICAL,
+          createdAt: "2026-01-02T00:00:00.000Z",
+          updatedAt: "2026-01-02T00:00:00.000Z",
+        },
+      },
+    ]);
+
+    // Prove the rewrite really happened rather than the driver having been
+    // lucky: the statement that went out carries the generated names.
+    const select = host.statements.at(-1)!.sql;
+    expect(select).toContain(`as "__c0"`);
+    expect(select).toContain(`as "__c7"`);
+  });
+
+  test("keeps column names reachable for a raw statement with no fields", async () => {
+    // `db.get(sql`...`)` is handed the Host's row untouched, and the block and
+    // mute gates in src/backend/lib read it BY NAME. A bare positional array
+    // answers `undefined` to `row.matched`, which those gates read as
+    // "not blocked".
+    const row = (await db.get(
+      sql`SELECT CASE WHEN EXISTS (SELECT 1 FROM ${blocks}) THEN 1 ELSE 0 END AS matched`,
+    )) as { matched: number } | undefined;
+    expect(row?.matched).toBe(0);
+
+    await block(SPAM_CANONICAL);
+    const present = (await db.get(
+      sql`SELECT CASE WHEN EXISTS (SELECT 1 FROM ${blocks}) THEN 1 ELSE 0 END AS matched`,
+    )) as { matched: number } | undefined;
+    expect(present?.matched).toBe(1);
+  });
+
+  test("get() on an empty result is undefined, not a row of undefineds", async () => {
+    // Drizzle's `mapGetResult` short-circuits on a FALSY row, and `[]` is
+    // truthy: an empty array becomes an object whose every field is undefined,
+    // which `if (exact) return true` in the block gate reads as a hit.
+    const missing = await db
+      .select()
+      .from(blocks)
+      .where(eq(blocks.blockedApId, STRANGER))
+      .get();
+    expect(missing).toBeUndefined();
+  });
+
+  test("a personal block gate decides correctly through the lane", async () => {
+    // The production gate: an exact miss must fall through to the identity-set
+    // statement, and that statement's `AS matched` column must be readable by
+    // name. Both halves are row shape, and both fail open or closed silently.
+    await block(SPAM_RETAINED);
+    expect(await personalActorIsBlockedBy(db, OWNER, SPAM_CANONICAL)).toBe(
+      true,
+    );
+    expect(await personalActorIsBlockedBy(db, OWNER, STRANGER)).toBe(false);
+    expect(
+      await resolveRetainedPersonalBlockTarget(db, OWNER, SPAM_CANONICAL),
+    ).toBe(SPAM_RETAINED);
+    expect(
+      await resolveRetainedPersonalBlockTarget(db, OWNER, STRANGER),
+    ).toBeNull();
+  });
+});
+
+test("managed relational refuses a row that does not match the projection", async () => {
+  // A Host that answered from a record-shaped driver returns one column fewer
+  // than the four `select ... from blocks` projects. Mapping it positionally
+  // would shift every field after the collision; refuse instead.
+  const database = createManagedRelationalDatabase({
+    materialization,
+    alias: "database",
+    idempotencyKey: () => "relational:column-guard",
+    gateway: {
+      async fetch() {
+        return Response.json({
+          contract: "takosumi.managed-relational-runtime/v1",
+          results: [
+            {
+              success: true,
+              columns: ["blocker_ap_id", "blocked_ap_id", "created_at"],
+              rows: [[OWNER, SPAM_CANONICAL, "2026-01-01T00:00:00.000Z"]],
+              meta: meta({ rows_read: 1 }),
+            },
+          ],
+        });
+      },
+    },
+  });
+
+  const error = await Promise.resolve(database.select().from(blocks)).catch(
+    (error: unknown) => error,
+  );
+  const cause = (error as Error & { cause?: unknown }).cause;
+  expect(cause).toBeInstanceOf(ProxyColumnMismatchError);
+  expect((cause as Error).message).toContain("returned 3 columns");
+});

--- a/src/backend/index.ts
+++ b/src/backend/index.ts
@@ -8,7 +8,7 @@ import {
   resolveRuntimeLane,
   wrapRuntimeBindings,
   wrapRuntimeMessageBatch,
-  type TakoserverWorkerBindings,
+  type PortableWorkerBindings,
 } from "./runtime/lane.ts";
 import type { EdgeQueueBatch } from "./runtime/edge-facades.ts";
 import {
@@ -997,10 +997,10 @@ export async function handleYurucommuQueueBatch(
 
 /**
  * Bindings that are not the runtime ports, and so pass through whichever lane
- * wrapper runs. Durable Objects live here: Takoform's Worker Version has no
- * Durable Object binding, so on the Takoserver lane both are simply unbound and
- * the routes that need them answer 503, exactly as on a Cloudflare deployment
- * that did not declare them.
+ * wrapper runs. Durable Objects live here: Takoform's Worker Version form has
+ * no Durable Object binding, so on the portable lane both are simply unbound
+ * and the routes that need them answer 503, exactly as on a Cloudflare
+ * deployment that did not declare them.
  */
 type PassthroughBindings = EnvVars & {
   ASSETS?: Fetcher;
@@ -1017,10 +1017,10 @@ type PassthroughBindings = EnvVars & {
 /**
  * What this Worker may be handed.
  *
- * Native Cloudflare bindings, or the portable facades a Takoserver Host
- * projects. `wrapRuntimeBindings` decides which by reading the deployment's
- * declared `YURUCOMMU_RUNTIME_LANE` and proving it against the bindings that
- * actually arrived; see runtime/lane.ts.
+ * Raw Cloudflare bindings, or the portable facades a wrapper host projects.
+ * `wrapRuntimeBindings` decides which by reading the deployment's declared
+ * `YURUCOMMU_RUNTIME_LANE` and proving it against the bindings that actually
+ * arrived; see runtime/lane.ts.
  */
 type WorkerBindings = PassthroughBindings &
   (
@@ -1031,7 +1031,7 @@ type WorkerBindings = PassthroughBindings &
         DELIVERY_QUEUE?: Queue<DeliveryQueueMessageV1>;
         DELIVERY_DLQ?: Queue<DeliveryDlqMessageV1>;
       }
-    | TakoserverWorkerBindings
+    | PortableWorkerBindings
   );
 
 function isMaterializedRuntimeEnv(

--- a/src/backend/public.ts
+++ b/src/backend/public.ts
@@ -36,9 +36,9 @@ export {
   createManagedRelationalDatabase,
   type ManagedRelationalDatabaseOptions,
 } from "./runtime/managed-relational.ts";
-// Takoserver-hosted lane: the portable binding facades a Worker Version
-// published through Takoform receives, and the lane selector that proves a
-// deployment's declared lane against the bindings that actually arrived.
+// The portable lane: the binding facades a wrapper host projects, and the lane
+// selector that proves a deployment's declared lane against the bindings that
+// actually arrived.
 export {
   DEFAULT_RUNTIME_LANE,
   RUNTIME_LANE_VAR,
@@ -47,11 +47,11 @@ export {
   assertRuntimeLaneBindings,
   resolveRuntimeLane,
   type CloudflareWorkerBindings,
+  type PortableWorkerBindings,
   type RuntimeLane,
-  type TakoserverWorkerBindings,
+  wrapPortableBindings,
   wrapRuntimeBindings,
   wrapRuntimeMessageBatch,
-  wrapTakoserverBindings,
 } from "./runtime/lane.ts";
 export {
   EDGE_KV_MAX_EXPIRATION_TTL_SECONDS,

--- a/src/backend/public.ts
+++ b/src/backend/public.ts
@@ -76,11 +76,16 @@ export {
   wrapEdgeKv,
 } from "./runtime/edge-kv.ts";
 export {
-  EdgeSqlColumnMismatchError,
   EdgeSqlShapeError,
   createEdgeSqlDatabase,
-  rewriteProjection,
 } from "./runtime/edge-sql.ts";
+export {
+  ProxyColumnMismatchError,
+  positionalRow,
+  rewriteProjection,
+  type ProjectedStatement,
+  type RewrittenStatement,
+} from "./runtime/sqlite-proxy-rows.ts";
 export {
   EdgeQueueShapeError,
   wrapEdgeMessageBatch,

--- a/src/backend/runtime/edge-facades.ts
+++ b/src/backend/runtime/edge-facades.ts
@@ -63,8 +63,8 @@ export interface EdgeSqlStatement {
 /**
  * One statement's result. `rows` are RECORDS keyed by result-column name, not
  * positional arrays — the single most consequential difference from D1, and the
- * reason `edge-sql.ts` has to rewrite the projection list before it can hand
- * anything to Drizzle.
+ * reason the lane has to rewrite the projection list (`sqlite-proxy-rows.ts`)
+ * before it can hand anything to Drizzle.
  */
 export interface EdgeSqlResult {
   readonly rows: readonly Readonly<Record<string, EdgeSqlValue>>[];

--- a/src/backend/runtime/edge-sql.ts
+++ b/src/backend/runtime/edge-sql.ts
@@ -2,30 +2,17 @@
  * `edge.sql@1.0.0` → Drizzle, through `drizzle-orm/sqlite-proxy`.
  *
  * Same seam as `managed-relational.ts`: one bounded prepared statement per
- * callback, `batch()` as one ordered-atomic Host call. What is different, and
- * what most of this file is about, is the ROW SHAPE.
+ * callback, `batch()` as one ordered-atomic Host call. What is different is the
+ * ROW SHAPE. D1 hands Drizzle positional arrays (`stmt.raw()`) and
+ * `sqlite-proxy` maps `rows[i][j]` positionally onto the fields it compiled;
+ * `edge.sql` returns RECORDS keyed by result-column name, and a record cannot
+ * represent the duplicate names Drizzle's join SQL produces.
  *
- * D1 hands Drizzle positional arrays (`stmt.raw()`), and `sqlite-proxy` maps
- * `rows[i][j]` positionally onto the fields it compiled. `edge.sql` returns
- * RECORDS keyed by result-column name. Turning a record back into a positional
- * array is only sound when the column names are DISTINCT and ORDERED, and
- * Drizzle's own SQL guarantees neither:
- *
- *     select "inbox"."actor_ap_id", ..., "activities"."actor_ap_id", ...
- *       from "inbox" inner join "activities" on ...
- *
- * SQLite names both result columns `actor_ap_id`, so the record keeps one of
- * them and every field after it shifts by one — a silent mis-read, not an
- * error. (`created_at` collides in the same query.) JavaScript's own key
- * ordering adds a second trap: an integer-like column name such as the `1` of
- * `select 1` sorts ahead of every other key regardless of insertion order.
- *
- * So this adapter rewrites the statement's projection list before sending it,
- * giving every unaliased item a unique, non-numeric name (`__c0`, `__c1`, ...).
- * Drizzle never looks at result-column names, so renaming them is invisible to
- * it. The rewrite is then BACKED BY A GUARD: the number of keys a row comes
- * back with must equal the number of projection items that were sent, and a
- * mismatch throws instead of returning a shifted row.
+ * The projection rewrite that makes those names distinct, the guard that
+ * refuses a row whose column count disagrees with the statement, and the row
+ * that answers to both positional and named reads all live in
+ * `sqlite-proxy-rows.ts`, shared with the managed relational lane. What is left
+ * here is the `edge.sql` value vocabulary and its request limits.
  */
 
 import {
@@ -45,6 +32,15 @@ import {
   type EdgeSqlResult,
   type EdgeSqlValue,
 } from "./edge-facades.ts";
+import {
+  ProxyColumnMismatchError,
+  positionalRow,
+  rewriteProjection,
+  type ProjectedStatement,
+} from "./sqlite-proxy-rows.ts";
+
+/** The lane name a row-shape refusal reports. */
+const LANE = "edge.sql";
 
 /** The statement, or a value in it, cannot be expressed over `edge.sql`. */
 export class EdgeSqlShapeError extends TypeError {
@@ -52,229 +48,6 @@ export class EdgeSqlShapeError extends TypeError {
     super(message);
     this.name = "EdgeSqlShapeError";
   }
-}
-
-/** A row came back with a different column count than the statement projected. */
-export class EdgeSqlColumnMismatchError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = "EdgeSqlColumnMismatchError";
-  }
-}
-
-const PROJECTION_ALIAS_PREFIX = "__c";
-
-const SELECT_LIST_TERMINATORS = new Set([
-  "from",
-  "where",
-  "group",
-  "having",
-  "window",
-  "order",
-  "limit",
-  "offset",
-  "union",
-  "except",
-  "intersect",
-]);
-
-interface ScannedWord {
-  readonly word: string;
-  readonly start: number;
-  readonly end: number;
-}
-
-interface Scan {
-  readonly words: readonly ScannedWord[];
-  readonly commas: readonly number[];
-}
-
-function isWordChar(ch: string): boolean {
-  return /[A-Za-z0-9_$]/.test(ch);
-}
-
-/**
- * Walk the statement recording the bare words and commas that sit at
- * parenthesis depth zero. Quoted identifiers, string literals, and comments are
- * skipped whole, so a `,` inside `'a,b'` or a `from` inside a subquery is never
- * mistaken for structure.
- */
-function scanTopLevel(sql: string): Scan {
-  const words: ScannedWord[] = [];
-  const commas: number[] = [];
-  let depth = 0;
-  let index = 0;
-  while (index < sql.length) {
-    const ch = sql[index]!;
-    if (ch === "'" || ch === '"' || ch === "`") {
-      index += 1;
-      while (index < sql.length) {
-        if (sql[index] === ch) {
-          if (sql[index + 1] === ch) index += 2;
-          else {
-            index += 1;
-            break;
-          }
-        } else index += 1;
-      }
-      continue;
-    }
-    if (ch === "[") {
-      const close = sql.indexOf("]", index + 1);
-      index = close === -1 ? sql.length : close + 1;
-      continue;
-    }
-    if (ch === "-" && sql[index + 1] === "-") {
-      const newline = sql.indexOf("\n", index);
-      index = newline === -1 ? sql.length : newline + 1;
-      continue;
-    }
-    if (ch === "/" && sql[index + 1] === "*") {
-      const close = sql.indexOf("*/", index + 2);
-      index = close === -1 ? sql.length : close + 2;
-      continue;
-    }
-    if (ch === "(") {
-      depth += 1;
-      index += 1;
-      continue;
-    }
-    if (ch === ")") {
-      depth -= 1;
-      index += 1;
-      continue;
-    }
-    if (ch === ",") {
-      if (depth === 0) commas.push(index);
-      index += 1;
-      continue;
-    }
-    if (isWordChar(ch) && !/[0-9]/.test(ch)) {
-      const start = index;
-      while (index < sql.length && isWordChar(sql[index]!)) index += 1;
-      if (depth === 0) {
-        words.push({
-          word: sql.slice(start, index).toLowerCase(),
-          start,
-          end: index,
-        });
-      }
-      continue;
-    }
-    if (/[0-9]/.test(ch)) {
-      while (index < sql.length && isWordChar(sql[index]!)) index += 1;
-      continue;
-    }
-    index += 1;
-  }
-  return { words, commas };
-}
-
-/** Does this projection item already carry its own `as "name"` alias? */
-function hasOwnAlias(item: string): boolean {
-  return scanTopLevel(item).words.some((word) => word.word === "as");
-}
-
-export interface RewrittenStatement {
-  readonly sql: string;
-  /**
-   * How many result columns the statement projects, when that could be
-   * determined. `undefined` means the guard cannot check this statement — a
-   * `select *`, or a shape with no projection list at all.
-   */
-  readonly columns: number | undefined;
-}
-
-/**
- * Give every projected column a distinct, non-numeric name.
- *
- * Handles the two shapes Drizzle emits: a `select` list (including one that
- * follows a `with` clause, whose CTE bodies are parenthesized and therefore
- * invisible to a depth-zero scan) and a `returning` list on a write. For a
- * compound `select ... union select ...` only the first arm is rewritten, which
- * is sufficient: SQLite takes a compound select's result-column names from its
- * first arm.
- *
- * Anything else — a `pragma`, a `create table`, a `select *` — is returned
- * untouched with no column count, because there is nothing safe to rename.
- */
-export function rewriteProjection(sql: string): RewrittenStatement {
-  const scan = scanTopLevel(sql);
-  const first = scan.words[0];
-  if (!first) return { sql, columns: undefined };
-
-  let listStart: number;
-  let listEnd: number;
-
-  if (first.word === "select" || first.word === "with") {
-    const selectAt = scan.words.findIndex((word) => word.word === "select");
-    if (selectAt === -1) return { sql, columns: undefined };
-    const select = scan.words[selectAt]!;
-    // The list begins right after the keyword, NOT at the next bare word: an
-    // item usually opens with a quoted identifier, which the scanner skips.
-    listStart = select.end;
-    let cursor = selectAt + 1;
-    const next = scan.words[cursor];
-    if (
-      next &&
-      (next.word === "distinct" || next.word === "all") &&
-      sql.slice(select.end, next.start).trim() === ""
-    ) {
-      listStart = next.end;
-      cursor += 1;
-    }
-    const terminator = scan.words
-      .slice(cursor)
-      .find((word) => SELECT_LIST_TERMINATORS.has(word.word));
-    listEnd = terminator ? terminator.start : sql.length;
-  } else {
-    // insert / update / delete: only a `returning` list is projected.
-    const returning = [...scan.words]
-      .reverse()
-      .find((word) => word.word === "returning");
-    if (!returning) return { sql, columns: undefined };
-    listStart = returning.end;
-    listEnd = sql.length;
-  }
-
-  if (listEnd <= listStart) return { sql, columns: undefined };
-
-  const boundaries = [
-    listStart,
-    ...scan.commas.filter((at) => at > listStart && at < listEnd),
-    listEnd,
-  ];
-  const items: { text: string; start: number; end: number }[] = [];
-  for (let index = 0; index + 1 < boundaries.length; index += 1) {
-    const start = index === 0 ? boundaries[0]! : boundaries[index]! + 1;
-    const end = boundaries[index + 1]!;
-    items.push({ text: sql.slice(start, end), start, end });
-  }
-  if (items.length === 0) return { sql, columns: undefined };
-
-  // `select *` and `"t".*` cannot take an alias, and their column count is not
-  // knowable from the text. Leave the whole statement alone.
-  if (items.some((item) => /(^|\.)\s*\*\s*$/.test(item.text.trim()))) {
-    return { sql, columns: undefined };
-  }
-
-  let out = "";
-  let cursor = 0;
-  items.forEach((item, position) => {
-    out += sql.slice(cursor, item.end);
-    if (!hasOwnAlias(item.text)) {
-      const trailing = item.text.length - item.text.trimEnd().length;
-      // Insert before the item's own trailing whitespace so the statement keeps
-      // its shape.
-      out =
-        out.slice(0, out.length - trailing) +
-        ` as "${PROJECTION_ALIAS_PREFIX}${position}"` +
-        out.slice(out.length - trailing);
-    }
-    cursor = item.end;
-  });
-  out += sql.slice(cursor);
-  return { sql: out, columns: items.length };
 }
 
 /** Project one bound parameter into the facade's closed value vocabulary. */
@@ -319,57 +92,14 @@ function fromEdgeSqlValue(value: EdgeSqlValue): unknown {
   return isEdgeEncodedBytes(value) ? decodeEdgeBytes(value) : value;
 }
 
-/** Array indices and `length` are the only names an array cannot also carry. */
-function canCarryName(key: string): boolean {
-  return key !== "length" && String(Number(key)) !== key;
-}
-
-/**
- * Build a row that answers to BOTH access styles.
- *
- * Drizzle reads a row positionally, so the array part is what it needs. But
- * `db.get(sql\`... AS matched\`)` — a raw statement with no compiled fields —
- * is handed the driver's row untouched, and on D1 that is a record: call sites
- * read `row.matched`. `sqlite-proxy` gives them the bare array instead, so on
- * this lane those reads would come back `undefined` — and several of them gate
- * block/mute enforcement, where `undefined` reads as "not blocked".
- *
- * Attaching the column names to the array satisfies both without asking the
- * callback to know which one Drizzle compiled.
- */
-function makeRow(
-  keys: readonly string[],
-  values: readonly unknown[],
-): unknown[] {
-  const row = [...values];
-  for (let index = 0; index < keys.length; index += 1) {
-    const key = keys[index]!;
-    if (canCarryName(key)) {
-      Object.defineProperty(row, key, {
-        value: values[index],
-        enumerable: false,
-        configurable: true,
-        writable: true,
-      });
-    }
-  }
-  return row;
-}
-
 function projectRows(
   result: EdgeSqlResult,
-  columns: number | undefined,
-  sql: string,
+  projection: ProjectedStatement,
 ): unknown[][] {
   return result.rows.map((row) => {
     const keys = Object.keys(row);
-    if (columns !== undefined && keys.length !== columns) {
-      throw new EdgeSqlColumnMismatchError(
-        `edge.sql returned ${keys.length} columns for a statement projecting ` +
-          `${columns}; the row cannot be mapped positionally. Statement: ${sql}`,
-      );
-    }
-    return makeRow(
+    return positionalRow(
+      projection,
       keys,
       keys.map((key) => fromEdgeSqlValue(row[key]!)),
     );
@@ -382,8 +112,7 @@ const TRANSACTION_CONTROL =
 interface PreparedStatement {
   readonly sql: string;
   readonly params: readonly EdgeSqlValue[];
-  readonly columns: number | undefined;
-  readonly original: string;
+  readonly projection: ProjectedStatement;
 }
 
 function prepare(sql: string, params: readonly unknown[]): PreparedStatement {
@@ -404,8 +133,7 @@ function prepare(sql: string, params: readonly unknown[]): PreparedStatement {
   return {
     sql: rewritten.sql,
     params: params.map(toEdgeSqlValue),
-    columns: rewritten.columns,
-    original: sql,
+    projection: { lane: LANE, sql, columns: rewritten.columns },
   };
 }
 
@@ -441,7 +169,7 @@ export function createEdgeSqlDatabase(binding: EdgeSqlBinding) {
       prepared.map((entry) => ({ sql: entry.sql, params: entry.params })),
     );
     if (results.length !== prepared.length) {
-      throw new EdgeSqlColumnMismatchError(
+      throw new ProxyColumnMismatchError(
         `edge.sql: transaction returned ${results.length} results for ` +
           `${prepared.length} statements`,
       );
@@ -469,7 +197,7 @@ function shape(
   statement: PreparedStatement,
   method: "run" | "all" | "values" | "get",
 ): { rows: unknown[]; meta: { changes: number } } {
-  const rows = projectRows(result, statement.columns, statement.original);
+  const rows = projectRows(result, statement.projection);
   return {
     rows: (method === "get" ? rows[0] : rows) as unknown[],
     meta: { changes: result.rowsWritten },

--- a/src/backend/runtime/lane.ts
+++ b/src/backend/runtime/lane.ts
@@ -3,14 +3,20 @@
  *
  * The same bundle runs on two backends that look identical from inside:
  *
- *   `cloudflare`   — published straight to Cloudflare Workers. `env.DB` is a
- *                    `D1Database`, `env.KV` a `KVNamespace`, `env.MEDIA` an
- *                    `R2Bucket`, `env.DELIVERY_QUEUE` a `Queue`.
- *   `takoform-v1`  — published through Takoform onto a Takoserver Host, managed
- *                    Cloudflare backend or self-host. The Host's generated
- *                    entrypoint replaces `env` before the module sees it, and
- *                    each binding is the portable facade its Interface names:
- *                    `edge.sql`, `edge.kv`, `edge.objects`, `edge.queue`.
+ *   `cloudflare`  — RAW Cloudflare bindings. `env.DB` is a `D1Database`,
+ *                   `env.KV` a `KVNamespace`, `env.MEDIA` an `R2Bucket`,
+ *                   `env.DELIVERY_QUEUE` a `Queue`. This is a Worker deployed
+ *                   straight to Cloudflare, and equally an ordinary-Workers
+ *                   Takoserver backend, which projects those same raw bindings.
+ *   `portable`    — the PORTABLE FACADES. A wrapper host — a self-hosted
+ *                   Takoserver, or a managed Workers-for-Platforms backend —
+ *                   replaces `env` before the module sees it, and each binding
+ *                   is the facade its Interface names: `edge.sql`, `edge.kv`,
+ *                   `edge.objects`, `edge.queue`.
+ *
+ * THE LANE NAMES THE BINDING SHAPE, not the tool that published the Worker. A
+ * deployment authored in Takoform lands on either one depending on the host it
+ * targets, so the lane cannot be inferred from the IaC that produced it.
  *
  * THE LANE IS DECLARED, NOT SNIFFED. Two of the bindings cannot be told apart
  * by shape at all — `edge.kv` and `KVNamespace` expose the same five method
@@ -19,10 +25,11 @@
  * argument and returns bytes, and the failure would surface much later as a
  * corrupt session or a rate-limit that never trips.
  *
- * So the lane comes from `YURUCOMMU_RUNTIME_LANE`, which the app's Takoform
- * module already sets (`deploy/takoform/main.tf`, `worker_plain_values`), and
- * the declaration is then cross-checked against the bindings that ARE decisive
- * — `DB` always, `MEDIA` when it is bound. A disagreement refuses to start.
+ * So the lane comes from `YURUCOMMU_RUNTIME_LANE`, which a self-host or managed
+ * Workers-for-Platforms deployment sets to `portable` and every raw-binding
+ * deployment leaves unset (or `cloudflare`). The declaration is then
+ * cross-checked against the bindings that ARE decisive — `DB` always, `MEDIA`
+ * when it is bound. A disagreement refuses to start.
  */
 
 import type {
@@ -62,7 +69,7 @@ import type { IQueueBatch, IQueueProducer } from "./queue.ts";
 export const RUNTIME_LANE_VAR = "YURUCOMMU_RUNTIME_LANE";
 
 /** Every lane this build knows how to run on. */
-export const RUNTIME_LANES = ["cloudflare", "takoform-v1"] as const;
+export const RUNTIME_LANES = ["cloudflare", "portable"] as const;
 
 export type RuntimeLane = (typeof RUNTIME_LANES)[number];
 
@@ -124,28 +131,28 @@ export function assertRuntimeLaneBindings(
   bindings: LaneBindings,
 ): void {
   const { DB, MEDIA } = bindings;
-  if (lane === "takoform-v1") {
+  if (lane === "portable") {
     if (isNativeD1Database(DB)) {
       throw new RuntimeLaneError(
-        `${RUNTIME_LANE_VAR}="takoform-v1" declares the Takoserver-hosted ` +
-          `lane, but env.DB is a native D1Database (prepare/batch). A Takoform ` +
-          `sqlite binding arrives as the edge.sql facade. Either the variable ` +
-          `is set on a direct Cloudflare deployment, or the Worker Version ` +
-          `declared a binding it did not receive.`,
+        `${RUNTIME_LANE_VAR}="portable" declares the portable-facade lane, ` +
+          `but env.DB is a native D1Database (prepare/batch). A host that ` +
+          `projects raw Cloudflare bindings — including an ordinary-Workers ` +
+          `Takoserver backend — is the cloudflare lane; leave the variable ` +
+          `unset there.`,
       );
     }
     if (!isEdgeSqlBinding(DB)) {
       throw new RuntimeLaneError(
-        `${RUNTIME_LANE_VAR}="takoform-v1" requires env.DB to be the ` +
+        `${RUNTIME_LANE_VAR}="portable" requires env.DB to be the ` +
           `edge.sql@1.0.0 facade (execute/query/transaction); it exposes ` +
           `neither that nor D1's prepare/batch.`,
       );
     }
     if (MEDIA !== undefined && isNativeR2Bucket(MEDIA)) {
       throw new RuntimeLaneError(
-        `${RUNTIME_LANE_VAR}="takoform-v1" declares the Takoserver-hosted ` +
-          `lane, but env.MEDIA is a native R2Bucket. A Takoform bucket ` +
-          `binding arrives as the edge.objects@1.0.0 facade.`,
+        `${RUNTIME_LANE_VAR}="portable" declares the portable-facade lane, ` +
+          `but env.MEDIA is a native R2Bucket. A portable bucket binding ` +
+          `arrives as the edge.objects@1.0.0 facade.`,
       );
     }
     return;
@@ -153,10 +160,10 @@ export function assertRuntimeLaneBindings(
   if (isEdgeSqlBinding(DB)) {
     throw new RuntimeLaneError(
       `env.DB is the edge.sql@1.0.0 facade (execute/query/transaction), but ` +
-        `${RUNTIME_LANE_VAR} does not declare the takoform-v1 lane. A ` +
-        `Takoserver-hosted Worker must declare it; without that this build ` +
-        `would hand the facade to drizzle-orm/d1 and every query would fail ` +
-        `at the first prepare().`,
+        `${RUNTIME_LANE_VAR} does not declare the portable lane. A Worker on a ` +
+        `wrapper host must declare it; without that this build would hand the ` +
+        `facade to drizzle-orm/d1 and every query would fail at the first ` +
+        `prepare().`,
     );
   }
   if (!isNativeD1Database(DB)) {
@@ -167,8 +174,8 @@ export function assertRuntimeLaneBindings(
   }
 }
 
-/** Bindings a Takoserver-hosted Worker Version receives. */
-export interface TakoserverWorkerBindings {
+/** Bindings a Worker receives from a host that projects portable facades. */
+export interface PortableWorkerBindings {
   DB: EdgeSqlBinding;
   KV: EdgeKvBinding;
   MEDIA?: EdgeObjectsBinding;
@@ -200,12 +207,12 @@ type WrappedRuntime<T> = Omit<
 };
 
 /**
- * Wrap Takoserver's portable facades into the runtime ports the app speaks.
+ * Wrap the portable facades into the runtime ports the app speaks.
  *
  * `ASSETS` passes through: a Takoform `external_services` entry is projected as
  * a `{fetch}` adapter, which is already the port's whole surface.
  */
-export function wrapTakoserverBindings<T extends TakoserverWorkerBindings>(
+export function wrapPortableBindings<T extends PortableWorkerBindings>(
   bindings: T,
 ): WrappedRuntime<T> {
   const { DB, MEDIA, KV, ASSETS, DELIVERY_QUEUE, DELIVERY_DLQ, ...rest } =
@@ -238,9 +245,9 @@ export function wrapRuntimeBindings<
     (bindings as Record<string, unknown>)[RUNTIME_LANE_VAR],
   );
   assertRuntimeLaneBindings(lane, bindings as LaneBindings);
-  return lane === "takoform-v1"
-    ? (wrapTakoserverBindings(
-        bindings as unknown as TakoserverWorkerBindings,
+  return lane === "portable"
+    ? (wrapPortableBindings(
+        bindings as unknown as PortableWorkerBindings,
       ) as unknown as WrappedRuntime<T>)
     : (wrapCloudflareBindings(
         bindings as unknown as CloudflareWorkerBindings & {
@@ -262,19 +269,19 @@ export function wrapRuntimeMessageBatch<T>(
   lane: RuntimeLane = DEFAULT_RUNTIME_LANE,
 ): IQueueBatch<T> {
   const isFacade = isEdgeQueueBatch(batch);
-  if (lane === "takoform-v1") {
+  if (lane === "portable") {
     if (!isFacade) {
       throw new RuntimeLaneError(
-        `${RUNTIME_LANE_VAR}="takoform-v1" declares the Takoserver-hosted ` +
-          `lane, but the queue event is a Cloudflare MessageBatch (ackAll).`,
+        `${RUNTIME_LANE_VAR}="portable" declares the portable-facade lane, ` +
+          `but the queue event is a Cloudflare MessageBatch (ackAll).`,
       );
     }
     return wrapEdgeMessageBatch<T>(batch);
   }
   if (isFacade) {
     throw new RuntimeLaneError(
-      `The queue event is a Takoserver batch (acknowledgeAll), but ` +
-        `${RUNTIME_LANE_VAR} does not declare the takoform-v1 lane.`,
+      `The queue event is a portable-facade batch (acknowledgeAll), but ` +
+        `${RUNTIME_LANE_VAR} does not declare the portable lane.`,
     );
   }
   return wrapCloudflareMessageBatch(batch as MessageBatch<T>);

--- a/src/backend/runtime/managed-relational.ts
+++ b/src/backend/runtime/managed-relational.ts
@@ -5,6 +5,7 @@ import {
   parseManagedRelationalBatchResponse,
   type ManagedRelationalMethod,
   type ManagedRelationalParameter,
+  type ManagedRelationalStatement,
 } from "@takosjp/takosumi-contract/managed-relational-runtime";
 import { parseManagedRuntimeConnectionMaterialization } from "@takosjp/takosumi-contract/managed-runtime-connections";
 import {
@@ -16,8 +17,16 @@ import {
 import * as schema from "../../db/schema.ts";
 import { ManagedRuntimeGatewayError } from "./managed-runtime.ts";
 import type { ManagedRuntimeGateway } from "./managed-runtime.ts";
+import {
+  positionalRow,
+  rewriteProjection,
+  type ProjectedStatement,
+} from "./sqlite-proxy-rows.ts";
 
 const DEFAULT_MAX_RELATIONAL_RESPONSE_BYTES = 8 * 1024 * 1024;
+
+/** The lane name a row-shape refusal reports. */
+const LANE = "managed relational";
 
 export interface ManagedRelationalDatabaseOptions {
   readonly materialization: unknown;
@@ -33,6 +42,11 @@ export interface ManagedRelationalDatabaseOptions {
  * Every callback is one bounded prepared statement. Drizzle `batch()` maps to
  * one ordered-atomic host call; transaction-control and migration SQL are
  * deliberately unavailable on this request path.
+ *
+ * Row shape is shared with the `edge.sql` lane (`sqlite-proxy-rows.ts`): the
+ * projection list is rewritten so no two result columns share a name, the
+ * column count that comes back is checked against the count that went out, and
+ * the row Drizzle indexes positionally also answers to its column names.
  */
 export function createManagedRelationalDatabase(
   options: ManagedRelationalDatabaseOptions,
@@ -64,13 +78,9 @@ export function createManagedRelationalDatabase(
       readonly method: ManagedRelationalMethod;
     }[],
   ) => {
-    const canonical = statements.map((statement) => ({
-      sql: statement.sql,
-      params: statement.params.map(relationalParameter),
-      method: statement.method,
-    }));
+    const prepared = statements.map(prepare);
     const request = managedRelationalBatchGatewayRequest(connection.authority, {
-      statements: canonical,
+      statements: prepared.map((entry) => entry.statement),
       idempotencyKey: idempotencyKey(),
     });
     const response = await boundedResponse(
@@ -91,40 +101,77 @@ export function createManagedRelationalDatabase(
     }
     const value = parseManagedRelationalBatchResponse(
       await response.json(),
-      canonical.length,
+      prepared.length,
     );
-    return value.results;
+    return value.results.map((result, index) =>
+      drizzleResult(result, prepared[index]!),
+    );
   };
 
   const callback: AsyncRemoteCallback = async (sql, params, method) => {
     const [result] = await execute([{ sql, params, method }]);
     if (!result) throw new Error("managed_relational_result_missing");
-    return drizzleResult(result, method);
+    return result;
   };
-  const batchCallback: AsyncBatchRemoteCallback = async (batch) => {
-    const results = await execute(batch);
-    return results.map((result, index) =>
-      drizzleResult(result, batch[index]!.method),
-    );
-  };
+  const batchCallback: AsyncBatchRemoteCallback = async (batch) =>
+    await execute(batch);
 
   return drizzleProxy(callback, batchCallback, { schema });
 }
 
+interface PreparedStatement {
+  readonly statement: ManagedRelationalStatement;
+  readonly projection: ProjectedStatement;
+}
+
+/**
+ * Trim first, then give every projected column a distinct name.
+ *
+ * The runtime contract refuses a statement whose text is not already trimmed,
+ * and Drizzle does not trim the raw `sql` template a call site wrote across
+ * several lines — so the personal block and mute gates' own statements would
+ * never reach the host at all.
+ */
+function prepare(statement: {
+  readonly sql: string;
+  readonly params: readonly unknown[];
+  readonly method: ManagedRelationalMethod;
+}): PreparedStatement {
+  const source = statement.sql.trim();
+  const rewritten = rewriteProjection(source);
+  return {
+    statement: {
+      sql: rewritten.sql,
+      params: statement.params.map(relationalParameter),
+      method: statement.method,
+    },
+    projection: { lane: LANE, sql: source, columns: rewritten.columns },
+  };
+}
+
+/**
+ * `sqlite-proxy` wants a flat row for `get` and an array of rows otherwise.
+ *
+ * A `get` that matched nothing must yield `undefined`, not an empty array:
+ * Drizzle's `mapGetResult` short-circuits on a FALSY row, and `[]` is truthy,
+ * so an empty array is mapped into an object whose every field is `undefined` —
+ * a "row" for a query that found none, which `if (exact) return true` in the
+ * personal block gate reads as a hit.
+ */
 function drizzleResult(
   result: Awaited<
     ReturnType<typeof parseManagedRelationalBatchResponse>
   >["results"][number],
-  method: ManagedRelationalMethod,
+  prepared: PreparedStatement,
 ) {
+  // sqlite-proxy exposes mutable `any[]` at this boundary even though the
+  // public runtime contract is intentionally immutable. `positionalRow` copies,
+  // so the provider-neutral contract never leaks a mutable result reference.
+  const rows = result.rows.map((row) =>
+    positionalRow(prepared.projection, result.columns, row),
+  );
   return {
-    // sqlite-proxy exposes mutable `any[]` at this boundary even though the
-    // public runtime contract is intentionally immutable. Copy here so the
-    // provider-neutral contract never leaks a mutable result reference.
-    rows:
-      method === "get"
-        ? [...(result.rows[0] ?? [])]
-        : result.rows.map((row) => [...row]),
+    rows: (prepared.statement.method === "get" ? rows[0] : rows) as unknown[],
     meta: result.meta,
   };
 }

--- a/src/backend/runtime/sqlite-proxy-rows.ts
+++ b/src/backend/runtime/sqlite-proxy-rows.ts
@@ -1,0 +1,309 @@
+/**
+ * Row shape for every `drizzle-orm/sqlite-proxy` lane.
+ *
+ * `sqlite-proxy` maps `rows[i][j]` POSITIONALLY onto the fields Drizzle
+ * compiled, so a lane is only correct while the j-th cell it hands back is the
+ * j-th item of the projection list that went out. Two things break that, and
+ * both break it SILENTLY:
+ *
+ * 1. Duplicate result-column names. Drizzle's join SQL is
+ *
+ *        select "inbox"."actor_ap_id", ..., "activities"."actor_ap_id", ...
+ *          from "inbox" inner join "activities" on ...
+ *
+ *    and SQLite names both result columns `actor_ap_id`. Any driver, facade, or
+ *    Host hop that materializes a row as a RECORD keeps one of them and every
+ *    later field shifts by one. (`created_at` collides in the same query, and
+ *    JavaScript's key ordering adds a second trap: an integer-like name such as
+ *    the `1` of `select 1` sorts ahead of every other key.) So this module
+ *    rewrites the projection list before it is sent, giving every unaliased
+ *    item a unique, non-numeric name (`__c0`, `__c1`, ...). Drizzle never looks
+ *    at result-column names, so the rename is invisible to it. The rewrite is
+ *    then BACKED BY A GUARD: a row that comes back with a different number of
+ *    columns than the statement projected throws instead of being mapped.
+ *
+ * 2. Rows with no names at all. Drizzle reads a row positionally, but
+ *    `db.get(sql`... AS matched`)` — a raw statement with no compiled fields —
+ *    is handed the driver's row untouched, and on D1 that is a record: call
+ *    sites read `row.matched`. A bare array answers `undefined` to those reads,
+ *    and several of them gate block/mute enforcement, where `undefined` reads
+ *    as "not blocked". So the row this module builds answers to BOTH access
+ *    styles: an array Drizzle can index, carrying its column names as
+ *    non-enumerable properties.
+ *
+ * Lanes differ only in how they obtain the (names, values) pair — `edge.sql`
+ * from a record per row, the managed relational runtime from a `columns` list
+ * beside positional rows — so both share everything below.
+ */
+
+/** A row came back with a different column count than the statement projected. */
+export class ProxyColumnMismatchError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ProxyColumnMismatchError";
+  }
+}
+
+const PROJECTION_ALIAS_PREFIX = "__c";
+
+const SELECT_LIST_TERMINATORS = new Set([
+  "from",
+  "where",
+  "group",
+  "having",
+  "window",
+  "order",
+  "limit",
+  "offset",
+  "union",
+  "except",
+  "intersect",
+]);
+
+interface ScannedWord {
+  readonly word: string;
+  readonly start: number;
+  readonly end: number;
+}
+
+interface Scan {
+  readonly words: readonly ScannedWord[];
+  readonly commas: readonly number[];
+}
+
+function isWordChar(ch: string): boolean {
+  return /[A-Za-z0-9_$]/.test(ch);
+}
+
+/**
+ * Walk the statement recording the bare words and commas that sit at
+ * parenthesis depth zero. Quoted identifiers, string literals, and comments are
+ * skipped whole, so a `,` inside `'a,b'` or a `from` inside a subquery is never
+ * mistaken for structure.
+ */
+function scanTopLevel(sql: string): Scan {
+  const words: ScannedWord[] = [];
+  const commas: number[] = [];
+  let depth = 0;
+  let index = 0;
+  while (index < sql.length) {
+    const ch = sql[index]!;
+    if (ch === "'" || ch === '"' || ch === "`") {
+      index += 1;
+      while (index < sql.length) {
+        if (sql[index] === ch) {
+          if (sql[index + 1] === ch) index += 2;
+          else {
+            index += 1;
+            break;
+          }
+        } else index += 1;
+      }
+      continue;
+    }
+    if (ch === "[") {
+      const close = sql.indexOf("]", index + 1);
+      index = close === -1 ? sql.length : close + 1;
+      continue;
+    }
+    if (ch === "-" && sql[index + 1] === "-") {
+      const newline = sql.indexOf("\n", index);
+      index = newline === -1 ? sql.length : newline + 1;
+      continue;
+    }
+    if (ch === "/" && sql[index + 1] === "*") {
+      const close = sql.indexOf("*/", index + 2);
+      index = close === -1 ? sql.length : close + 2;
+      continue;
+    }
+    if (ch === "(") {
+      depth += 1;
+      index += 1;
+      continue;
+    }
+    if (ch === ")") {
+      depth -= 1;
+      index += 1;
+      continue;
+    }
+    if (ch === ",") {
+      if (depth === 0) commas.push(index);
+      index += 1;
+      continue;
+    }
+    if (isWordChar(ch) && !/[0-9]/.test(ch)) {
+      const start = index;
+      while (index < sql.length && isWordChar(sql[index]!)) index += 1;
+      if (depth === 0) {
+        words.push({
+          word: sql.slice(start, index).toLowerCase(),
+          start,
+          end: index,
+        });
+      }
+      continue;
+    }
+    if (/[0-9]/.test(ch)) {
+      while (index < sql.length && isWordChar(sql[index]!)) index += 1;
+      continue;
+    }
+    index += 1;
+  }
+  return { words, commas };
+}
+
+/** Does this projection item already carry its own `as "name"` alias? */
+function hasOwnAlias(item: string): boolean {
+  return scanTopLevel(item).words.some((word) => word.word === "as");
+}
+
+export interface RewrittenStatement {
+  readonly sql: string;
+  /**
+   * How many result columns the statement projects, when that could be
+   * determined. `undefined` means the guard cannot check this statement — a
+   * `select *`, or a shape with no projection list at all.
+   */
+  readonly columns: number | undefined;
+}
+
+/**
+ * Give every projected column a distinct, non-numeric name.
+ *
+ * Handles the two shapes Drizzle emits: a `select` list (including one that
+ * follows a `with` clause, whose CTE bodies are parenthesized and therefore
+ * invisible to a depth-zero scan) and a `returning` list on a write. For a
+ * compound `select ... union select ...` only the first arm is rewritten, which
+ * is sufficient: SQLite takes a compound select's result-column names from its
+ * first arm.
+ *
+ * Anything else — a `pragma`, a `create table`, a `select *` — is returned
+ * untouched with no column count, because there is nothing safe to rename.
+ */
+export function rewriteProjection(sql: string): RewrittenStatement {
+  const scan = scanTopLevel(sql);
+  const first = scan.words[0];
+  if (!first) return { sql, columns: undefined };
+
+  let listStart: number;
+  let listEnd: number;
+
+  if (first.word === "select" || first.word === "with") {
+    const selectAt = scan.words.findIndex((word) => word.word === "select");
+    if (selectAt === -1) return { sql, columns: undefined };
+    const select = scan.words[selectAt]!;
+    // The list begins right after the keyword, NOT at the next bare word: an
+    // item usually opens with a quoted identifier, which the scanner skips.
+    listStart = select.end;
+    let cursor = selectAt + 1;
+    const next = scan.words[cursor];
+    if (
+      next &&
+      (next.word === "distinct" || next.word === "all") &&
+      sql.slice(select.end, next.start).trim() === ""
+    ) {
+      listStart = next.end;
+      cursor += 1;
+    }
+    const terminator = scan.words
+      .slice(cursor)
+      .find((word) => SELECT_LIST_TERMINATORS.has(word.word));
+    listEnd = terminator ? terminator.start : sql.length;
+  } else {
+    // insert / update / delete: only a `returning` list is projected.
+    const returning = [...scan.words]
+      .reverse()
+      .find((word) => word.word === "returning");
+    if (!returning) return { sql, columns: undefined };
+    listStart = returning.end;
+    listEnd = sql.length;
+  }
+
+  if (listEnd <= listStart) return { sql, columns: undefined };
+
+  const boundaries = [
+    listStart,
+    ...scan.commas.filter((at) => at > listStart && at < listEnd),
+    listEnd,
+  ];
+  const items: { text: string; start: number; end: number }[] = [];
+  for (let index = 0; index + 1 < boundaries.length; index += 1) {
+    const start = index === 0 ? boundaries[0]! : boundaries[index]! + 1;
+    const end = boundaries[index + 1]!;
+    items.push({ text: sql.slice(start, end), start, end });
+  }
+  if (items.length === 0) return { sql, columns: undefined };
+
+  // `select *` and `"t".*` cannot take an alias, and their column count is not
+  // knowable from the text. Leave the whole statement alone.
+  if (items.some((item) => /(^|\.)\s*\*\s*$/.test(item.text.trim()))) {
+    return { sql, columns: undefined };
+  }
+
+  let out = "";
+  let cursor = 0;
+  items.forEach((item, position) => {
+    out += sql.slice(cursor, item.end);
+    if (!hasOwnAlias(item.text)) {
+      const trailing = item.text.length - item.text.trimEnd().length;
+      // Insert before the item's own trailing whitespace so the statement keeps
+      // its shape.
+      out =
+        out.slice(0, out.length - trailing) +
+        ` as "${PROJECTION_ALIAS_PREFIX}${position}"` +
+        out.slice(out.length - trailing);
+    }
+    cursor = item.end;
+  });
+  out += sql.slice(cursor);
+  return { sql: out, columns: items.length };
+}
+
+/** What a lane must remember about a statement to shape its rows back. */
+export interface ProjectedStatement {
+  /** Which lane is speaking, so a refusal names the surface that refused. */
+  readonly lane: string;
+  /** The statement as the caller wrote it, for the refusal message. */
+  readonly sql: string;
+  /** `rewriteProjection`'s column count, or `undefined` when unknowable. */
+  readonly columns: number | undefined;
+}
+
+/** Array indices and `length` are the only names an array cannot also carry. */
+function canCarryName(key: string): boolean {
+  return key !== "length" && String(Number(key)) !== key;
+}
+
+/**
+ * Build the row `sqlite-proxy` indexes positionally, carrying its column names.
+ *
+ * Fails closed first: if the lane came back with a different number of columns
+ * than the statement projected, the cells no longer line up with the fields
+ * Drizzle compiled, and returning them would be a silent mis-read.
+ */
+export function positionalRow(
+  statement: ProjectedStatement,
+  columns: readonly string[],
+  values: readonly unknown[],
+): unknown[] {
+  if (statement.columns !== undefined && columns.length !== statement.columns) {
+    throw new ProxyColumnMismatchError(
+      `${statement.lane} returned ${columns.length} columns for a statement ` +
+        `projecting ${statement.columns}; the row cannot be mapped ` +
+        `positionally. Statement: ${statement.sql}`,
+    );
+  }
+  const row = [...values];
+  for (let index = 0; index < columns.length; index += 1) {
+    const key = columns[index]!;
+    if (canCarryName(key)) {
+      Object.defineProperty(row, key, {
+        value: values[index],
+        enumerable: false,
+        configurable: true,
+        writable: true,
+      });
+    }
+  }
+  return row;
+}

--- a/src/backend/server.ts
+++ b/src/backend/server.ts
@@ -92,7 +92,7 @@ const ENV_PASSTHROUGH_KEY_SET: Record<LocalRuntimeEnvKey, true> = {
   // Carried so a shared env file reads the same everywhere, but nothing here
   // consults it: this server builds the runtime ports directly from its own
   // compat classes rather than wrapping a Worker's bindings, so it is neither
-  // the `cloudflare` nor the `takoform-v1` lane. See runtime/lane.ts.
+  // the `cloudflare` nor the `portable` lane. See runtime/lane.ts.
   YURUCOMMU_RUNTIME_LANE: true,
   ENABLE_TAKOS_TOOLS: true,
   AUTH_PASSWORD_HASH: true,

--- a/src/backend/types.ts
+++ b/src/backend/types.ts
@@ -16,12 +16,13 @@ import type {
 export interface EnvVars {
   APP_URL: string;
 
-  // Which runtime the Worker was published onto, and therefore what shape its
-  // bindings arrive in. Unset (or "cloudflare") = native Cloudflare bindings;
-  // "takoform-v1" = the portable edge.sql / edge.kv / edge.objects / edge.queue
-  // facades a Takoserver-hosted Worker Version receives. The value is checked
-  // against the bindings and a disagreement refuses to start — see
-  // runtime/lane.ts and docs/design/runtime-lanes.md.
+  // What shape the Worker's bindings arrive in. Unset (or "cloudflare") = raw
+  // Cloudflare bindings, which is also what an ordinary-Workers Takoserver
+  // backend projects; "portable" = the edge.sql / edge.kv / edge.objects /
+  // edge.queue facades a wrapper host (self-host, managed
+  // Workers-for-Platforms) projects. The value is checked against the bindings
+  // and a disagreement refuses to start — see runtime/lane.ts and
+  // docs/design/runtime-lanes.md.
   YURUCOMMU_RUNTIME_LANE?: string;
 
   // Takos-specific endpoints are opt-in (fail-close by default).


### PR DESCRIPTION
Fixes four defects in the Takosumi managed relational lane (no column names on positional rows, empty `get` returning a phantom row, duplicate join column names, untrimmed statements) that made personal block/mute checks fail open or block everyone; the projection rewrite and column-count guard are now shared with the Takoserver lane. Renames the runtime lane values to exactly `cloudflare` and `portable` (no alias) because the portable facades exist only on wrapper hosts. Version untouched (3.4.4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013SB7CxTvxopFWhZLHfUKx4