### PR TITLE
Establish the public origin from the request on the portable lane

### DIFF
--- a/docs/design/runtime-lanes.md
+++ b/docs/design/runtime-lanes.md
@@ -190,6 +190,113 @@ projection の書き換え・column 数 guard・名前つき row は `sqlite-pro
 - enumeration（`list`）と `head` は core の `ObjectStore` に無いので adapter にもあり
   ません。Host は両方 projection しますが、port が使いません。
 
+## `APP_URL` を var で渡せない — 公開 origin は request が確立する
+
+Status: **実装済み**（`src/backend/runtime/public-origin.ts`。test は
+`src/backend/__tests__/runtime/public-origin.test.ts`）。まだ publish していない
+ので、release 版に載るのは次の core / API release です。
+
+この app が federation で名乗る id は全部 absolute です。actor id、activity /
+object id、`inbox` / `outbox` / `followers`、OIDC の `redirect_uri`、notification の
+link、`.well-known` の discovery document — どれも `${APP_URL}/…` で、間違った値は
+壊れた画面ではなく、**remote が既に cache した永続的な誤答**になります。
+
+ところが `APP_URL` は plain var で、wrapper host ではそれを渡せないことがあります。
+Takoform の `WorkerEndpoint` が公開 origin を割り当てるのは、var を運ぶはずだった
+`WorkerVersion` が既に immutable になった **後** です。deployer は apply 時点でその
+値を知らず、後から注入する二度目の apply もありません。origin は存在するのに、知って
+いるのは Host だけで、その値が語られる唯一の場所は **Host がここへ routing してくる
+request** です。
+
+そこで `portable` lane では、`APP_URL` 未設定を「1 回の request を観測して pin する」
+ことで答えます。優先順位は次の通りで、上が勝ちます。
+
+1. **`APP_URL`**（設定されていれば常に authoritative）。operator が書いたそのままの値を
+   使い、この module は検証も cache も persist もしません。set した operator は既に
+   決めているのであって、以前の release が受け入れていた値をここで拒否する立場に
+   ありません。
+2. **KV に pin 済みの origin**。request 経路でも background 経路でも同じです。
+   **first writer wins**: 一度書かれた値は、その後どんな `Host` の request が来ても
+   置き換わりません。
+3. **今の request の origin**。まだ pin が無いときだけ、ここから確立します。
+4. どれも無ければ origin はありません。background work は
+   `undefined/ap/users/alice` を作る代わりに **fail closed** します。
+
+### 何を信じるか
+
+**runtime が渡してきた request URL だけ**です。`X-Forwarded-Host` も
+`X-Forwarded-Proto` も、header から読んだ `Host` も信じません（client が書けるため）。
+両方の wrapper host は hostname で routing し、Worker 自身の公開 endpoint で受けた
+request をそのまま渡します。managed Workers-for-Platforms の gateway は
+`new URL(request.url).hostname` の host route を引いて **同じ `Request` object** を
+dispatch し、self-host の workerd router は hostname を key にした table から service
+を選んで素通しします。その Worker 向けに publish されていない hostname は、この code に
+届く前に 404 です。したがって request に乗っている origin は Host が割り当てたもの
+——まさに var で渡せなかった値そのものです。
+
+`cloudflare` lane では推測しません。Cloudflare へ直 deploy した Worker は workers.dev
+でも、account が持つ全ての custom domain でも route pattern でも応答するので、同じ
+推論をすると「最初に届いた hostname」が instance の名前を永久に決めてしまいます。この
+lane はこれまで通り `APP_URL` を明示的に要求します。
+
+### https を要求する
+
+公開 fediverse origin は https で、Takoserver の `WorkerEndpoint` が割り当てる origin も
+常に https です（`canonicalWorkerEndpointOrigin`）。ここで https を要求するのは、http
+request が「delivery に署名し actor id を作る origin」を pin できないようにするため
+です。例外は loopback http（`localhost` / `127.0.0.1` / `[::1]` / `*.localhost`）だけで、
+これは routing されない名前であり、開発者が実際に serve している origin です。
+
+したがって **workerd の前で TLS を終端して平文 http を話す wrapper host は、何も確立
+しません**。`request.url` が `http://…` なので derivation は拒否し、その deployment は
+`APP_URL` を設定する必要があります。設定できます——TLS を終端した operator は hostname を
+自分で選んでいるからです。拒否が正解で、代わりに forwarded-proto header を信じるのは、
+その proxy が唯一の書き手だと証明できないまま信じることです。
+
+### どこに pin するか、その consistency
+
+pin は **KV** の `__yurucommu/runtime/canonical-origin/v1` に置きます。両 lane が必ず
+持つ store であること（`DB` も同じく必ずありますが、origin は readiness probe と、
+自分の名前を知るために transaction を開けたくない queue work が必要とします）、そして
+Yurucommu 自身の生成 Worker entry が既に同じ key へ pin していることが理由です。
+
+KV は eventually consistent で compare-and-swap がありません。したがって first writer
+wins は **read → write → read back** で実現します。read back で別の origin が返った
+isolate は race に負けたので、2 つの identity を同時に serve する代わりにその request を
+拒否します。次の request は「pin 済み」経路で勝者の値を読みます。read back が未収束
+（`null`）なら自分の書き込みとして扱います——自分で書いたからです。
+
+観測結果は isolate ごとに cache されます（全 request で KV を読まないため。first writer
+wins なので 2 回目の read は 1 回目と同じ値しか返しません）。operator が意図的に別の
+origin へ pin し直した場合、その後に起動した isolate から新しい値が見えます。即座に
+上書きしたいなら `APP_URL` を設定してください——常に勝ち、cache されません。
+
+### 経路ごとの挙動
+
+- **request**: `createYurucommuBackendApp` が最初に登録する middleware が確立します。
+  readiness probe と `.well-known` の discovery document が同じ origin を見るように、
+  route より前に置いてあります（origin を自分の traffic からしか知りえない Worker で
+  `/readyz` が「APP_URL がない」と言い続けたら、その Worker は永久に ready になりません）。
+  この middleware は **request を失敗させません**。確立できなければ `APP_URL` は未設定の
+  ままで、`/readyz` が今まで通り hard missing binding として 503 で報告します。500 に
+  すると readiness probe ごと落ちて、精密な答えが generic な答えに変わります。
+- **queue**: core の default export が `withRequiredBackgroundPublicOrigin` を通します。
+  `APP_URL` も pin も無ければ **throw** します。batch は retry され、traffic が origin を
+  確立した後に配送されます。`undefined/ap/users/…` で配って remote に cache させるよりも
+  良い失敗です。
+- **scheduled**: retention は DB / MEDIA / queue しか使わず、application URL を必要と
+  しません。ここでは origin を発明も要求もしません。
+
+`APP_URL` と request origin が食い違っても、この module は refuse しません。既存の挙動が
+そうだからです（mismatch を拒否するのは CSRF middleware の Origin / Referer check で、
+そちらは変えていません）。pin 済み origin と違う `Host` で来た request も、instance の
+名前を変えません。
+
+自前の Worker entry を持つ product は
+`@takosjp/yurucommu-core/server` から `establishRequestPublicOrigin` /
+`withRequiredBackgroundPublicOrigin` / `canonicalPublicOrigin` /
+`CANONICAL_ORIGIN_KV_KEY` を import して同じ規則を使えます。
+
 ## portable Worker は compatibility flag を要求しない
 
 wrapper host が生成する workerd config の `compatibilityFlags` は
@@ -241,3 +348,8 @@ binding が欠けるのは backend が出せないからではなく、**Version
 - `MEDIA` 未 bind → 既存の "Object storage unavailable" (503)
 
 という、これまでと同じ挙動になります。
+
+`KV` は例外で、`portable` lane の hard requirement です。session と rate limit に加えて
+観測済み公開 origin の pin もここに置くので（前節）、`KV` 未 bind かつ `APP_URL` 未設定の
+deployment は origin を確立できず、`/readyz` が `APP_URL` を missing として 503 を返し
+続けます。

--- a/src/backend/__tests__/runtime/public-origin.test.ts
+++ b/src/backend/__tests__/runtime/public-origin.test.ts
@@ -1,0 +1,413 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import { readFile, readdir } from "node:fs/promises";
+import { drizzle } from "drizzle-orm/libsql";
+import { createClient } from "@libsql/client";
+
+import * as schema from "../../../db/schema.ts";
+import type { Database } from "../../../db/index.ts";
+import type { Env } from "../../types.ts";
+import { createYurucommuBackendApp } from "../../index.ts";
+import worker from "../../public.ts";
+import {
+  CANONICAL_ORIGIN_KV_KEY,
+  PublicOriginError,
+  canonicalPublicOrigin,
+  establishRequestPublicOrigin,
+  requireBackgroundPublicOrigin,
+  resetObservedPublicOrigin,
+  withRequiredBackgroundPublicOrigin,
+} from "../../runtime/public-origin.ts";
+
+/**
+ * The origin a Takoform-hosted Worker cannot be told.
+ *
+ * `WorkerEndpoint` allocates the public origin AFTER the immutable
+ * `WorkerVersion` that would have carried `APP_URL` as a plain var, so on the
+ * portable lane the value exists only on the requests the Host routes here.
+ * These tests pin the whole rule: what may become an origin, who wins when two
+ * sources disagree, that the first observation is the last one, and that work
+ * without a request refuses instead of minting `undefined/ap/users/…`.
+ */
+
+const HOST_ASSIGNED = "https://yurucommu-a1b2c3.workers.example";
+const OPERATOR_SET = "https://social.operator.example";
+
+class MockKV {
+  store = new Map<string, string>();
+  puts = 0;
+  async get(key: string): Promise<string | null> {
+    return this.store.get(key) ?? null;
+  }
+  async put(key: string, value: string): Promise<void> {
+    this.puts += 1;
+    this.store.set(key, value);
+  }
+  async delete(key: string): Promise<void> {
+    this.store.delete(key);
+  }
+  async list() {
+    return {
+      keys: [...this.store.keys()].map((name) => ({ name })),
+      list_complete: true as const,
+    };
+  }
+}
+
+function portableEnv(kv: MockKV, extra: Record<string, unknown> = {}) {
+  return {
+    YURUCOMMU_RUNTIME_LANE: "portable",
+    KV: kv,
+    DB_INSTANCE: {},
+    ...extra,
+  } as unknown as Env;
+}
+
+async function freshDb(): Promise<Database> {
+  const client = createClient({ url: ":memory:" });
+  const root = new URL("../../../../migrations/", import.meta.url);
+  const files = (await readdir(root)).filter((f) => f.endsWith(".sql")).sort();
+  for (const file of files) {
+    await client.executeMultiple(await readFile(new URL(file, root), "utf8"));
+  }
+  return drizzle(client, { schema }) as unknown as Database;
+}
+
+beforeEach(() => {
+  // The observation is cached per isolate, and a test file is one isolate.
+  resetObservedPublicOrigin();
+});
+
+describe("what may become a public origin", () => {
+  test("an https origin is taken as-is", () => {
+    expect(canonicalPublicOrigin(HOST_ASSIGNED)).toEqual(HOST_ASSIGNED);
+    expect(canonicalPublicOrigin(`${HOST_ASSIGNED}/`)).toEqual(HOST_ASSIGNED);
+    expect(canonicalPublicOrigin("https://host.example:8443")).toEqual(
+      "https://host.example:8443",
+    );
+  });
+
+  test("plain http on a routable host is refused", () => {
+    // A wrapper host that terminates TLS in front of workerd hands the Worker
+    // an http request. Trusting it would let a forwarded-proto header nobody
+    // owns decide what this instance signs deliveries as.
+    expect(() => canonicalPublicOrigin("http://social.example")).toThrow(
+      PublicOriginError,
+    );
+    expect(() => canonicalPublicOrigin("http://social.example")).toThrow(
+      /https/,
+    );
+  });
+
+  test("loopback http is the one exception", () => {
+    expect(canonicalPublicOrigin("http://localhost:3000")).toEqual(
+      "http://localhost:3000",
+    );
+    expect(canonicalPublicOrigin("http://127.0.0.1:8787")).toEqual(
+      "http://127.0.0.1:8787",
+    );
+    // A self-host Takoserver's local Worker endpoint is `<script>.localhost`.
+    expect(canonicalPublicOrigin("http://yurucommu.localhost")).toEqual(
+      "http://yurucommu.localhost",
+    );
+  });
+
+  test("anything that is not just an origin is refused", () => {
+    // The value is concatenated with `/ap/users/…` at hundreds of call sites.
+    for (const bad of [
+      "https://host.example/base",
+      "https://host.example/?x=1",
+      "https://host.example/#f",
+      "https://user:pw@host.example",
+      "not-a-url",
+      "",
+    ]) {
+      expect(() => canonicalPublicOrigin(bad)).toThrow(PublicOriginError);
+    }
+  });
+});
+
+describe("establishing the origin from a request", () => {
+  test("the request URL's own origin is pinned in KV", async () => {
+    const kv = new MockKV();
+    const origin = await establishRequestPublicOrigin(
+      portableEnv(kv),
+      new Request(`${HOST_ASSIGNED}/api/timeline`),
+    );
+
+    expect(origin).toEqual(HOST_ASSIGNED);
+    expect(kv.store.get(CANONICAL_ORIGIN_KV_KEY)).toEqual(HOST_ASSIGNED);
+  });
+
+  test("a forged forwarding header cannot become the origin", async () => {
+    const kv = new MockKV();
+    const origin = await establishRequestPublicOrigin(
+      portableEnv(kv),
+      new Request(`${HOST_ASSIGNED}/api/timeline`, {
+        headers: {
+          "X-Forwarded-Host": "attacker.example",
+          "X-Forwarded-Proto": "https",
+          Host: "attacker.example",
+        },
+      }),
+    );
+
+    expect(origin).toEqual(HOST_ASSIGNED);
+  });
+
+  test("an http request establishes nothing", async () => {
+    const kv = new MockKV();
+    await expect(
+      establishRequestPublicOrigin(
+        portableEnv(kv),
+        new Request("http://social.example/api/timeline"),
+      ),
+    ).rejects.toThrow(PublicOriginError);
+    expect(kv.store.has(CANONICAL_ORIGIN_KV_KEY)).toBe(false);
+  });
+
+  test("the first writer wins: a later host does not re-pin", async () => {
+    const kv = new MockKV();
+    kv.store.set(CANONICAL_ORIGIN_KV_KEY, HOST_ASSIGNED);
+
+    const origin = await establishRequestPublicOrigin(
+      portableEnv(kv),
+      new Request("https://a-second-domain.example/api/timeline"),
+    );
+
+    expect(origin).toEqual(HOST_ASSIGNED);
+    expect(kv.puts).toEqual(0);
+    expect(kv.store.get(CANONICAL_ORIGIN_KV_KEY)).toEqual(HOST_ASSIGNED);
+  });
+
+  test("losing the write race refuses rather than serving two identities", async () => {
+    const kv = new MockKV();
+    // Another isolate's write lands between this one's put and its read-back.
+    const raced = {
+      ...kv,
+      get: async (key: string) =>
+        kv.puts === 0 ? null : "https://other-endpoint.example",
+      put: async (key: string, value: string) => {
+        await kv.put(key, value);
+      },
+    } as unknown as MockKV;
+
+    await expect(
+      establishRequestPublicOrigin(
+        portableEnv(raced),
+        new Request(`${HOST_ASSIGNED}/api/timeline`),
+      ),
+    ).rejects.toThrow(/concurrently pinned/);
+  });
+
+  test("a hand-written pin is refused, not silently replaced", async () => {
+    const kv = new MockKV();
+    kv.store.set(CANONICAL_ORIGIN_KV_KEY, "http://typo.example/oops");
+
+    await expect(
+      establishRequestPublicOrigin(
+        portableEnv(kv),
+        new Request(`${HOST_ASSIGNED}/api/timeline`),
+      ),
+    ).rejects.toThrow(PublicOriginError);
+  });
+});
+
+describe("the origin for work that has no request", () => {
+  test("APP_URL beats an already-pinned origin", async () => {
+    const kv = new MockKV();
+    kv.store.set(CANONICAL_ORIGIN_KV_KEY, HOST_ASSIGNED);
+
+    const env = portableEnv(kv, { APP_URL: OPERATOR_SET });
+    expect(await requireBackgroundPublicOrigin(env)).toEqual(OPERATOR_SET);
+    expect(await withRequiredBackgroundPublicOrigin(env)).toBe(env);
+  });
+
+  test("the pinned origin is used when APP_URL is unset", async () => {
+    const kv = new MockKV();
+    kv.store.set(CANONICAL_ORIGIN_KV_KEY, HOST_ASSIGNED);
+
+    const patched = await withRequiredBackgroundPublicOrigin(portableEnv(kv));
+    expect(patched.APP_URL).toEqual(HOST_ASSIGNED);
+  });
+
+  test("neither source is a refusal that names the fix", async () => {
+    const kv = new MockKV();
+    await expect(
+      requireBackgroundPublicOrigin(portableEnv(kv)),
+    ).rejects.toThrow(PublicOriginError);
+    await expect(
+      requireBackgroundPublicOrigin(portableEnv(kv)),
+    ).rejects.toThrow(/APP_URL is unset and no request has pinned an origin/);
+  });
+
+  test("the queue handler refuses a batch it cannot address", async () => {
+    // The core Worker entry, end to end: no APP_URL, nothing pinned, so the
+    // batch throws (and is retried) instead of federating `undefined/ap/…`.
+    const kv = new MockKV();
+    const batch = {
+      queue: "yurucommu-delivery",
+      messages: [],
+      ackAll: () => {},
+      retryAll: () => {},
+    };
+
+    await expect(
+      worker.queue(
+        batch as never,
+        {
+          DB: {
+            prepare: () => ({}),
+            batch: async () => [],
+            exec: async () => ({}),
+            dump: async () => new ArrayBuffer(0),
+          },
+          KV: kv,
+        } as never,
+      ),
+    ).rejects.toThrow(PublicOriginError);
+  });
+});
+
+describe("the app served on a Host-assigned origin", () => {
+  test("absolute URLs are built from the request origin, and it is pinned", async () => {
+    const kv = new MockKV();
+    const app = createYurucommuBackendApp();
+
+    const res = await app.fetch(
+      new Request(`${HOST_ASSIGNED}/.well-known/nodeinfo`),
+      portableEnv(kv),
+    );
+    const body = (await res.json()) as { links: Array<{ href: string }> };
+
+    expect(res.status).toEqual(200);
+    expect(body.links.map((l) => l.href)).toEqual([
+      `${HOST_ASSIGNED}/nodeinfo/2.0`,
+      `${HOST_ASSIGNED}/nodeinfo/2.1`,
+    ]);
+    expect(kv.store.get(CANONICAL_ORIGIN_KV_KEY)).toEqual(HOST_ASSIGNED);
+  });
+
+  test("the OIDC redirect_uri points back at the assigned origin", async () => {
+    const kv = new MockKV();
+    const app = createYurucommuBackendApp();
+
+    const res = await app.fetch(
+      new Request(`${HOST_ASSIGNED}/api/auth/login/google`),
+      portableEnv(kv, {
+        GOOGLE_CLIENT_ID: "client-123",
+        GOOGLE_CLIENT_SECRET: "secret-456",
+      }),
+    );
+
+    expect(res.status).toEqual(302);
+    const location = new URL(res.headers.get("Location") ?? "");
+    expect(location.searchParams.get("redirect_uri")).toEqual(
+      `${HOST_ASSIGNED}/api/auth/callback/google`,
+    );
+  });
+
+  test("the instance actor id is minted on the assigned origin", async () => {
+    const kv = new MockKV();
+    const app = createYurucommuBackendApp();
+
+    const res = await app.fetch(
+      new Request(`${HOST_ASSIGNED}/ap/actor`),
+      portableEnv(kv, { DB_INSTANCE: await freshDb() }),
+    );
+    const body = (await res.json()) as {
+      id: string;
+      inbox: string;
+      publicKey: { id: string };
+    };
+
+    expect(res.status).toEqual(200);
+    expect(body.id).toEqual(`${HOST_ASSIGNED}/ap/actor`);
+    expect(body.inbox).toEqual(`${HOST_ASSIGNED}/ap/actor/inbox`);
+    expect(body.publicKey.id).toEqual(`${HOST_ASSIGNED}/ap/actor#main-key`);
+  });
+
+  test("readiness reports ready once a request has established the origin", async () => {
+    const kv = new MockKV();
+    const app = createYurucommuBackendApp();
+    const env = portableEnv(kv, {
+      ENCRYPTION_KEY: "0".repeat(64),
+      AUTH_PASSWORD_HASH: "pbkdf2$1$salt$hash",
+    });
+
+    const res = await app.fetch(new Request(`${HOST_ASSIGNED}/readyz`), env);
+    const body = (await res.json()) as { missingBindings: string[] };
+
+    expect(res.status).toEqual(200);
+    expect(body.missingBindings).not.toContain("APP_URL");
+  });
+
+  test("APP_URL wins over the request origin, and nothing is pinned", async () => {
+    const kv = new MockKV();
+    const app = createYurucommuBackendApp();
+
+    const res = await app.fetch(
+      // A request that arrived on a different hostname than the operator's
+      // APP_URL does not change what this instance calls itself.
+      new Request(`${HOST_ASSIGNED}/.well-known/nodeinfo`),
+      portableEnv(kv, { APP_URL: OPERATOR_SET }),
+    );
+    const body = (await res.json()) as { links: Array<{ href: string }> };
+
+    expect(body.links[0].href).toEqual(`${OPERATOR_SET}/nodeinfo/2.0`);
+    expect(kv.store.has(CANONICAL_ORIGIN_KV_KEY)).toBe(false);
+  });
+
+  test("an http request neither establishes nor fails the request", async () => {
+    const kv = new MockKV();
+    const app = createYurucommuBackendApp();
+
+    const res = await app.fetch(
+      new Request("http://tls-terminated.example/readyz"),
+      portableEnv(kv),
+    );
+    const body = (await res.json()) as { missingBindings: string[] };
+
+    // The probe still answers — precisely, and about the right binding.
+    expect(res.status).toEqual(503);
+    expect(body.missingBindings).toContain("APP_URL");
+    expect(kv.store.has(CANONICAL_ORIGIN_KV_KEY)).toBe(false);
+  });
+});
+
+describe("the cloudflare lane", () => {
+  test("does not infer an origin from a request", async () => {
+    const kv = new MockKV();
+    const app = createYurucommuBackendApp();
+
+    const res = await app.fetch(new Request(`${HOST_ASSIGNED}/readyz`), {
+      KV: kv,
+      DB_INSTANCE: {},
+    } as unknown as Env);
+    const body = (await res.json()) as { missingBindings: string[] };
+
+    // A Worker deployed straight to Cloudflare answers on workers.dev, on every
+    // custom domain, and on every route its account holds. Whichever hostname
+    // arrived first must not get to name the instance.
+    expect(res.status).toEqual(503);
+    expect(body.missingBindings).toContain("APP_URL");
+    expect(kv.store.has(CANONICAL_ORIGIN_KV_KEY)).toBe(false);
+  });
+
+  test("still serves an explicitly configured APP_URL", async () => {
+    const kv = new MockKV();
+    const app = createYurucommuBackendApp();
+
+    const res = await app.fetch(
+      new Request("https://whatever.example/.well-known/nodeinfo"),
+      {
+        KV: kv,
+        DB_INSTANCE: {},
+        APP_URL: OPERATOR_SET,
+      } as unknown as Env,
+    );
+    const body = (await res.json()) as { links: Array<{ href: string }> };
+
+    expect(body.links[0].href).toEqual(`${OPERATOR_SET}/nodeinfo/2.0`);
+    expect(kv.store.has(CANONICAL_ORIGIN_KV_KEY)).toBe(false);
+  });
+});

--- a/src/backend/index.ts
+++ b/src/backend/index.ts
@@ -1,4 +1,4 @@
-import { Hono, type Context } from "hono";
+import { Hono, type Context, type Next } from "hono";
 import { MOBILE_PUSH_REGISTRATION_PATH } from "./lib/mobile-contract.ts";
 import { NOTIFICATION_PUSHER_REGISTRATION_PATH } from "./lib/notification-pusher-contract.ts";
 import type { Env, EnvVars, Variables } from "./types.ts";
@@ -9,7 +9,13 @@ import {
   wrapRuntimeBindings,
   wrapRuntimeMessageBatch,
   type PortableWorkerBindings,
+  type RuntimeLane,
 } from "./runtime/lane.ts";
+import {
+  configuredAppUrl,
+  establishRequestPublicOrigin,
+  withRequiredBackgroundPublicOrigin,
+} from "./runtime/public-origin.ts";
 import type { EdgeQueueBatch } from "./runtime/edge-facades.ts";
 import {
   getMobileOidcAudience,
@@ -925,6 +931,65 @@ function mountStaticFallback(app: YurucommuApp): void {
   });
 }
 
+/**
+ * Give this request an `APP_URL` when the Host, not the deployer, chose it.
+ *
+ * Registered BEFORE every other route so `/readyz` and the `.well-known`
+ * discovery documents see the same origin the rest of the app mints ids from —
+ * a readiness probe that reported `APP_URL` missing on a Worker whose origin
+ * only its own traffic can reveal would never go ready.
+ *
+ * It runs on the `portable` lane alone. There, a wrapper host routes by
+ * hostname and delivers the request it received on the Worker's public
+ * endpoint, so the request URL IS the assigned origin (see
+ * runtime/public-origin.ts). A Worker deployed straight to Cloudflare answers
+ * on workers.dev, on every custom domain, and on every route pattern its
+ * account holds, so the same inference there would let whichever hostname
+ * happened to arrive first name the instance for good; that lane keeps
+ * requiring an explicit `APP_URL` exactly as before.
+ *
+ * It never fails a request. When no origin can be established — the request is
+ * plain http, KV is unbound, an operator hand-wrote the pin — `APP_URL` simply
+ * stays unset, which `/readyz` already reports as a hard missing binding.
+ * Turning that into a 500 would take the readiness probe down with it and
+ * replace a precise answer with a generic one.
+ */
+function publicOriginMiddleware() {
+  let warned = false;
+  return async (
+    c: Context<{ Bindings: Env; Variables: Variables }>,
+    next: Next,
+  ) => {
+    if (configuredAppUrl(c.env) !== null) return next();
+    // An unrecognised lane declaration is refused at the binding boundary by
+    // wrapRuntimeBindings. Reaching here with one means the app was composed
+    // directly, and the safe reading of "not a lane I know" is "do not infer".
+    let lane: RuntimeLane;
+    try {
+      lane = resolveRuntimeLane(c.env.YURUCOMMU_RUNTIME_LANE);
+    } catch {
+      return next();
+    }
+    if (lane !== "portable") return next();
+    try {
+      const origin = await establishRequestPublicOrigin(c.env, c.req.raw);
+      c.env = { ...c.env, APP_URL: origin };
+      warned = false;
+    } catch (error) {
+      // Once per isolate: this condition is a property of the deployment, not
+      // of the request, so it would otherwise repeat on every single one.
+      if (!warned) {
+        warned = true;
+        log.warn("Could not establish this instance's public origin", {
+          event: "runtime.public_origin.unestablished",
+          error,
+        });
+      }
+    }
+    return next();
+  };
+}
+
 export function createYurucommuBackendApp(
   options: CreateYurucommuBackendAppOptionsV1 = {},
 ): YurucommuApp {
@@ -941,6 +1006,10 @@ export function createYurucommuBackendApp(
     }
   }
 
+  // Before the readiness probes, because they report on APP_URL and the
+  // `.well-known` discovery documents publish it. Reads no body and consults no
+  // route, so it does not weaken the body-cap ordering below.
+  app.use("*", publicOriginMiddleware());
   mountReadinessRoutes(app, options.discovery);
   // Body-size cap must run BEFORE any handler reads the body or executes
   // expensive auth / rate-limit logic. Mounted after readiness probes so
@@ -1056,9 +1125,15 @@ export default {
     bindings: WorkerBindings,
   ): Promise<void> {
     const lane = resolveRuntimeLane(bindings.YURUCOMMU_RUNTIME_LANE);
+    // Federation delivery signs and addresses from this instance's own actor
+    // ids, and a queue invocation has no request to learn the origin from. When
+    // `APP_URL` is unset and no request has pinned one yet, this THROWS: the
+    // batch is retried later, after traffic has established the origin, instead
+    // of being delivered under `undefined/ap/users/…` to peers that would cache
+    // it. See runtime/public-origin.ts.
     return handleYurucommuQueueBatch(
       wrapRuntimeMessageBatch(batch, lane),
-      wrapRuntimeBindings(bindings),
+      await withRequiredBackgroundPublicOrigin(wrapRuntimeBindings(bindings)),
     );
   },
 

--- a/src/backend/public.ts
+++ b/src/backend/public.ts
@@ -53,6 +53,21 @@ export {
   wrapRuntimeBindings,
   wrapRuntimeMessageBatch,
 } from "./runtime/lane.ts";
+// The public origin: `APP_URL` when the deployment could carry one, and the
+// origin one request established when only the Host knew it. A product that
+// composes its own Worker entry uses these for the handlers the core default
+// export does not own.
+export {
+  CANONICAL_ORIGIN_KV_KEY,
+  PublicOriginError,
+  canonicalPublicOrigin,
+  configuredAppUrl,
+  establishRequestPublicOrigin,
+  peekObservedPublicOrigin,
+  requireBackgroundPublicOrigin,
+  resetObservedPublicOrigin,
+  withRequiredBackgroundPublicOrigin,
+} from "./runtime/public-origin.ts";
 export {
   EDGE_KV_MAX_EXPIRATION_TTL_SECONDS,
   EDGE_KV_MIN_EXPIRATION_TTL_SECONDS,

--- a/src/backend/runtime/public-origin.ts
+++ b/src/backend/runtime/public-origin.ts
@@ -1,0 +1,263 @@
+/**
+ * The one absolute origin this instance is: `APP_URL`, or the one a request
+ * established when the Host — not the deployer — chose it.
+ *
+ * Every federated identity this app mints is absolute. Actor ids, activity and
+ * object ids, `inbox` / `outbox` / `followers` collections, the OIDC
+ * `redirect_uri`, notification links, and the `.well-known` discovery documents
+ * are all `${APP_URL}/…`, and a wrong one is not a broken page — it is a
+ * permanent, federated wrong answer that remote servers have already cached.
+ *
+ * `APP_URL` is a plain variable, and on a wrapper host it cannot always be one.
+ * A Takoform `WorkerEndpoint` allocates the Worker's public origin AFTER the
+ * `WorkerVersion` that would have carried the variable is already immutable, so
+ * the deployer does not know the value at apply time and there is no second
+ * apply that could inject it. The origin exists, but only the Host knows it,
+ * and the only place it is ever spoken is on the requests the Host routes here.
+ *
+ * So on the `portable` lane an unset `APP_URL` is answered by OBSERVING one
+ * request and PINNING what it observed:
+ *
+ *   1. `APP_URL` is authoritative whenever it is set. It is used exactly as the
+ *      operator wrote it and is never validated, cached, or persisted here —
+ *      an operator who sets it has already decided, and this module has no
+ *      standing to refuse a value the previous release accepted.
+ *   2. Otherwise the origin PINNED IN KV wins, for every request and for
+ *      background work alike. First writer wins: once a value is stored, no
+ *      later request replaces it, whatever `Host` that request carried.
+ *   3. Otherwise a request may establish it, from the request URL's own origin
+ *      and from nothing else.
+ *   4. Otherwise there is no origin, and background work refuses rather than
+ *      minting `undefined/ap/users/alice`.
+ *
+ * WHAT IS TRUSTED. The request URL as the runtime delivers it, and only that.
+ * Not `X-Forwarded-Host`, not `X-Forwarded-Proto`, not `Host` read out of the
+ * headers — nothing a client can write. Both wrapper hosts route by hostname
+ * and deliver the request they received on the Worker's own public endpoint:
+ * Takoserver's managed Workers-for-Platforms gateway looks up a host route for
+ * `new URL(request.url).hostname` and dispatches the SAME `Request` object, and
+ * the self-host workerd router picks a service from a table keyed by hostname
+ * and forwards unchanged. A hostname nobody published for this Worker is a 404
+ * before any of this code runs, so the origin on the request is one the Host
+ * assigned — which is exactly the value that could not be delivered as a var.
+ *
+ * WHY HTTPS. A public fediverse origin is https, and Takoserver's own
+ * `WorkerEndpoint` can only ever assign an https origin. Requiring it here
+ * means an http request cannot pin an origin that would then sign deliveries
+ * and mint actor ids. Loopback http is the one exception, because `localhost`
+ * is not routable and is the origin a developer actually serves on.
+ *
+ * A wrapper host that terminates TLS in FRONT of workerd and speaks plain http
+ * to it therefore establishes nothing: `request.url` is `http://…` and the
+ * derivation refuses. That deployment must set `APP_URL`, which it can, because
+ * an operator who terminates TLS chose the hostname themselves. Refusing is the
+ * point — the alternative is trusting a forwarded-proto header that the same
+ * proxy may or may not be the only writer of.
+ */
+
+import type { Env, EnvVars } from "../types.ts";
+import type { IKeyValueStore } from "./types.ts";
+
+/**
+ * Where the observed origin is pinned.
+ *
+ * The key is shared with the origin pin Yurucommu's own generated Worker entry
+ * writes, so a deployment that pinned an origin under the product's
+ * implementation keeps it when the product delegates to this one.
+ */
+export const CANONICAL_ORIGIN_KV_KEY =
+  "__yurucommu/runtime/canonical-origin/v1";
+
+/** No usable public origin, or a candidate that may not become one. */
+export class PublicOriginError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "PublicOriginError";
+  }
+}
+
+/**
+ * Hostnames whose http origin is still trustworthy, because they are not
+ * routable off the machine. `*.localhost` is included: RFC 6761 reserves the
+ * whole tree for loopback, and a self-host Worker endpoint on a local Takoserver
+ * is `<script>.localhost`.
+ */
+function isLoopbackHostname(hostname: string): boolean {
+  return (
+    hostname === "localhost" ||
+    hostname === "127.0.0.1" ||
+    hostname === "[::1]" ||
+    hostname.endsWith(".localhost")
+  );
+}
+
+/**
+ * Reduce a candidate to a bare origin, or refuse it.
+ *
+ * Refuses anything that is not just an origin — a path, a query, a fragment,
+ * embedded credentials — because the value is concatenated with `/ap/users/…`
+ * at hundreds of call sites and a stray path would silently produce a second,
+ * parallel set of actor ids.
+ */
+export function canonicalPublicOrigin(value: string): string {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new PublicOriginError(
+      `"${value}" is not a URL and cannot be this instance's public origin.`,
+    );
+  }
+  if (
+    url.username !== "" ||
+    url.password !== "" ||
+    url.search !== "" ||
+    url.hash !== "" ||
+    url.pathname !== "/"
+  ) {
+    throw new PublicOriginError(
+      `"${value}" is not a bare origin; this instance's public origin must ` +
+        `carry no path, query, fragment, or credentials.`,
+    );
+  }
+  if (
+    url.protocol !== "https:" &&
+    !(url.protocol === "http:" && isLoopbackHostname(url.hostname))
+  ) {
+    throw new PublicOriginError(
+      `"${value}" is not an https origin. A public origin observed from a ` +
+        `request must be https (loopback http is the only exception); set ` +
+        `APP_URL explicitly when this Worker is served over plain http.`,
+    );
+  }
+  return url.origin;
+}
+
+/** `APP_URL` exactly as the operator set it, or null when it is not set. */
+export function configuredAppUrl(env: Partial<EnvVars>): string | null {
+  const raw = typeof env.APP_URL === "string" ? env.APP_URL.trim() : "";
+  return raw.length > 0 ? raw : null;
+}
+
+/**
+ * The origin this isolate has already established.
+ *
+ * Cached because the alternative is a KV read on the hot path of every single
+ * request, and because the value cannot legitimately change: first writer wins,
+ * so a second read can only ever return what the first one did. An operator who
+ * deliberately re-pins a different origin (see {@link resetObservedPublicOrigin})
+ * is served the new value by isolates started after the change.
+ */
+let observedPublicOrigin: string | null = null;
+
+/** Forget this isolate's observation. Tests, and an operator-driven re-pin. */
+export function resetObservedPublicOrigin(): void {
+  observedPublicOrigin = null;
+}
+
+/** What this isolate has observed so far, without touching KV. */
+export function peekObservedPublicOrigin(): string | null {
+  return observedPublicOrigin;
+}
+
+type PublicOriginEnv = Partial<EnvVars> & { KV?: IKeyValueStore };
+
+function requireKv(env: PublicOriginEnv): IKeyValueStore {
+  if (!env.KV) {
+    throw new PublicOriginError(
+      "KV is not bound, so this instance's public origin can be neither read " +
+        "nor pinned. Bind KV, or set APP_URL.",
+    );
+  }
+  return env.KV;
+}
+
+async function readPinnedOrigin(kv: IKeyValueStore): Promise<string | null> {
+  const stored = await kv.get(CANONICAL_ORIGIN_KV_KEY);
+  if (stored === null) return null;
+  // A stored value that no longer canonicalizes is a refusal, never a silent
+  // fallback to the current request: it means somebody wrote the key by hand.
+  return canonicalPublicOrigin(stored);
+}
+
+/**
+ * Establish this instance's public origin from one request, once.
+ *
+ * CONSISTENCY. The pin lives in KV, the one store both lanes always have (`DB`
+ * is equally present, but the origin is needed by the readiness probe and by
+ * queue work that must not open a transaction to learn its own name). KV is
+ * eventually consistent and has no compare-and-swap, so "first writer wins" is
+ * enforced by reading before writing and then READING BACK: an isolate that
+ * finds a different origin on the read-back lost the race and refuses this
+ * request rather than serving two identities. The next request reads the
+ * winner's value through the ordinary stored-value path. A read-back that has
+ * not converged yet (null) is treated as our own write, because we wrote it.
+ */
+export async function establishRequestPublicOrigin(
+  env: PublicOriginEnv,
+  request: Request,
+): Promise<string> {
+  if (observedPublicOrigin !== null) return observedPublicOrigin;
+
+  const kv = requireKv(env);
+  const pinned = await readPinnedOrigin(kv);
+  if (pinned !== null) {
+    observedPublicOrigin = pinned;
+    return pinned;
+  }
+
+  const requestOrigin = canonicalPublicOrigin(new URL(request.url).origin);
+  await kv.put(CANONICAL_ORIGIN_KV_KEY, requestOrigin);
+  const readback = await kv.get(CANONICAL_ORIGIN_KV_KEY);
+  if (readback !== null && canonicalPublicOrigin(readback) !== requestOrigin) {
+    throw new PublicOriginError(
+      `this instance's public origin was concurrently pinned to ` +
+        `"${readback}" while this request was establishing ` +
+        `"${requestOrigin}". The pinned origin stands; retry.`,
+    );
+  }
+  observedPublicOrigin = requestOrigin;
+  return requestOrigin;
+}
+
+/**
+ * The public origin for work that has no request to read it from.
+ *
+ * Queue consumers sign federation deliveries and address them from this
+ * instance's actor ids; there is no request in scope and nothing to derive one
+ * from. `APP_URL` first, then the pinned origin, then a refusal — never a
+ * guess, and never `undefined` concatenated into an actor id.
+ */
+export async function requireBackgroundPublicOrigin(
+  env: PublicOriginEnv,
+): Promise<string> {
+  const configured = configuredAppUrl(env);
+  if (configured !== null) return configured;
+  if (observedPublicOrigin !== null) return observedPublicOrigin;
+
+  const pinned = await readPinnedOrigin(requireKv(env));
+  if (pinned === null) {
+    throw new PublicOriginError(
+      "this instance's public origin has not been observed yet: APP_URL is " +
+        "unset and no request has pinned an origin. Serve one request on the " +
+        "Worker's public endpoint before background delivery can address " +
+        "anything.",
+    );
+  }
+  observedPublicOrigin = pinned;
+  return pinned;
+}
+
+/**
+ * The env background work should run with: `APP_URL` present, or a refusal.
+ *
+ * Returned as a copy rather than by mutating the caller's bindings, so the same
+ * `env` may be handed to several handlers without one of them rewriting what
+ * the others read.
+ */
+export async function withRequiredBackgroundPublicOrigin(
+  env: Env,
+): Promise<Env> {
+  if (configuredAppUrl(env) !== null) return env;
+  return { ...env, APP_URL: await requireBackgroundPublicOrigin(env) };
+}


### PR DESCRIPTION
On a Takoform-hosted Worker the deployer cannot deliver `APP_URL` before apply, so on the `portable` lane the core now establishes the public origin from the request URL's origin (never forwarded headers), pins it first-writer-wins in KV, requires https (loopback excepted), and hands the app an `Env` whose `APP_URL` is the effective origin so every consumer (OIDC, ActivityPub, CSRF, discovery, queue delivery) follows; `APP_URL` stays authoritative when set, background work without an established origin fails closed. Cloudflare lane unchanged. Version untouched; `bun run check` green (22 new tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013SB7CxTvxopFWhZLHfUKx4